### PR TITLE
Fix issue 181 unlock bug

### DIFF
--- a/contracts/ClaimsReward.sol
+++ b/contracts/ClaimsReward.sol
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017 NexusMutual.io
+/* Copyright (C) 2020 NexusMutual.io
 
   This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -25,7 +25,7 @@ import "./Pool1.sol";
 
 
 contract ClaimsReward is Iupgradable {
-    using SafeMath for uint;
+     using SafeMath for uint;
 
     NXMToken internal tk;
     TokenController internal tc;
@@ -72,8 +72,9 @@ contract ClaimsReward is Iupgradable {
         } else if (status == 12) { // when current status is "Claim Accepted Payout Pending"
             bool succ = p1.sendClaimPayout(coverid, claimid, qd.getCoverSumAssured(coverid).mul(DECIMAL1E18), 
             qd.getCoverMemberAddress(coverid), qd.getCurrencyOfCover(coverid));
-            if (succ) 
+            if (succ) {
                 c1.setClaimStatus(claimid, 14);
+            }
         }
         c1.changePendingClaimStart();
     }
@@ -109,8 +110,9 @@ contract ClaimsReward is Iupgradable {
         (tokens, claimId, verdict, claimed) = cd.getVoteDetails(voteid);
         lastClaimedCheck = false;
         int8 claimVerdict = cd.getFinalVerdict(claimId);
-        if (claimVerdict == 0)
+        if (claimVerdict == 0) {
             lastClaimedCheck = true;
+        }
 
         if (claimVerdict == verdict && (claimed == false || flag == 1)) {
             
@@ -144,8 +146,9 @@ contract ClaimsReward is Iupgradable {
     /// @dev Transfers all tokens held by contract to a new contract in case of upgrade.
     function upgrade(address _newAdd) public onlyInternal {
         uint amount = tk.balanceOf(address(this));
-        if (amount > 0)
+        if (amount > 0) {
             require(tk.transfer(_newAdd, amount));
+        }
         
     }
 
@@ -188,14 +191,14 @@ contract ClaimsReward is Iupgradable {
             for (uint i = 0; i < lengthVote; i++) {
                 voteId = cd.getVoteAddressCA(msg.sender, i);
                 (, claimid, , claimed) = cd.getVoteDetails(voteId);
-                if (claimid == claimId) break;
+                if (claimid == claimId) { break; }
             }
         } else {
             lengthVote = cd.getVoteAddressMemberLength(msg.sender);
             for (uint j = 0; j < lengthVote; j++) {
                 voteId = cd.getVoteAddressMember(msg.sender, j);
                 (, claimid, , claimed) = cd.getVoteDetails(voteId);
-                if (claimid == claimId) break;
+                if (claimid == claimId) { break; }
             }
         }
         (reward, , , ) = getRewardToBeGiven(check, voteId, 1);
@@ -203,20 +206,20 @@ contract ClaimsReward is Iupgradable {
     }
 
     /**
-     * @dev Function used to claim all pending rewards on a list of proposals.
+     * @dev Function used to claim all pending rewards : Claims Assessment + Risk Assessment + Governance
+     * Claim assesment, Risk assesment, Governance rewards
      */
     function claimAllPendingReward(uint records) public isMemberAndcheckPause {
         _claimRewardToBeDistributed(records);
         _claimStakeCommission(records);
-        tf.unlockStakerUnlockableTokens(msg.sender); 
-        uint gvReward = gv.claimReward(msg.sender, records);
-        if (gvReward > 0) {
-            require(tk.transfer(msg.sender, gvReward));
+        uint governanceRewards = gv.claimReward(msg.sender, records);
+        if (governanceRewards > 0) {
+            require(tk.transfer(msg.sender, governanceRewards));
         }
     }
 
     /**
-     * @dev Function used to get pending rewards of a particular user address.
+     * @dev Function used to get pending rewards + withdrawable tokens of a particular user address.
      * @param _add user address.
      * @return total reward amount of the user
      */
@@ -226,12 +229,13 @@ contract ClaimsReward is Iupgradable {
         uint commissionReedmed = td.getStakerTotalReedmedStakeCommission(_add);
         uint unlockableStakedTokens = tf.getStakerAllUnlockableStakedTokens(_add);
         uint governanceReward = gv.getPendingReward(_add);
+        uint lockedCA = tc.tokensUnlockable(_add, "CLA");
         total = caReward.add(unlockableStakedTokens).add(commissionEarned.
-        sub(commissionReedmed)).add(governanceReward);
+            sub(commissionReedmed)).add(governanceReward).add(lockedCA);
     }
 
     /// @dev Rewards/Punishes users who  participated in Claims assessment.
-    //             Unlocking and burning of the tokens will also depend upon the status of claim.
+    //    Unlocking and burning of the tokens will also depend upon the status of claim.
     /// @param claimid Claim Id.
     function _rewardAgainstClaim(uint claimid, uint coverid, uint sumAssured, uint status) internal {
         uint premiumNXM = qd.getCoverPremiumNXM(coverid);
@@ -312,8 +316,9 @@ contract ClaimsReward is Iupgradable {
 
             c1.setClaimStatus(claimid, status);
 
-            if (rewardOrPunish)
+            if (rewardOrPunish) {
                 _rewardAgainstClaim(claimid, coverid, sumAssured, status);
+            }
         }
     }
 
@@ -331,8 +336,9 @@ contract ClaimsReward is Iupgradable {
             uint thresholdUnreached = 0;
             // Minimum threshold for member voting is reached only when 
             // value of tokens used for voting > 5* sum assured of claim id
-            if (mvTokens < sumAssured.mul(5))
+            if (mvTokens < sumAssured.mul(5)) {
                 thresholdUnreached = 1;
+            }
 
             uint accept;
             (, accept) = cd.getClaimMVote(claimid, 1);
@@ -386,8 +392,9 @@ contract ClaimsReward is Iupgradable {
         for (i = lastIndex; i < lengthVote && counter < _records; i++) {
             voteid = cd.getVoteAddressCA(msg.sender, i);
             (tokenForVoteId, lastClaimedCheck, , perc) = getRewardToBeGiven(1, voteid, 0);
-            if (lastClaimed == lengthVote && lastClaimedCheck == true)
+            if (lastClaimed == lengthVote && lastClaimedCheck == true) {
                 lastClaimed = i;
+            }
             (, claimId, , claimed) = cd.getVoteDetails(voteid);
 
             if (perc > 0 && !claimed) {
@@ -395,44 +402,54 @@ contract ClaimsReward is Iupgradable {
                 cd.setRewardClaimed(voteid, true);
             } else if (perc == 0 && cd.getFinalVerdict(claimId) != 0 && !claimed) {
                 (perc, , ) = cd.getClaimRewardDetail(claimId);
-                if (perc == 0)
+                if (perc == 0) {
                     counter++;
+                }
                 cd.setRewardClaimed(voteid, true);
             }
-            if (tokenForVoteId > 0)
+            if (tokenForVoteId > 0) {
                 total = tokenForVoteId.add(total);
+            }
         }
-        if(lastClaimed == lengthVote)
+        if (lastClaimed == lengthVote) {
             cd.setRewardDistributedIndexCA(msg.sender, i);
-        else
+        }
+        else {
             cd.setRewardDistributedIndexCA(msg.sender, lastClaimed);
+        }
         lengthVote = cd.getVoteAddressMemberLength(msg.sender);
         lastClaimed = lengthVote;
         _days = _days.mul(counter);
-        if (tc.tokensLockedAtTime(msg.sender, "CLA", now) > 0)
+        if (tc.tokensLockedAtTime(msg.sender, "CLA", now) > 0) {
             tc.reduceLock(msg.sender, "CLA", _days);
+        }
         (, lastIndex) = cd.getRewardDistributedIndex(msg.sender);
         lastClaimed = lengthVote;
         counter = 0;
         for (i = lastIndex; i < lengthVote && counter < _records; i++) {
             voteid = cd.getVoteAddressMember(msg.sender, i);
             (tokenForVoteId, lastClaimedCheck, , ) = getRewardToBeGiven(0, voteid, 0);
-            if (lastClaimed == lengthVote && lastClaimedCheck == true)
+            if (lastClaimed == lengthVote && lastClaimedCheck == true) {
                 lastClaimed = i;
+            }
             (, claimId, , claimed) = cd.getVoteDetails(voteid);
-            if (claimed == false && cd.getFinalVerdict(claimId) != 0){
+            if (claimed == false && cd.getFinalVerdict(claimId) != 0) {
                 cd.setRewardClaimed(voteid, true);
                 counter++;
             }
-            if (tokenForVoteId > 0)
+            if (tokenForVoteId > 0) {
                 total = tokenForVoteId.add(total);
+            }
         }
-        if (total > 0)
+        if (total > 0) {
             require(tk.transfer(msg.sender, total));
-        if(lastClaimed == lengthVote) 
+        }
+        if (lastClaimed == lengthVote) {
             cd.setRewardDistributedIndexMV(msg.sender, i);
-        else
+        }
+        else {
             cd.setRewardDistributedIndexMV(msg.sender, lastClaimed);
+        }
     }
 
     /**
@@ -454,19 +471,22 @@ contract ClaimsReward is Iupgradable {
             commissionEarned = td.getStakerEarnedStakeCommission(msg.sender, i);
             maxCommission = td.getStakerInitialStakedAmountOnContract(
                 msg.sender, i).mul(td.stakerMaxCommissionPer()).div(100);
-            if (lastCommisionRedeemed == len && maxCommission != commissionEarned)
+            if (lastCommisionRedeemed == len && maxCommission != commissionEarned) {
                 lastCommisionRedeemed = i;
+            }
             td.pushRedeemedStakeCommissions(msg.sender, i, commissionEarned.sub(commissionRedeemed));
             total = total.add(commissionEarned.sub(commissionRedeemed));
             counter++;
         }
-            if(lastCommisionRedeemed == len)
-                td.setLastCompletedStakeCommissionIndex(msg.sender, i);
-            else
-                td.setLastCompletedStakeCommissionIndex(msg.sender, lastCommisionRedeemed); 
+        if (lastCommisionRedeemed == len) {
+            td.setLastCompletedStakeCommissionIndex(msg.sender, i);
+        } else {
+            td.setLastCompletedStakeCommissionIndex(msg.sender, lastCommisionRedeemed); 
+        }
 
-        if (total > 0) 
+        if (total > 0) {
             require(tk.transfer(msg.sender, total)); //solhint-disable-line
+        }
         
     }
 }

--- a/contracts/TokenController.sol
+++ b/contracts/TokenController.sol
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017 NexusMutual.io
+/* Copyright (C) 2020 NexusMutual.io
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -26,6 +26,9 @@ contract TokenController is IERC1132, Iupgradable {
     event Burned(address indexed member, bytes32 lockedUnder, uint256 amount);
 
     NXMToken public token;
+
+    uint public minCALockTime = uint(30).mul(1 days);
+    bytes32 private constant CLA = bytes32("CLA");
     
     /**
     * @dev Just for interface
@@ -44,13 +47,15 @@ contract TokenController is IERC1132, Iupgradable {
     
     /**
     * @dev Locks a specified amount of tokens,
-    *    for a specified reason and time
-    * @param _reason The reason to lock tokens
+    *    for CLA reason and for a specified time
+    * @param _reason The reason to lock tokens, currently restricted to CLA
     * @param _amount Number of tokens to be locked
     * @param _time Lock time in seconds
     */
-    function lock(bytes32 _reason, uint256 _amount, uint256 _time) public returns (bool)
+    function lock(bytes32 _reason, uint256 _amount, uint256 _time) public checkPause returns (bool)
     {
+        require(_reason == CLA,"Restricted to reason CLA");
+        require(minCALockTime <= _time,"Should lock for minimum time");
         // If tokens are already locked, then functions extendLock or
         // increaseLockAmount should be used to make any changes
         _lock(msg.sender, _reason, _amount, _time);
@@ -77,14 +82,16 @@ contract TokenController is IERC1132, Iupgradable {
     }
   
     /**
-    * @dev Extends lock for a specified reason and time
-    * @param _reason The reason to lock tokens
+    * @dev Extends lock for reason CLA for a specified time
+    * @param _reason The reason to lock tokens, currently restricted to CLA
     * @param _time Lock extension time in seconds
     */
     function extendLock(bytes32 _reason, uint256 _time)
         public
+        checkPause
         returns (bool)
     {
+        require(_reason == CLA,"Restricted to reason CLA");
         _extendLock(msg.sender, _reason, _time);
         return true;
     }
@@ -104,15 +111,21 @@ contract TokenController is IERC1132, Iupgradable {
     }
     
     /**
-    * @dev Increase number of tokens locked for a specified reason
-    * @param _reason The reason to lock tokens
+    * @dev Increase number of tokens locked for a CLA reason
+    * @param _reason The reason to lock tokens, currently restricted to CLA
     * @param _amount Number of tokens to be increased
     */
     function increaseLockAmount(bytes32 _reason, uint256 _amount)
         public
+        checkPause
         returns (bool)
     {    
-        _increaseLockAmount(msg.sender, _reason, _amount);
+        require(_reason == CLA,"Restricted to reason CLA");
+        require(_tokensLocked(msg.sender, _reason) > 0);
+        token.operatorTransfer(msg.sender, _amount);
+
+        locked[msg.sender][_reason].amount = locked[msg.sender][_reason].amount.add(_amount);
+        emit Locked(msg.sender, _reason, _amount, locked[msg.sender][_reason].validity);
         return true;
     }
 
@@ -193,26 +206,36 @@ contract TokenController is IERC1132, Iupgradable {
     }
 
     /**
-    * @dev Unlocks the unlockable tokens of a specified address
-    * @param _of Address of user, claiming back unlockable tokens
+    * @dev Unlocks the unlockable tokens against CLA of a specified address
+    * @param _of Address of user, claiming back unlockable tokens against CLA
     */
     function unlock(address _of)
         public
+        checkPause
         returns (uint256 unlockableTokens)
     {
-        uint256 lockedTokens;
 
-        for (uint256 i = 0; i < lockReason[_of].length; i++) {
-            lockedTokens = _tokensUnlockable(_of, lockReason[_of][i]);
-            if (lockedTokens > 0) {
-                unlockableTokens = unlockableTokens.add(lockedTokens);
-                locked[_of][lockReason[_of][i]].claimed = true;
-                emit Unlocked(_of, lockReason[_of][i], lockedTokens);
-            }
+        unlockableTokens = _tokensUnlockable(_of, CLA);
+        if (unlockableTokens > 0) {
+            locked[_of][CLA].claimed = true;
+            emit Unlocked(_of, CLA, unlockableTokens);
+            require(token.transfer(_of, unlockableTokens));
         }  
 
-        if (unlockableTokens > 0)
-            require(token.transfer(_of, unlockableTokens));
+    }
+
+    /**
+     * @dev Updates Uint Parameters of a code
+     * @param code whose details we want to update
+     * @param val value to set
+     */
+    function updateUintParameters(bytes8 code, uint val) public {
+        require(ms.checkIsAuthToGoverned(msg.sender));
+        if (code == "MNCLT") {
+            minCALockTime = val.mul(1 days);
+        } else {
+            revert("Invalid param code");
+        }
     }
 
     /**
@@ -325,7 +348,7 @@ contract TokenController is IERC1132, Iupgradable {
         for (uint256 i = 0; i < lockReason[_of].length; i++) {
             amount = amount.add(_tokensLockedAtTime(_of, lockReason[_of][i], _time));
         }
-    } 
+    }
 
     /**
     * @dev Locks a specified amount of tokens against an address,
@@ -339,8 +362,9 @@ contract TokenController is IERC1132, Iupgradable {
         require(_tokensLocked(_of, _reason) == 0);
         require(_amount != 0);
 
-        if (locked[_of][_reason].amount == 0)
+        if (locked[_of][_reason].amount == 0) {
             lockReason[_of].push(_reason);
+        }
 
         require(token.operatorTransfer(_of, _amount));
 
@@ -361,8 +385,9 @@ contract TokenController is IERC1132, Iupgradable {
         view
         returns (uint256 amount)
     {
-        if (!locked[_of][_reason].claimed)
+        if (!locked[_of][_reason].claimed) {
             amount = locked[_of][_reason].amount;
+        }
     }
 
     /**
@@ -378,8 +403,9 @@ contract TokenController is IERC1132, Iupgradable {
         view
         returns (uint256 amount)
     {
-        if (locked[_of][_reason].validity > _time)
+        if (locked[_of][_reason].validity > _time) {
             amount = locked[_of][_reason].amount;
+        }
     }
     
     /**
@@ -407,20 +433,6 @@ contract TokenController is IERC1132, Iupgradable {
         locked[_of][_reason].validity = locked[_of][_reason].validity.sub(_time);
         emit Locked(_of, _reason, locked[_of][_reason].amount, locked[_of][_reason].validity);
     }
-    
-    /**
-    * @dev Increase number of tokens locked for a specified reason
-    * @param _of The address whose tokens are locked
-    * @param _reason The reason to lock tokens
-    * @param _amount Number of tokens to be increased
-    */
-    function _increaseLockAmount(address _of, bytes32 _reason, uint256 _amount) internal {
-        require(_tokensLocked(_of, _reason) > 0);
-        token.operatorTransfer(msg.sender, _amount);
-
-        locked[_of][_reason].amount = locked[_of][_reason].amount.add(_amount);
-        emit Locked(_of, _reason, _amount, locked[_of][_reason].validity);
-    }
 
     /**
     * @dev Returns unlockable tokens for a specified address for a specified reason
@@ -429,8 +441,9 @@ contract TokenController is IERC1132, Iupgradable {
     */
     function _tokensUnlockable(address _of, bytes32 _reason) internal view returns (uint256 amount)
     {
-      if (locked[_of][_reason].validity <= now && !locked[_of][_reason].claimed) //solhint-disable-line
+        if (locked[_of][_reason].validity <= now && !locked[_of][_reason].claimed) {
             amount = locked[_of][_reason].amount;
+        }
     }
 
     /**
@@ -443,10 +456,14 @@ contract TokenController is IERC1132, Iupgradable {
         uint256 amount = _tokensLocked(_of, _reason);
         require(amount >= _amount);
         
-        if (amount == _amount)
+        if (amount == _amount) {
             locked[_of][_reason].claimed = true;
+        }
         
         locked[_of][_reason].amount = locked[_of][_reason].amount.sub(_amount);
+        if (locked[_of][_reason].amount == 0) {
+            _removeReason(_of, _reason);
+        }
         token.burn(_amount);
         emit Burned(_of, _reason, _amount);
     }
@@ -457,17 +474,31 @@ contract TokenController is IERC1132, Iupgradable {
     * @param _reason reason of the lock
     * @param _amount amount of tokens to release
     */
-    function _releaseLockedTokens(address _of, bytes32 _reason, uint256 _amount) 
-        internal 
+    function _releaseLockedTokens(address _of, bytes32 _reason, uint256 _amount) internal 
     {
         uint256 amount = _tokensLocked(_of, _reason);
         require(amount >= _amount);
 
-        if (amount == _amount)
+        if (amount == _amount) {
             locked[_of][_reason].claimed = true;
+        }
 
         locked[_of][_reason].amount = locked[_of][_reason].amount.sub(_amount);
+        if (locked[_of][_reason].amount == 0) {
+            _removeReason(_of, _reason);
+        }
         require(token.transfer(_of, _amount));
         emit Unlocked(_of, _reason, _amount);
+    }
+
+    function _removeReason(address _of, bytes32 _reason) internal {
+        uint len = lockReason[_of].length;
+        for (uint i = 0; i < len; i++) {
+            if (lockReason[_of][i] == _reason) {
+                lockReason[_of][i] = lockReason[_of][len.sub(1)];
+                lockReason[_of].pop();
+                break;
+            }
+        }   
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -178,6 +178,14 @@
           "integrity": "sha512-G0UmX5uKEmW+ZAhmZ6PLTQ5eu/VPaT+d/tdLd5IFsKRPcbe6lPxocBtcYBFSaLaCW8O60AX90e91Nsp8lVHCNw==",
           "dev": true
         },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "eth-lib": {
           "version": "0.2.7",
           "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
@@ -244,6 +252,11 @@
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
           "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
           "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "scrypt-js": {
           "version": "2.0.3",
@@ -524,8 +537,7 @@
           "dev": true,
           "requires": {
             "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.1",
-            "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
+            "web3-core-helpers": "1.2.1"
           }
         },
         "web3-shh": {
@@ -554,6 +566,17 @@
             "underscore": "1.9.1",
             "utf8": "3.0.0"
           }
+        },
+        "websocket": {
+          "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
+          "from": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
+          "requires": {
+            "debug": "^2.2.0",
+            "es5-ext": "^0.10.50",
+            "nan": "^2.14.0",
+            "typedarray-to-buffer": "^3.1.5",
+            "yaeti": "^0.0.6"
+          }
         }
       }
     },
@@ -561,7 +584,6 @@
       "version": "4.11.6",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
       "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -592,8 +614,7 @@
     "@types/node": {
       "version": "13.7.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.0.tgz",
-      "integrity": "sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ==",
-      "dev": true
+      "integrity": "sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ=="
     },
     "JSONStream": {
       "version": "1.3.5",
@@ -1746,10 +1767,6 @@
         }
       }
     },
-    "bignumber.js": {
-      "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-      "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
-    },
     "bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -2845,16 +2862,6 @@
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
       "dev": true
     },
-    "d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "dev": true,
-      "requires": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
-      }
-    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -3405,28 +3412,6 @@
         "is-symbol": "^1.0.2"
       }
     },
-    "es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-      "dev": true,
-      "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
-      }
-    },
-    "es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "dev": true,
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
     "es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
@@ -3440,16 +3425,6 @@
       "dev": true,
       "requires": {
         "es6-promise": "^4.0.3"
-      }
-    },
-    "es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "dev": true,
-      "requires": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
       }
     },
     "escape-html": {
@@ -3766,6 +3741,10 @@
         "web3": "0.20.2"
       },
       "dependencies": {
+        "bignumber.js": {
+          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+        },
         "bitcore-lib": {
           "version": "0.15.0",
           "resolved": "https://registry.npmjs.org/bitcore-lib/-/bitcore-lib-0.15.0.tgz",
@@ -3823,7 +3802,6 @@
           "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.2.tgz",
           "integrity": "sha1-xU2sX8DjdzmcBMGm7LsS5FEyeNY=",
           "requires": {
-            "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
             "crypto-js": "^3.1.4",
             "utf8": "^2.1.1",
             "xhr2": "*",
@@ -3848,22 +3826,12 @@
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "dev": true,
       "requires": {
-        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
         "ethereumjs-util": "^5.1.1"
       },
       "dependencies": {
-        "bindings": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-          "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-          "requires": {
-            "file-uri-to-path": "1.0.0"
-          }
-        },
         "ethereumjs-abi": {
           "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
-          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-          "dev": true,
+          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
           "requires": {
             "bn.js": "^4.11.8",
             "ethereumjs-util": "^6.0.0"
@@ -3873,7 +3841,6 @@
               "version": "6.2.0",
               "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
               "integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
-              "dev": true,
               "requires": {
                 "@types/bn.js": "^4.11.3",
                 "bn.js": "^4.11.0",
@@ -3883,33 +3850,6 @@
                 "rlp": "^2.2.3",
                 "secp256k1": "^3.0.1"
               }
-            },
-            "keccak": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
-              "integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
-              "dev": true,
-              "requires": {
-                "bindings": "^1.5.0",
-                "inherits": "^2.0.4",
-                "nan": "^2.14.0",
-                "safe-buffer": "^5.2.0"
-              }
-            },
-            "rlp": {
-              "version": "2.2.4",
-              "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.4.tgz",
-              "integrity": "sha512-fdq2yYCWpAQBhwkZv+Z8o/Z4sPmYm1CUq6P7n6lVTOdb949CnqA0sndXal5C1NleSVSZm6q5F3iEbauyVln/iw==",
-              "dev": true,
-              "requires": {
-                "bn.js": "^4.11.1"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-              "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
-              "dev": true
             }
           }
         },
@@ -4565,23 +4505,6 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        }
-      }
-    },
-    "ext": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
-      "dev": true,
-      "requires": {
-        "type": "^2.0.0"
-      },
-      "dependencies": {
-        "type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
-          "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
           "dev": true
         }
       }
@@ -8175,12 +8098,6 @@
       "integrity": "sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==",
       "dev": true
     },
-    "next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
-      "dev": true
-    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -9143,8 +9060,7 @@
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
           "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "2.0.0",
@@ -9952,23 +9868,6 @@
       "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
       "dev": true
     },
-    "scrypt-shim": {
-      "version": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
-      "from": "github:web3-js/scrypt-shim",
-      "dev": true,
-      "requires": {
-        "scryptsy": "^2.1.0",
-        "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
-      }
-    },
     "scrypt.js": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.3.0.tgz",
@@ -9993,8 +9892,7 @@
     "scryptsy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-2.1.0.tgz",
-      "integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w==",
-      "dev": true
+      "integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w=="
     },
     "secp256k1": {
       "version": "3.8.0",
@@ -10546,6 +10444,14 @@
           "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.14.tgz",
           "integrity": "sha512-G0UmX5uKEmW+ZAhmZ6PLTQ5eu/VPaT+d/tdLd5IFsKRPcbe6lPxocBtcYBFSaLaCW8O60AX90e91Nsp8lVHCNw==",
           "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "eth-lib": {
           "version": "0.2.7",
@@ -11313,6 +11219,11 @@
           "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
         },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
         "pify": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -11809,8 +11720,7 @@
           "dev": true,
           "requires": {
             "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.1",
-            "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
+            "web3-core-helpers": "1.2.1"
           }
         },
         "web3-shh": {
@@ -11823,6 +11733,17 @@
             "web3-core-method": "1.2.1",
             "web3-core-subscriptions": "1.2.1",
             "web3-net": "1.2.1"
+          }
+        },
+        "websocket": {
+          "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
+          "from": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
+          "requires": {
+            "debug": "^2.2.0",
+            "es5-ext": "^0.10.50",
+            "nan": "^2.14.0",
+            "typedarray-to-buffer": "^3.1.5",
+            "yaeti": "^0.0.6"
           }
         }
       }
@@ -12672,12 +12593,6 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz",
       "integrity": "sha1-RTFhdwRp1FzSZsNkBOK8maj6mUQ="
     },
-    "type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
-      "dev": true
-    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -12714,15 +12629,6 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
-    },
-    "typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "dev": true,
-      "requires": {
-        "is-typedarray": "^1.0.0"
-      }
     },
     "uglify-js": {
       "version": "3.7.7",
@@ -13006,11 +12912,16 @@
       "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.7.tgz",
       "integrity": "sha512-VU6/DSUX93d1fCzBz7WP/SGCQizO1rKZi4Px9j/3yRyfssHyFcZamMw2/sj4E8TlfMXONvZLoforR8B4bRoyTQ==",
       "requires": {
-        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
         "crypto-js": "^3.1.4",
         "utf8": "^2.1.1",
         "xhr2-cookies": "^1.1.0",
         "xmlhttprequest": "*"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+        }
       }
     },
     "web3-bzz": {
@@ -13470,7 +13381,6 @@
         "eth-lib": "0.2.7",
         "ethereumjs-common": "^1.3.2",
         "ethereumjs-tx": "^2.1.1",
-        "scrypt-shim": "github:web3-js/scrypt-shim",
         "underscore": "1.9.1",
         "uuid": "3.3.2",
         "web3-core": "1.2.2",
@@ -13532,6 +13442,19 @@
             "nan": "^2.14.0",
             "safe-buffer": "^5.2.0"
           }
+        },
+        "scrypt-shim": {
+          "version": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
+          "from": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
+          "requires": {
+            "scryptsy": "^2.1.0",
+            "semver": "^6.3.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         },
         "underscore": {
           "version": "1.9.1",
@@ -13923,15 +13846,38 @@
       "dev": true,
       "requires": {
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.2",
-        "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
+        "web3-core-helpers": "1.2.2"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
         "underscore": {
           "version": "1.9.1",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
           "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
           "dev": true
+        },
+        "websocket": {
+          "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
+          "from": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
+          "requires": {
+            "debug": "^2.2.0",
+            "es5-ext": "^0.10.50",
+            "nan": "^2.14.0",
+            "typedarray-to-buffer": "^3.1.5",
+            "yaeti": "^0.0.6"
+          }
         }
       }
     },
@@ -13984,35 +13930,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
           "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
-          "dev": true
-        }
-      }
-    },
-    "websocket": {
-      "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
-      "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
-      "dev": true,
-      "requires": {
-        "debug": "^2.2.0",
-        "es5-ext": "^0.10.50",
-        "nan": "^2.14.0",
-        "typedarray-to-buffer": "^3.1.5",
-        "yaeti": "^0.0.6"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
       }
@@ -14260,12 +14177,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-      "dev": true
-    },
-    "yaeti": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
       "dev": true
     },
     "yallist": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -537,7 +537,22 @@
           "dev": true,
           "requires": {
             "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.1"
+            "web3-core-helpers": "1.2.1",
+            "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
+          },
+          "dependencies": {
+            "websocket": {
+              "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
+              "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
+              "dev": true,
+              "requires": {
+                "debug": "^2.2.0",
+                "es5-ext": "^0.10.50",
+                "nan": "^2.14.0",
+                "typedarray-to-buffer": "^3.1.5",
+                "yaeti": "^0.0.6"
+              }
+            }
           }
         },
         "web3-shh": {
@@ -584,6 +599,7 @@
       "version": "4.11.6",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
       "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -614,7 +630,8 @@
     "@types/node": {
       "version": "13.7.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.0.tgz",
-      "integrity": "sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ=="
+      "integrity": "sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ==",
+      "dev": true
     },
     "JSONStream": {
       "version": "1.3.5",
@@ -1767,6 +1784,10 @@
         }
       }
     },
+    "bignumber.js": {
+      "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+      "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+    },
     "bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -2862,6 +2883,15 @@
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
       "dev": true
     },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -3412,6 +3442,26 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "es5-ext": {
+      "version": "0.10.53",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.3",
+        "next-tick": "~1.0.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
     "es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
@@ -3425,6 +3475,15 @@
       "dev": true,
       "requires": {
         "es6-promise": "^4.0.3"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "requires": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
       }
     },
     "escape-html": {
@@ -3802,10 +3861,17 @@
           "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.2.tgz",
           "integrity": "sha1-xU2sX8DjdzmcBMGm7LsS5FEyeNY=",
           "requires": {
+            "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
             "crypto-js": "^3.1.4",
             "utf8": "^2.1.1",
             "xhr2": "*",
             "xmlhttprequest": "*"
+          },
+          "dependencies": {
+            "bignumber.js": {
+              "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+              "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+            }
           }
         }
       }
@@ -3826,12 +3892,14 @@
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "dev": true,
       "requires": {
+        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
         "ethereumjs-util": "^5.1.1"
       },
       "dependencies": {
         "ethereumjs-abi": {
           "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
-          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
+          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+          "dev": true,
           "requires": {
             "bn.js": "^4.11.8",
             "ethereumjs-util": "^6.0.0"
@@ -3841,6 +3909,7 @@
               "version": "6.2.0",
               "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
               "integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+              "dev": true,
               "requires": {
                 "@types/bn.js": "^4.11.3",
                 "bn.js": "^4.11.0",
@@ -3856,12 +3925,14 @@
         "inherits": {
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "dev": true
         },
         "keccak": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
           "integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
+          "dev": true,
           "requires": {
             "bindings": "^1.5.0",
             "inherits": "^2.0.4",
@@ -4506,6 +4577,21 @@
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true
+        }
+      }
+    },
+    "ext": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "requires": {
+        "type": "^2.0.0"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+          "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
         }
       }
     },
@@ -6791,8 +6877,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-windows": {
       "version": "1.0.2",
@@ -8098,6 +8183,11 @@
       "integrity": "sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==",
       "dev": true
     },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -9060,7 +9150,8 @@
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
           "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "escape-string-regexp": {
           "version": "2.0.0",
@@ -9868,6 +9959,23 @@
       "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
       "dev": true
     },
+    "scrypt-shim": {
+      "version": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
+      "from": "github:web3-js/scrypt-shim",
+      "dev": true,
+      "requires": {
+        "scryptsy": "^2.1.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "scrypt.js": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.3.0.tgz",
@@ -9892,7 +10000,8 @@
     "scryptsy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-2.1.0.tgz",
-      "integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w=="
+      "integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w==",
+      "dev": true
     },
     "secp256k1": {
       "version": "3.8.0",
@@ -11720,7 +11829,22 @@
           "dev": true,
           "requires": {
             "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.1"
+            "web3-core-helpers": "1.2.1",
+            "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
+          },
+          "dependencies": {
+            "websocket": {
+              "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
+              "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
+              "dev": true,
+              "requires": {
+                "debug": "^2.2.0",
+                "es5-ext": "^0.10.50",
+                "nan": "^2.14.0",
+                "typedarray-to-buffer": "^3.1.5",
+                "yaeti": "^0.0.6"
+              }
+            }
           }
         },
         "web3-shh": {
@@ -12593,6 +12717,11 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz",
       "integrity": "sha1-RTFhdwRp1FzSZsNkBOK8maj6mUQ="
     },
+    "type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -12629,6 +12758,14 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
     },
     "uglify-js": {
       "version": "3.7.7",
@@ -12912,16 +13049,11 @@
       "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.7.tgz",
       "integrity": "sha512-VU6/DSUX93d1fCzBz7WP/SGCQizO1rKZi4Px9j/3yRyfssHyFcZamMw2/sj4E8TlfMXONvZLoforR8B4bRoyTQ==",
       "requires": {
+        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
         "crypto-js": "^3.1.4",
         "utf8": "^2.1.1",
         "xhr2-cookies": "^1.1.0",
         "xmlhttprequest": "*"
-      },
-      "dependencies": {
-        "bignumber.js": {
-          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
-        }
       }
     },
     "web3-bzz": {
@@ -13381,6 +13513,7 @@
         "eth-lib": "0.2.7",
         "ethereumjs-common": "^1.3.2",
         "ethereumjs-tx": "^2.1.1",
+        "scrypt-shim": "github:web3-js/scrypt-shim",
         "underscore": "1.9.1",
         "uuid": "3.3.2",
         "web3-core": "1.2.2",
@@ -13442,19 +13575,6 @@
             "nan": "^2.14.0",
             "safe-buffer": "^5.2.0"
           }
-        },
-        "scrypt-shim": {
-          "version": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
-          "from": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
-          "requires": {
-            "scryptsy": "^2.1.0",
-            "semver": "^6.3.0"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         },
         "underscore": {
           "version": "1.9.1",
@@ -13846,38 +13966,15 @@
       "dev": true,
       "requires": {
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.2"
+        "web3-core-helpers": "1.2.2",
+        "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
         "underscore": {
           "version": "1.9.1",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
           "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
           "dev": true
-        },
-        "websocket": {
-          "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
-          "from": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
-          "requires": {
-            "debug": "^2.2.0",
-            "es5-ext": "^0.10.50",
-            "nan": "^2.14.0",
-            "typedarray-to-buffer": "^3.1.5",
-            "yaeti": "^0.0.6"
-          }
         }
       }
     },
@@ -13930,6 +14027,35 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
           "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
+          "dev": true
+        }
+      }
+    },
+    "websocket": {
+      "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
+      "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
+      "dev": true,
+      "requires": {
+        "debug": "^2.2.0",
+        "es5-ext": "^0.10.50",
+        "nan": "^2.14.0",
+        "typedarray-to-buffer": "^3.1.5",
+        "yaeti": "^0.0.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
       }
@@ -14178,6 +14304,11 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
+    },
+    "yaeti": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
     },
     "yallist": {
       "version": "2.1.2",

--- a/test/09_ClaimReward.test.js
+++ b/test/09_ClaimReward.test.js
@@ -14,11 +14,11 @@ const MemberRoles = artifacts.require('MemberRoles');
 const NXMaster = artifacts.require('NXMaster');
 const MCR = artifacts.require('MCR');
 const Governance = artifacts.require('Governance');
-const { assertRevert } = require('./utils/assertRevert');
-const { advanceBlock } = require('./utils/advanceToBlock');
-const { ether, toHex, toWei } = require('./utils/ethTools');
-const { increaseTimeTo, duration } = require('./utils/increaseTime');
-const { latestTime } = require('./utils/latestTime');
+const {assertRevert} = require('./utils/assertRevert');
+const {advanceBlock} = require('./utils/advanceToBlock');
+const {ether, toHex, toWei} = require('./utils/ethTools');
+const {increaseTimeTo, duration} = require('./utils/increaseTime');
+const {latestTime} = require('./utils/latestTime');
 const gvProp = require('./utils/gvProposal.js').gvProposal;
 const encode = require('./utils/encoder.js').encode;
 const getQuoteValues = require('./utils/getQuote.js').getQuoteValues;
@@ -115,30 +115,30 @@ contract('ClaimsReward', function([
 
     // await mr.payJoiningFee(owner, { from: owner, value: fee });
     // await mr.kycVerdict(owner, true);
-    await mr.payJoiningFee(member1, { from: member1, value: fee });
+    await mr.payJoiningFee(member1, {from: member1, value: fee});
     await mr.kycVerdict(member1, true);
-    await mr.payJoiningFee(member2, { from: member2, value: fee });
+    await mr.payJoiningFee(member2, {from: member2, value: fee});
     await mr.kycVerdict(member2, true);
-    await mr.payJoiningFee(member3, { from: member3, value: fee });
+    await mr.payJoiningFee(member3, {from: member3, value: fee});
     await mr.kycVerdict(member3, true);
-    await mr.payJoiningFee(staker1, { from: staker1, value: fee });
+    await mr.payJoiningFee(staker1, {from: staker1, value: fee});
     await mr.kycVerdict(staker1, true);
-    await mr.payJoiningFee(staker2, { from: staker2, value: fee });
+    await mr.payJoiningFee(staker2, {from: staker2, value: fee});
     await mr.kycVerdict(staker2, true);
-    await mr.payJoiningFee(coverHolder, { from: coverHolder, value: fee });
+    await mr.payJoiningFee(coverHolder, {from: coverHolder, value: fee});
     await mr.kycVerdict(coverHolder, true);
-    await mr.payJoiningFee(newMember1, { from: newMember1, value: fee });
+    await mr.payJoiningFee(newMember1, {from: newMember1, value: fee});
     await mr.kycVerdict(newMember1, true);
-    await mr.payJoiningFee(newMember2, { from: newMember2, value: fee });
+    await mr.payJoiningFee(newMember2, {from: newMember2, value: fee});
     await mr.kycVerdict(newMember2, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: member1 });
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: member2 });
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: member3 });
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: staker1 });
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: staker2 });
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: coverHolder });
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: newMember1 });
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: newMember2 });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: member1});
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: member2});
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: member3});
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: staker1});
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: staker2});
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: coverHolder});
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: newMember1});
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: newMember2});
     await tk.transfer(member1, ether(150));
     await tk.transfer(member2, ether(150));
     await tk.transfer(member3, ether(150));
@@ -147,8 +147,8 @@ contract('ClaimsReward', function([
     await tk.transfer(coverHolder, ether(150));
     await tk.transfer(newMember1, ether(150));
     await tk.transfer(newMember2, ether(150));
-    await tf.addStake(smartConAdd, stakeTokens, { from: staker1 });
-    await tf.addStake(smartConAdd, stakeTokens, { from: staker2 });
+    await tf.addStake(smartConAdd, stakeTokens, {from: staker1});
+    await tf.addStake(smartConAdd, stakeTokens, {from: staker2});
     maxVotingTime = await cd.maxVotingTime();
   });
 
@@ -157,9 +157,9 @@ contract('ClaimsReward', function([
     let initialBalance;
     let initialTokenBalance;
     before(async function() {
-      await tc.lock(CLA, tokens, validity, { from: member1 });
-      await tc.lock(CLA, tokens, validity, { from: member2 });
-      await tc.lock(CLA, tokens, validity, { from: member3 });
+      await tc.lock(CLA, tokens, validity, {from: member1});
+      await tc.lock(CLA, tokens, validity, {from: member2});
+      await tc.lock(CLA, tokens, validity, {from: member3});
       coverDetails[4] = 7972408607001;
       var vrsdata = await getQuoteValues(
         coverDetails,
@@ -176,20 +176,20 @@ contract('ClaimsReward', function([
         vrsdata[0],
         vrsdata[1],
         vrsdata[2],
-        { from: coverHolder, value: coverDetails[1] }
+        {from: coverHolder, value: coverDetails[1]}
       );
       coverID = await qd.getAllCoversOfUser(coverHolder);
-      await cl.submitClaim(coverID[0], { from: coverHolder });
+      await cl.submitClaim(coverID[0], {from: coverHolder});
       claimId = (await cd.actualClaimLength()) - 1;
       const maxVotingTime = await cd.maxVotingTime();
       const now = await latestTime();
       closingTime = new BN(maxVotingTime.toString()).add(
         new BN(now.toString())
       );
-      await cl.submitCAVote(claimId, -1, { from: member1 });
-      await cl.submitCAVote(claimId, -1, { from: member2 });
-      await cl.submitCAVote(claimId, -1, { from: member3 });
-      await cr.claimAllPendingReward(20, { from: member1 });
+      await cl.submitCAVote(claimId, -1, {from: member1});
+      await cl.submitCAVote(claimId, -1, {from: member2});
+      await cl.submitCAVote(claimId, -1, {from: member3});
+      await cr.claimAllPendingReward(20, {from: member1});
       await increaseTimeTo(
         new BN(closingTime.toString()).add(new BN((2).toString()))
       );
@@ -219,9 +219,9 @@ contract('ClaimsReward', function([
       initialTokenBalance = await tk.balanceOf(cr.address);
       initialBalance = await tk.balanceOf(member1);
       rewardToGet = await cr.getAllPendingRewardOfUser(member1);
-      await assertRevert(cr.claimAllPendingReward(20, { from: notMember }));
-      await cr.claimAllPendingReward(20, { from: member1 });
-      await cr.claimAllPendingReward(20, { from: member1 });
+      await assertRevert(cr.claimAllPendingReward(20, {from: notMember}));
+      await cr.claimAllPendingReward(20, {from: member1});
+      await cr.claimAllPendingReward(20, {from: member1});
       (await cr.getAllPendingRewardOfUser(member1))
         .toString()
         .should.be.equal((0).toString());
@@ -245,7 +245,7 @@ contract('ClaimsReward', function([
         );
       let proposalIds = [];
 
-      await cr.claimAllPendingReward(20, { from: member1 });
+      await cr.claimAllPendingReward(20, {from: member1});
     });
   });
   describe('Staker gets reward', function() {
@@ -263,9 +263,10 @@ contract('ClaimsReward', function([
         staker1
       );
     });
-    it('9.4 should be able to claim reward', async function() {
+    it('9.4 should be able to claim reward and unlock all unlockable tokens', async function() {
       let proposalIds = [];
-      await cr.claimAllPendingReward(20, { from: staker1 });
+      await cr.claimAllPendingReward(20, {from: staker1});
+      await tf.unlockStakerUnlockableTokens(staker1);
       (await cr.getAllPendingRewardOfUser(staker1))
         .toString()
         .should.be.equal((0).toString());
@@ -297,11 +298,11 @@ contract('ClaimsReward', function([
 
   describe('Misc', function() {
     it('9.8 should not be able change claim status', async function() {
-      await assertRevert(cr.changeClaimStatus(claimId, { from: notMember }));
+      await assertRevert(cr.changeClaimStatus(claimId, {from: notMember}));
     });
 
     it('9.9 should not be able call upgrade function of this contract', async function() {
-      await assertRevert(cr.upgrade(member1, { from: notMember }));
+      await assertRevert(cr.upgrade(member1, {from: notMember}));
     });
   });
 
@@ -315,7 +316,7 @@ contract('ClaimsReward', function([
       conAdds.push(smartConAdd4);
       conAdds.push(smartConAdd5);
       for (let j = 0; j < conAdds.length; j++) {
-        await tf.addStake(conAdds[j], toWei(30), { from: newMember1 });
+        await tf.addStake(conAdds[j], toWei(30), {from: newMember1});
       }
       let coverDetailsTest = [
         1,
@@ -346,7 +347,7 @@ contract('ClaimsReward', function([
           vrsdata[0],
           vrsdata[1],
           vrsdata[2],
-          { from: newMember2, value: coverDetailsTest[1].toString() }
+          {from: newMember2, value: coverDetailsTest[1].toString()}
         );
       }
     });
@@ -359,7 +360,7 @@ contract('ClaimsReward', function([
       let initialLastClaimed = await td.lastCompletedStakeCommission(
         newMember1
       );
-      await cr.claimAllPendingReward(3, { from: newMember1 });
+      await cr.claimAllPendingReward(3, {from: newMember1});
       assert.equal(
         await td.getStakerTotalReedmedStakeCommission(newMember1),
         toWei(45)
@@ -369,7 +370,7 @@ contract('ClaimsReward', function([
         initialLastClaimed / 1 + 3
       );
       let initialBal = await tk.balanceOf(newMember1);
-      await cr.claimAllPendingReward(3, { from: newMember1 });
+      await cr.claimAllPendingReward(3, {from: newMember1});
       let finalBal = await tk.balanceOf(newMember1);
       assert.equal(finalBal - initialBal, toWei(25));
       assert.equal(
@@ -399,11 +400,11 @@ contract('ClaimsReward', function([
         vrsdata[0],
         vrsdata[1],
         vrsdata[2],
-        { from: newMember2, value: coverDetailsTest[1].toString() }
+        {from: newMember2, value: coverDetailsTest[1].toString()}
       );
 
       initialBal = await tk.balanceOf(newMember1);
-      await cr.claimAllPendingReward(5, { from: newMember1 });
+      await cr.claimAllPendingReward(5, {from: newMember1});
       finalBal = await tk.balanceOf(newMember1);
       assert.equal(finalBal - initialBal, toWei(5));
       assert.equal(
@@ -416,7 +417,7 @@ contract('ClaimsReward', function([
       coverID = await qd.getAllCoversOfUser(newMember2);
       let initialLastClaimed = await cd.getRewardDistributedIndex(newMember1);
       assert.equal(initialLastClaimed[0], 0);
-      await tc.lock(CLA, toWei(40), validity, { from: newMember1 });
+      await tc.lock(CLA, toWei(40), validity, {from: newMember1});
       let returnData = await claimAssesmentVoting(
         1,
         coverID,
@@ -429,21 +430,21 @@ contract('ClaimsReward', function([
         '2000'
       );
       let initialBal = await tk.balanceOf(newMember1);
-      await cr.claimAllPendingReward(3, { from: newMember1 });
+      await cr.claimAllPendingReward(3, {from: newMember1});
       let finalBal = await tk.balanceOf(newMember1);
       assert.equal(parseFloat(returnData[0]), toWei(180));
       assert.equal((finalBal / 1 - initialBal / 1).toString(), toWei(180));
       let newLastIndex = await cd.getRewardDistributedIndex(newMember1);
       assert.equal(newLastIndex[0], initialLastClaimed[0] / 1 + 3);
       initialBal = await tk.balanceOf(newMember1);
-      await cr.claimAllPendingReward(3, { from: newMember1 });
+      await cr.claimAllPendingReward(3, {from: newMember1});
       finalBal = await tk.balanceOf(newMember1);
       newLastIndex = await cd.getRewardDistributedIndex(newMember1);
       assert.equal(newLastIndex[0], initialLastClaimed[0] / 1 + 3);
       assert.equal((finalBal / 1 - initialBal / 1).toString(), toWei(30));
       await P1.__callback(returnData[1], '');
       initialBal = await tk.balanceOf(newMember1);
-      await cr.claimAllPendingReward(3, { from: newMember1 });
+      await cr.claimAllPendingReward(3, {from: newMember1});
       finalBal = await tk.balanceOf(newMember1);
       newLastIndex = await cd.getRewardDistributedIndex(newMember1);
       assert.equal(newLastIndex[0], initialLastClaimed[0] / 1 + 5);
@@ -466,21 +467,21 @@ contract('ClaimsReward', function([
         '2000'
       );
       let initialBal = await tk.balanceOf(newMember1);
-      await cr.claimAllPendingReward(3, { from: newMember1 });
+      await cr.claimAllPendingReward(3, {from: newMember1});
       let finalBal = await tk.balanceOf(newMember1);
       assert.equal(parseFloat(returnData[0]), toWei(180));
       assert.equal((finalBal / 1 - initialBal / 1).toString(), toWei(180));
       let newLastIndex = await cd.getRewardDistributedIndex(newMember1);
       assert.equal(newLastIndex[1], initialLastClaimed[1] / 1 + 3);
       initialBal = await tk.balanceOf(newMember1);
-      await cr.claimAllPendingReward(3, { from: newMember1 });
+      await cr.claimAllPendingReward(3, {from: newMember1});
       finalBal = await tk.balanceOf(newMember1);
       newLastIndex = await cd.getRewardDistributedIndex(newMember1);
       assert.equal(newLastIndex[1], initialLastClaimed[1] / 1 + 3);
       assert.equal((finalBal / 1 - initialBal / 1).toString(), toWei(30));
       await P1.__callback(returnData[1], '');
       initialBal = await tk.balanceOf(newMember1);
-      await cr.claimAllPendingReward(3, { from: newMember1 });
+      await cr.claimAllPendingReward(3, {from: newMember1});
       finalBal = await tk.balanceOf(newMember1);
       newLastIndex = await cd.getRewardDistributedIndex(newMember1);
       assert.equal(newLastIndex[1], initialLastClaimed[1] / 1 + 5);
@@ -506,8 +507,8 @@ async function claimAssesmentVoting(
 
   claimId = await cd.actualClaimLength();
   for (let i = 0; i < 5; i++) {
-    await cl.submitClaim(coverid[i], { from: newMember2 });
-    if (ca == 1) await cl.submitCAVote(claimId, -1, { from: newMember1 });
+    await cl.submitClaim(coverid[i], {from: newMember2});
+    if (ca == 1) await cl.submitCAVote(claimId, -1, {from: newMember1});
     let now = await latestTime();
     closingTime = new BN(_increaseTime.toString()).add(new BN(now.toString()));
     await increaseTimeTo(
@@ -517,7 +518,7 @@ async function claimAssesmentVoting(
     if (i != 3 || ca != 1) await P1.__callback(apiid, '');
     else pendingClaimAPIId = apiid;
     if (ca != 1) {
-      await cl.submitMemberVote(claimId, -1, { from: newMember1 });
+      await cl.submitMemberVote(claimId, -1, {from: newMember1});
       now = await latestTime();
       closingTime = new BN(_increaseTime.toString()).add(
         new BN(now.toString())

--- a/test/16_burnStakerStake.test.js
+++ b/test/16_burnStakerStake.test.js
@@ -7,11 +7,11 @@ const MemberRoles = artifacts.require('MemberRoles');
 const NXMaster = artifacts.require('NXMaster');
 const ClaimsReward = artifacts.require('ClaimsReward');
 
-const { assertRevert } = require('./utils/assertRevert');
-const { advanceBlock } = require('./utils/advanceToBlock');
-const { ether, toHex, toWei } = require('./utils/ethTools');
-const { increaseTimeTo, duration } = require('./utils/increaseTime');
-const { latestTime } = require('./utils/latestTime');
+const {assertRevert} = require('./utils/assertRevert');
+const {advanceBlock} = require('./utils/advanceToBlock');
+const {ether, toHex, toWei} = require('./utils/ethTools');
+const {increaseTimeTo, duration} = require('./utils/increaseTime');
+const {latestTime} = require('./utils/latestTime');
 
 const stakedContract = '0xd0a6e6c54dbc68db5db3a091b171a77407ff7ccf';
 
@@ -49,15 +49,15 @@ contract('NXMToken:Staking', function([owner, UW1, UW2, UW3]) {
     mr = await MemberRoles.at(await nxms.getLatestAddress('0x4d52'));
     await mr.addMembersBeforeLaunch([], []);
     (await mr.launched()).should.be.equal(true);
-    await mr.payJoiningFee(UW1, { from: UW1, value: fee });
+    await mr.payJoiningFee(UW1, {from: UW1, value: fee});
     await mr.kycVerdict(UW1, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: UW1 });
-    await mr.payJoiningFee(UW2, { from: UW2, value: fee });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: UW1});
+    await mr.payJoiningFee(UW2, {from: UW2, value: fee});
     await mr.kycVerdict(UW2, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: UW2 });
-    await mr.payJoiningFee(UW3, { from: UW3, value: fee });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: UW2});
+    await mr.payJoiningFee(UW3, {from: UW3, value: fee});
     await mr.kycVerdict(UW3, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: UW3 });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: UW3});
     await tk.transfer(UW1, tokens);
     await tk.transfer(UW2, tokens);
     await tk.transfer(UW3, tokens);
@@ -71,12 +71,14 @@ contract('NXMToken:Staking', function([owner, UW1, UW2, UW3]) {
 
         describe('At day 0', function() {
           it('16.1 UW1 to add stake on Smart Contracts', async function() {
-            await tf.addStake(stakedContract, stakeTokens, { from: UW1 });
-            (await tf.getStakerLockedTokensOnSmartContract(
-              UW1,
-              stakedContract,
-              0
-            ))
+            await tf.addStake(stakedContract, stakeTokens, {from: UW1});
+            (
+              await tf.getStakerLockedTokensOnSmartContract(
+                UW1,
+                stakedContract,
+                0
+              )
+            )
               .toString()
               .should.be.equal(stakeTokens.toString());
           });
@@ -87,8 +89,8 @@ contract('NXMToken:Staking', function([owner, UW1, UW2, UW3]) {
             let time = await latestTime();
             time = time + (await duration.days(10));
             await increaseTimeTo(time + 10);
-            await tf.addStake(stakedContract, stakeTokens, { from: UW2 });
-            await cr.claimAllPendingReward(20, { from: UW1 });
+            await tf.addStake(stakedContract, stakeTokens, {from: UW2});
+            await tf.unlockStakerUnlockableTokens(UW1);
             let newBal = await tk.balanceOf(UW1);
             console.log(
               'initialBal ',
@@ -96,11 +98,13 @@ contract('NXMToken:Staking', function([owner, UW1, UW2, UW3]) {
               ' newBal ',
               parseFloat(newBal)
             );
-            (await tf.getStakerLockedTokensOnSmartContract(
-              UW2,
-              stakedContract,
-              1
-            ))
+            (
+              await tf.getStakerLockedTokensOnSmartContract(
+                UW2,
+                stakedContract,
+                1
+              )
+            )
               .toString()
               .should.be.equal(stakeTokens.toString());
             (newBal / 1).should.be.equal(initialBal / 1 + 100 * toWei(1));
@@ -111,7 +115,7 @@ contract('NXMToken:Staking', function([owner, UW1, UW2, UW3]) {
             let time = await latestTime();
             time = time + (await duration.days(10));
             await increaseTimeTo(time + 10);
-            await tf.addStake(stakedContract, stakeTokens, { from: UW3 });
+            await tf.addStake(stakedContract, stakeTokens, {from: UW3});
             await tf.burnStakerLockedToken(stakedContract, 0);
             let tx = await tf.burnStakerLockedToken(
               stakedContract,
@@ -126,11 +130,13 @@ contract('NXMToken:Staking', function([owner, UW1, UW2, UW3]) {
               ' burnedUW2 ',
               burnedUW2[5] / 1
             );
-            (await tf.getStakerLockedTokensOnSmartContract(
-              UW3,
-              stakedContract,
-              2
-            ))
+            (
+              await tf.getStakerLockedTokensOnSmartContract(
+                UW3,
+                stakedContract,
+                2
+              )
+            )
               .toString()
               .should.be.equal(stakeTokens.toString());
             (burnedUW1[5] / 1).should.be.equal(2300 * toWei(1));
@@ -164,9 +170,9 @@ contract('NXMToken:Staking', function([owner, UW1, UW2, UW3]) {
               ' unlockableUW3 ',
               parseFloat(unlockableUW3)
             );
-            await cr.claimAllPendingReward(20, { from: UW1 });
-            await cr.claimAllPendingReward(20, { from: UW2 });
-            await cr.claimAllPendingReward(20, { from: UW3 });
+            await tf.unlockStakerUnlockableTokens(UW1);
+            await tf.unlockStakerUnlockableTokens(UW2);
+            await tf.unlockStakerUnlockableTokens(UW3);
             let newBalUW1 = await tk.balanceOf(UW1);
             let newBalUW2 = await tk.balanceOf(UW2);
             let newBalUW3 = await tk.balanceOf(UW3);
@@ -214,9 +220,9 @@ contract('NXMToken:Staking', function([owner, UW1, UW2, UW3]) {
               ' unlockableUW3 ',
               parseFloat(unlockableUW3)
             );
-            await cr.claimAllPendingReward(20, { from: UW1 });
-            await cr.claimAllPendingReward(20, { from: UW2 });
-            await cr.claimAllPendingReward(20, { from: UW3 });
+            await tf.unlockStakerUnlockableTokens(UW1);
+            await tf.unlockStakerUnlockableTokens(UW2);
+            await tf.unlockStakerUnlockableTokens(UW3);
             let newBalUW1 = await tk.balanceOf(UW1);
             let newBalUW2 = await tk.balanceOf(UW2);
             let newBalUW3 = await tk.balanceOf(UW3);
@@ -296,9 +302,9 @@ contract('NXMToken:Staking', function([owner, UW1, UW2, UW3]) {
               ' unlockableUW3 ',
               parseFloat(unlockableUW3)
             );
-            await cr.claimAllPendingReward(20, { from: UW1 });
-            await cr.claimAllPendingReward(20, { from: UW2 });
-            await cr.claimAllPendingReward(20, { from: UW3 });
+            await tf.unlockStakerUnlockableTokens(UW1);
+            await tf.unlockStakerUnlockableTokens(UW2);
+            await tf.unlockStakerUnlockableTokens(UW3);
             let newBalUW1 = await tk.balanceOf(UW1);
             let newBalUW2 = await tk.balanceOf(UW2);
             let newBalUW3 = await tk.balanceOf(UW3);
@@ -349,9 +355,9 @@ contract('NXMToken:Staking', function([owner, UW1, UW2, UW3]) {
               ' unlockableUW3 ',
               parseFloat(unlockableUW3)
             );
-            await cr.claimAllPendingReward(20, { from: UW1 });
-            await cr.claimAllPendingReward(20, { from: UW2 });
-            await cr.claimAllPendingReward(20, { from: UW3 });
+            await tf.unlockStakerUnlockableTokens(UW1);
+            await tf.unlockStakerUnlockableTokens(UW2);
+            await tf.unlockStakerUnlockableTokens(UW3);
             let newBalUW1 = await tk.balanceOf(UW1);
             let newBalUW2 = await tk.balanceOf(UW2);
             let newBalUW3 = await tk.balanceOf(UW3);
@@ -402,9 +408,9 @@ contract('NXMToken:Staking', function([owner, UW1, UW2, UW3]) {
               ' unlockableUW3 ',
               parseFloat(unlockableUW3)
             );
-            await cr.claimAllPendingReward(20, { from: UW1 });
-            await cr.claimAllPendingReward(20, { from: UW2 });
-            await cr.claimAllPendingReward(20, { from: UW3 });
+            await tf.unlockStakerUnlockableTokens(UW1);
+            await tf.unlockStakerUnlockableTokens(UW2);
+            await tf.unlockStakerUnlockableTokens(UW3);
             let newBalUW1 = await tk.balanceOf(UW1);
             let newBalUW2 = await tk.balanceOf(UW2);
             let newBalUW3 = await tk.balanceOf(UW3);

--- a/test/18_ClaimAssessment.test.js
+++ b/test/18_ClaimAssessment.test.js
@@ -18,11 +18,11 @@ const MemberRoles = artifacts.require('MemberRoles');
 const NXMaster = artifacts.require('NXMaster');
 const Governance = artifacts.require('Governance');
 
-const { assertRevert } = require('./utils/assertRevert');
-const { advanceBlock } = require('./utils/advanceToBlock');
-const { ether, toHex, toWei } = require('./utils/ethTools');
-const { increaseTimeTo, duration } = require('./utils/increaseTime');
-const { latestTime } = require('./utils/latestTime');
+const {assertRevert} = require('./utils/assertRevert');
+const {advanceBlock} = require('./utils/advanceToBlock');
+const {ether, toHex, toWei} = require('./utils/ethTools');
+const {increaseTimeTo, duration} = require('./utils/increaseTime');
+const {latestTime} = require('./utils/latestTime');
 const gvProp = require('./utils/gvProposal.js').gvProposal;
 const encode = require('./utils/encoder.js').encode;
 const getQuoteValues = require('./utils/getQuote.js').getQuoteValues;
@@ -136,7 +136,7 @@ contract('Claim: Assessment 2', function([
     await DSV.setRate(25);
     await pd.changeCurrencyAssetBaseMin(ethereum_string, toWei(30));
     await tf.upgradeCapitalPool(dai.address);
-    await p1.sendEther({ from: owner, value: toWei(2500) });
+    await p1.sendEther({from: owner, value: toWei(2500)});
     await pd.changeCurrencyAssetBaseMin(dai_string, toWei(750));
     await dai.transfer(p1.address, toWei(1250));
     await mcr.addMCRData(
@@ -154,7 +154,7 @@ contract('Claim: Assessment 2', function([
     // await td.changeBookTime(60);
     // await mr.payJoiningFee(owner, { from: owner, value: fee });
     // await mr.kycVerdict(owner, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: owner });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: owner});
     // if ((await tk.totalSupply()) < 600000 * toWei(1))
     //   await tc.mint(owner, 600000 * toWei(1) - (await tk.totalSupply()));
     // else await tc.burnFrom(owner, (await tk.totalSupply()) - 600000 * toWei(1));
@@ -164,190 +164,190 @@ contract('Claim: Assessment 2', function([
 
     // let ia_pool_eth = await web3.eth.getBalance(p2.address);
     // let ia_pool_dai = await dai.balanceOf(p2.address);
-    await mr.payJoiningFee(underWriter1, { from: underWriter1, value: fee });
+    await mr.payJoiningFee(underWriter1, {from: underWriter1, value: fee});
     await mr.kycVerdict(underWriter1, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: underWriter1 });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: underWriter1});
 
-    await mr.payJoiningFee(underWriter2, { from: underWriter2, value: fee });
+    await mr.payJoiningFee(underWriter2, {from: underWriter2, value: fee});
     await mr.kycVerdict(underWriter2, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: underWriter2 });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: underWriter2});
 
-    await mr.payJoiningFee(underWriter3, { from: underWriter3, value: fee });
+    await mr.payJoiningFee(underWriter3, {from: underWriter3, value: fee});
     await mr.kycVerdict(underWriter3, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: underWriter3 });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: underWriter3});
 
-    await mr.payJoiningFee(underWriter4, { from: underWriter4, value: fee });
+    await mr.payJoiningFee(underWriter4, {from: underWriter4, value: fee});
     await mr.kycVerdict(underWriter4, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: underWriter4 });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: underWriter4});
 
-    await mr.payJoiningFee(underWriter5, { from: underWriter5, value: fee });
+    await mr.payJoiningFee(underWriter5, {from: underWriter5, value: fee});
     await mr.kycVerdict(underWriter5, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: underWriter5 });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: underWriter5});
 
-    await mr.payJoiningFee(underWriter6, { from: underWriter6, value: fee });
+    await mr.payJoiningFee(underWriter6, {from: underWriter6, value: fee});
     await mr.kycVerdict(underWriter6, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: underWriter6 });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: underWriter6});
 
     await mr.payJoiningFee(claimAssessor1, {
       from: claimAssessor1,
       value: fee
     });
     await mr.kycVerdict(claimAssessor1, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: claimAssessor1 });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: claimAssessor1});
 
     await mr.payJoiningFee(claimAssessor2, {
       from: claimAssessor2,
       value: fee
     });
     await mr.kycVerdict(claimAssessor2, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: claimAssessor2 });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: claimAssessor2});
 
     await mr.payJoiningFee(claimAssessor3, {
       from: claimAssessor3,
       value: fee
     });
     await mr.kycVerdict(claimAssessor3, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: claimAssessor3 });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: claimAssessor3});
 
     await mr.payJoiningFee(claimAssessor4, {
       from: claimAssessor4,
       value: fee
     });
     await mr.kycVerdict(claimAssessor4, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: claimAssessor4 });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: claimAssessor4});
 
     await mr.payJoiningFee(claimAssessor5, {
       from: claimAssessor5,
       value: fee
     });
     await mr.kycVerdict(claimAssessor5, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: claimAssessor5 });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: claimAssessor5});
 
-    await mr.payJoiningFee(coverHolder1, { from: coverHolder1, value: fee });
+    await mr.payJoiningFee(coverHolder1, {from: coverHolder1, value: fee});
     await mr.kycVerdict(coverHolder1, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: coverHolder1 });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: coverHolder1});
 
-    await mr.payJoiningFee(coverHolder2, { from: coverHolder2, value: fee });
+    await mr.payJoiningFee(coverHolder2, {from: coverHolder2, value: fee});
     await mr.kycVerdict(coverHolder2, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: coverHolder2 });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: coverHolder2});
 
-    await mr.payJoiningFee(coverHolder3, { from: coverHolder3, value: fee });
+    await mr.payJoiningFee(coverHolder3, {from: coverHolder3, value: fee});
     await mr.kycVerdict(coverHolder3, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: coverHolder3 });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: coverHolder3});
 
-    await mr.payJoiningFee(coverHolder4, { from: coverHolder4, value: fee });
+    await mr.payJoiningFee(coverHolder4, {from: coverHolder4, value: fee});
     await mr.kycVerdict(coverHolder4, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: coverHolder4 });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: coverHolder4});
 
-    await mr.payJoiningFee(coverHolder5, { from: coverHolder5, value: fee });
+    await mr.payJoiningFee(coverHolder5, {from: coverHolder5, value: fee});
     await mr.kycVerdict(coverHolder5, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: coverHolder5 });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: coverHolder5});
 
-    await mr.payJoiningFee(coverHolder6, { from: coverHolder6, value: fee });
+    await mr.payJoiningFee(coverHolder6, {from: coverHolder6, value: fee});
     await mr.kycVerdict(coverHolder6, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: coverHolder6 });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: coverHolder6});
 
-    await mr.payJoiningFee(coverHolder7, { from: coverHolder7, value: fee });
+    await mr.payJoiningFee(coverHolder7, {from: coverHolder7, value: fee});
     await mr.kycVerdict(coverHolder7, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: coverHolder7 });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: coverHolder7});
 
-    await mr.payJoiningFee(coverHolder8, { from: coverHolder8, value: fee });
+    await mr.payJoiningFee(coverHolder8, {from: coverHolder8, value: fee});
     await mr.kycVerdict(coverHolder8, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: coverHolder8 });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: coverHolder8});
 
-    await mr.payJoiningFee(coverHolder9, { from: coverHolder9, value: fee });
+    await mr.payJoiningFee(coverHolder9, {from: coverHolder9, value: fee});
     await mr.kycVerdict(coverHolder9, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: coverHolder9 });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: coverHolder9});
 
-    await mr.payJoiningFee(member1, { from: member1, value: fee });
+    await mr.payJoiningFee(member1, {from: member1, value: fee});
     await mr.kycVerdict(member1, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: member1 });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: member1});
 
-    await mr.payJoiningFee(member2, { from: member2, value: fee });
+    await mr.payJoiningFee(member2, {from: member2, value: fee});
     await mr.kycVerdict(member2, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: member2 });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: member2});
 
-    await mr.payJoiningFee(member3, { from: member3, value: fee });
+    await mr.payJoiningFee(member3, {from: member3, value: fee});
     await mr.kycVerdict(member3, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: member3 });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: member3});
 
-    await mr.payJoiningFee(member4, { from: member4, value: fee });
+    await mr.payJoiningFee(member4, {from: member4, value: fee});
     await mr.kycVerdict(member4, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: member4 });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: member4});
 
-    await mr.payJoiningFee(member5, { from: member5, value: fee });
+    await mr.payJoiningFee(member5, {from: member5, value: fee});
     await mr.kycVerdict(member5, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: member5 });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: member5});
 
-    await mr.payJoiningFee(member6, { from: member6, value: fee });
+    await mr.payJoiningFee(member6, {from: member6, value: fee});
     await mr.kycVerdict(member6, true);
-    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, { from: member6 });
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: member6});
 
-    await tk.transfer(underWriter1, toWei(19095), { from: owner });
-    await tk.transfer(underWriter2, toWei(16080), { from: owner });
-    await tk.transfer(underWriter3, toWei(15050), { from: owner });
-    await tk.transfer(underWriter4, toWei(18035), { from: owner });
-    await tk.transfer(underWriter5, toWei(17065), { from: owner });
-    await tk.transfer(underWriter6, toWei(19095), { from: owner });
+    await tk.transfer(underWriter1, toWei(19095), {from: owner});
+    await tk.transfer(underWriter2, toWei(16080), {from: owner});
+    await tk.transfer(underWriter3, toWei(15050), {from: owner});
+    await tk.transfer(underWriter4, toWei(18035), {from: owner});
+    await tk.transfer(underWriter5, toWei(17065), {from: owner});
+    await tk.transfer(underWriter6, toWei(19095), {from: owner});
 
-    await tk.transfer(claimAssessor1, toWei(50000), { from: owner });
-    await tk.transfer(claimAssessor2, toWei(30000), { from: owner });
-    await tk.transfer(claimAssessor3, toWei(20000), { from: owner });
-    await tk.transfer(claimAssessor4, toWei(60000), { from: owner });
-    await tk.transfer(claimAssessor5, toWei(50000), { from: owner });
+    await tk.transfer(claimAssessor1, toWei(50000), {from: owner});
+    await tk.transfer(claimAssessor2, toWei(30000), {from: owner});
+    await tk.transfer(claimAssessor3, toWei(20000), {from: owner});
+    await tk.transfer(claimAssessor4, toWei(60000), {from: owner});
+    await tk.transfer(claimAssessor5, toWei(50000), {from: owner});
 
-    await tk.transfer(coverHolder1, toWei(1000), { from: owner });
-    await tk.transfer(coverHolder2, toWei(1000), { from: owner });
-    await tk.transfer(coverHolder3, toWei(1000), { from: owner });
-    await tk.transfer(coverHolder4, toWei(1000), { from: owner });
-    await tk.transfer(coverHolder5, toWei(1000), { from: owner });
-    await tk.transfer(coverHolder6, toWei(1000), { from: owner });
-    await tk.transfer(coverHolder7, toWei(1000), { from: owner });
-    await tk.transfer(coverHolder8, toWei(1000), { from: owner });
-    await tk.transfer(coverHolder9, toWei(1000), { from: owner });
+    await tk.transfer(coverHolder1, toWei(1000), {from: owner});
+    await tk.transfer(coverHolder2, toWei(1000), {from: owner});
+    await tk.transfer(coverHolder3, toWei(1000), {from: owner});
+    await tk.transfer(coverHolder4, toWei(1000), {from: owner});
+    await tk.transfer(coverHolder5, toWei(1000), {from: owner});
+    await tk.transfer(coverHolder6, toWei(1000), {from: owner});
+    await tk.transfer(coverHolder7, toWei(1000), {from: owner});
+    await tk.transfer(coverHolder8, toWei(1000), {from: owner});
+    await tk.transfer(coverHolder9, toWei(1000), {from: owner});
 
-    await tk.transfer(member1, toWei(30000), { from: owner });
-    await tk.transfer(member2, toWei(20000), { from: owner });
-    await tk.transfer(member3, toWei(10000), { from: owner });
-    await tk.transfer(member4, toWei(20000), { from: owner });
-    await tk.transfer(member5, toWei(30000), { from: owner });
-    await tk.transfer(member6, toWei(150000), { from: owner });
+    await tk.transfer(member1, toWei(30000), {from: owner});
+    await tk.transfer(member2, toWei(20000), {from: owner});
+    await tk.transfer(member3, toWei(10000), {from: owner});
+    await tk.transfer(member4, toWei(20000), {from: owner});
+    await tk.transfer(member5, toWei(30000), {from: owner});
+    await tk.transfer(member6, toWei(150000), {from: owner});
 
     // now stake the tokens from the underwriters to the contracts
     // Smart contract 1
-    tf.addStake(SC1, toWei(2000), { from: underWriter1 });
-    tf.addStake(SC1, toWei(3000), { from: underWriter2 });
-    tf.addStake(SC1, toWei(4000), { from: underWriter3 });
-    tf.addStake(SC1, toWei(5000), { from: underWriter4 });
-    tf.addStake(SC1, toWei(6000), { from: underWriter5 });
+    tf.addStake(SC1, toWei(2000), {from: underWriter1});
+    tf.addStake(SC1, toWei(3000), {from: underWriter2});
+    tf.addStake(SC1, toWei(4000), {from: underWriter3});
+    tf.addStake(SC1, toWei(5000), {from: underWriter4});
+    tf.addStake(SC1, toWei(6000), {from: underWriter5});
 
     // Smart contract 2
-    tf.addStake(SC2, toWei(4000), { from: underWriter3 });
-    tf.addStake(SC2, toWei(5000), { from: underWriter2 });
-    tf.addStake(SC2, toWei(6000), { from: underWriter5 });
-    tf.addStake(SC2, toWei(7000), { from: underWriter4 });
-    tf.addStake(SC2, toWei(8000), { from: underWriter1 });
+    tf.addStake(SC2, toWei(4000), {from: underWriter3});
+    tf.addStake(SC2, toWei(5000), {from: underWriter2});
+    tf.addStake(SC2, toWei(6000), {from: underWriter5});
+    tf.addStake(SC2, toWei(7000), {from: underWriter4});
+    tf.addStake(SC2, toWei(8000), {from: underWriter1});
 
     // Smart contract 3
-    tf.addStake(SC3, toWei(5000), { from: underWriter5 });
-    tf.addStake(SC3, toWei(6000), { from: underWriter4 });
-    tf.addStake(SC3, toWei(7000), { from: underWriter3 });
-    tf.addStake(SC3, toWei(8000), { from: underWriter2 });
-    tf.addStake(SC3, toWei(9000), { from: underWriter1 });
+    tf.addStake(SC3, toWei(5000), {from: underWriter5});
+    tf.addStake(SC3, toWei(6000), {from: underWriter4});
+    tf.addStake(SC3, toWei(7000), {from: underWriter3});
+    tf.addStake(SC3, toWei(8000), {from: underWriter2});
+    tf.addStake(SC3, toWei(9000), {from: underWriter1});
 
     // Smart contract 4
-    tf.addStake(SC4, toWei(30), { from: underWriter4 });
-    tf.addStake(SC4, toWei(40), { from: underWriter3 });
-    tf.addStake(SC4, toWei(50), { from: underWriter5 });
-    tf.addStake(SC4, toWei(60), { from: underWriter2 });
-    tf.addStake(SC4, toWei(70), { from: underWriter1 });
+    tf.addStake(SC4, toWei(30), {from: underWriter4});
+    tf.addStake(SC4, toWei(40), {from: underWriter3});
+    tf.addStake(SC4, toWei(50), {from: underWriter5});
+    tf.addStake(SC4, toWei(60), {from: underWriter2});
+    tf.addStake(SC4, toWei(70), {from: underWriter1});
 
     // Smart contract 5
-    tf.addStake(SC5, toWei(5), { from: underWriter4 });
-    tf.addStake(SC5, toWei(10), { from: underWriter3 });
-    tf.addStake(SC5, toWei(15), { from: underWriter5 });
-    tf.addStake(SC5, toWei(20), { from: underWriter2 });
-    tf.addStake(SC5, toWei(25), { from: underWriter1 });
+    tf.addStake(SC5, toWei(5), {from: underWriter4});
+    tf.addStake(SC5, toWei(10), {from: underWriter3});
+    tf.addStake(SC5, toWei(15), {from: underWriter5});
+    tf.addStake(SC5, toWei(20), {from: underWriter2});
+    tf.addStake(SC5, toWei(25), {from: underWriter1});
 
     actionHash = encode('updateUintParameters(bytes8,uint)', 'A', 10);
     await gvProp(26, actionHash, mr, gv, 2);
@@ -405,8 +405,10 @@ contract('Claim: Assessment 2', function([
         }
       }
       function claimAllUWRewards() {
-        for (let i = 0; i < UWarray.length; i++)
-          cr.claimAllPendingReward(20, { from: UWarray[i] });
+        for (let i = 0; i < UWarray.length; i++) {
+          cr.claimAllPendingReward(20, {from: UWarray[i]});
+          tf.unlockStakerUnlockableTokens(UWarray[i]);
+        }
       }
       // buy cover 1
 
@@ -437,7 +439,7 @@ contract('Claim: Assessment 2', function([
         vrsdata[0],
         vrsdata[1],
         vrsdata[2],
-        { from: coverHolder5, value: '6570841889000000' }
+        {from: coverHolder5, value: '6570841889000000'}
       );
       let lockedCN = await tf.getLockedCNAgainstCover(1);
       claimAllUWRewards();
@@ -483,7 +485,7 @@ contract('Claim: Assessment 2', function([
         vrsdata[0],
         vrsdata[1],
         vrsdata[2],
-        { from: coverHolder3 }
+        {from: coverHolder3}
       );
       lockedCN = await tf.getLockedCNAgainstCover(2);
       claimAllUWRewards();
@@ -525,7 +527,7 @@ contract('Claim: Assessment 2', function([
         vrsdata[0],
         vrsdata[1],
         vrsdata[2],
-        { from: coverHolder1, value: '26283367556000000' }
+        {from: coverHolder1, value: '26283367556000000'}
       );
       lockedCN = await tf.getLockedCNAgainstCover(3);
       claimAllUWRewards();
@@ -571,7 +573,7 @@ contract('Claim: Assessment 2', function([
         vrsdata[0],
         vrsdata[1],
         vrsdata[2],
-        { from: coverHolder2 }
+        {from: coverHolder2}
       );
       lockedCN = await tf.getLockedCNAgainstCover(4);
       claimAllUWRewards();
@@ -613,7 +615,7 @@ contract('Claim: Assessment 2', function([
         vrsdata[0],
         vrsdata[1],
         vrsdata[2],
-        { from: coverHolder4, value: '59137577002000000' }
+        {from: coverHolder4, value: '59137577002000000'}
       );
       lockedCN = await tf.getLockedCNAgainstCover(5);
       claimAllUWRewards();
@@ -659,7 +661,7 @@ contract('Claim: Assessment 2', function([
         vrsdata[0],
         vrsdata[1],
         vrsdata[2],
-        { from: coverHolder6 }
+        {from: coverHolder6}
       );
       lockedCN = await tf.getLockedCNAgainstCover(6);
       claimAllUWRewards();
@@ -701,7 +703,7 @@ contract('Claim: Assessment 2', function([
         vrsdata[0],
         vrsdata[1],
         vrsdata[2],
-        { from: coverHolder7, value: '105133470226000000' }
+        {from: coverHolder7, value: '105133470226000000'}
       );
       lockedCN = await tf.getLockedCNAgainstCover(7);
       claimAllUWRewards();
@@ -747,7 +749,7 @@ contract('Claim: Assessment 2', function([
         vrsdata[0],
         vrsdata[1],
         vrsdata[2],
-        { from: coverHolder8 }
+        {from: coverHolder8}
       );
       lockedCN = await tf.getLockedCNAgainstCover(8);
       claimAllUWRewards();
@@ -790,7 +792,7 @@ contract('Claim: Assessment 2', function([
         vrsdata[0],
         vrsdata[1],
         vrsdata[2],
-        { from: coverHolder9, value: '164271047228000000' }
+        {from: coverHolder9, value: '164271047228000000'}
       );
       lockedCN = await tf.getLockedCNAgainstCover(9);
       claimAllUWRewards();
@@ -806,7 +808,7 @@ contract('Claim: Assessment 2', function([
         );
 
       await tf.upgradeCapitalPool(dai.address);
-      await p1.sendEther({ from: owner, value: 50 * toWei(1) });
+      await p1.sendEther({from: owner, value: 50 * toWei(1)});
       await dai.transfer(p1.address, toWei(1250));
       let lockCNFlag = 1;
       for (let i = 0; i < UWarray.length; i++) {
@@ -853,26 +855,26 @@ contract('Claim: Assessment 2', function([
         UWTotalBalanceBefore[i] =
           parseFloat(await tc.totalBalanceOf(UWarray[i])) / toWei(1);
       }
-      await tc.lock(CLA, toWei(50000), validity, { from: claimAssessor1 });
-      await tc.lock(CLA, toWei(30000), validity, { from: claimAssessor2 });
-      await tc.lock(CLA, toWei(20000), validity, { from: claimAssessor3 });
+      await tc.lock(CLA, toWei(50000), validity, {from: claimAssessor1});
+      await tc.lock(CLA, toWei(30000), validity, {from: claimAssessor2});
+      await tc.lock(CLA, toWei(20000), validity, {from: claimAssessor3});
       // cannot withdraw/switch membership as it has staked tokens
-      await assertRevert(mr.withdrawMembership({ from: claimAssessor1 }));
+      await assertRevert(mr.withdrawMembership({from: claimAssessor1}));
       await assertRevert(
-        mr.switchMembership(tc.address, { from: claimAssessor1 })
+        mr.switchMembership(tc.address, {from: claimAssessor1})
       );
 
       coverID = await qd.getAllCoversOfUser(coverHolder5);
 
       // try submitting an invalid cover ID
-      await assertRevert(tf.depositCN(46, { from: owner }));
+      await assertRevert(tf.depositCN(46, {from: owner}));
 
-      await cl.submitClaim(coverID[0], { from: coverHolder5 });
+      await cl.submitClaim(coverID[0], {from: coverHolder5});
       APIID = await pd.allAPIcall((await pd.getApilCallLength()) - 1);
 
       // try submitting the same claim again (to pass the TokenData.sol setDepositCN's require condition of the coverage report)
       // await assertRevert(cl.submitClaim(coverID[0], { from: coverHolder5 }));
-      await assertRevert(td.setDepositCN(coverID[0], true, { from: owner }));
+      await assertRevert(td.setDepositCN(coverID[0], true, {from: owner}));
 
       let now = await latestTime();
       claimID = (await cd.actualClaimLength()) - 1;
@@ -890,9 +892,9 @@ contract('Claim: Assessment 2', function([
       // tries to burn CA votes, but reverts as not auth to governed
       await assertRevert(tf.burnCAToken(claimID, 10, claimAssessor1));
 
-      await cl.submitCAVote(claimID, -1, { from: claimAssessor1 });
-      await cl.submitCAVote(claimID, -1, { from: claimAssessor2 });
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor3 });
+      await cl.submitCAVote(claimID, -1, {from: claimAssessor1});
+      await cl.submitCAVote(claimID, -1, {from: claimAssessor2});
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor3});
 
       claimAssessor1Object.newLockDate = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -966,9 +968,12 @@ contract('Claim: Assessment 2', function([
         toWei(1);
 
       let proposalIds = [];
-      await cr.claimAllPendingReward(20, { from: claimAssessor1 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor2 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor3 });
+      await cr.claimAllPendingReward(20, {from: claimAssessor1});
+      await cr.claimAllPendingReward(20, {from: claimAssessor2});
+      await cr.claimAllPendingReward(20, {from: claimAssessor3});
+      await tf.unlockStakerUnlockableTokens(claimAssessor1);
+      await tf.unlockStakerUnlockableTokens(claimAssessor2);
+      await tf.unlockStakerUnlockableTokens(claimAssessor3);
 
       claimAssessor1Object.lockPeriodAfterRewardRecieved = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -1078,7 +1083,7 @@ contract('Claim: Assessment 2', function([
       // await tc.lock(CLA, 20000 * toWei(1), validity, {from: claimAssessor3});
 
       coverID = await qd.getAllCoversOfUser(coverHolder5);
-      await cl.submitClaim(coverID[0], { from: coverHolder5 });
+      await cl.submitClaim(coverID[0], {from: coverHolder5});
       APIID = await pd.allAPIcall((await pd.getApilCallLength()) - 1);
 
       claimID = (await cd.actualClaimLength()) - 1;
@@ -1093,9 +1098,9 @@ contract('Claim: Assessment 2', function([
         await tc.getLockedTokensValidity(claimAssessor3, CLA)
       );
 
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor1 });
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor2 });
-      await cl.submitCAVote(claimID, -1, { from: claimAssessor3 });
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor1});
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor2});
+      await cl.submitCAVote(claimID, -1, {from: claimAssessor3});
 
       claimAssessor1Object.newLockDate = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -1174,9 +1179,12 @@ contract('Claim: Assessment 2', function([
         toWei(1);
 
       let proposalIds = [];
-      await cr.claimAllPendingReward(20, { from: claimAssessor1 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor2 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor3 });
+      await cr.claimAllPendingReward(20, {from: claimAssessor1});
+      await cr.claimAllPendingReward(20, {from: claimAssessor2});
+      await cr.claimAllPendingReward(20, {from: claimAssessor3});
+      await tf.unlockStakerUnlockableTokens(claimAssessor1);
+      await tf.unlockStakerUnlockableTokens(claimAssessor2);
+      await tf.unlockStakerUnlockableTokens(claimAssessor3);
 
       claimAssessor1Object.lockPeriodAfterRewardRecieved = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -1326,7 +1334,7 @@ contract('Claim: Assessment 2', function([
       }
 
       coverID = await qd.getAllCoversOfUser(coverHolder3);
-      await cl.submitClaim(coverID[0], { from: coverHolder3 });
+      await cl.submitClaim(coverID[0], {from: coverHolder3});
       claimID = (await cd.actualClaimLength()) - 1;
       APIID = await pd.allAPIcall((await pd.getApilCallLength()) - 1);
 
@@ -1340,9 +1348,9 @@ contract('Claim: Assessment 2', function([
         await tc.getLockedTokensValidity(claimAssessor3, CLA)
       );
 
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor1 });
-      await cl.submitCAVote(claimID, -1, { from: claimAssessor2 });
-      await cl.submitCAVote(claimID, -1, { from: claimAssessor3 });
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor1});
+      await cl.submitCAVote(claimID, -1, {from: claimAssessor2});
+      await cl.submitCAVote(claimID, -1, {from: claimAssessor3});
 
       claimAssessor1Object.newLockDate = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -1386,13 +1394,13 @@ contract('Claim: Assessment 2', function([
         toWei(1);
 
       // now member voting started
-      await cl.submitMemberVote(claimID, -1, { from: member1 });
-      await cl.submitMemberVote(claimID, -1, { from: member2 });
-      await cl.submitMemberVote(claimID, 1, { from: member3 });
+      await cl.submitMemberVote(claimID, -1, {from: member1});
+      await cl.submitMemberVote(claimID, -1, {from: member2});
+      await cl.submitMemberVote(claimID, 1, {from: member3});
 
       // cannot withdraw/switch membership as member has voted
-      await assertRevert(mr.withdrawMembership({ from: member1 }));
-      await assertRevert(mr.switchMembership(tc.address, { from: member1 }));
+      await assertRevert(mr.withdrawMembership({from: member1}));
+      await assertRevert(mr.switchMembership(tc.address, {from: member1}));
       // to close the member voting
       maxVotingTime = await cd.maxVotingTime();
       now = await latestTime();
@@ -1407,9 +1415,12 @@ contract('Claim: Assessment 2', function([
       await p1.__callback(APIID, '');
 
       let proposalIds = [];
-      await cr.claimAllPendingReward(20, { from: claimAssessor1 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor2 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor3 });
+      await cr.claimAllPendingReward(20, {from: claimAssessor1});
+      await cr.claimAllPendingReward(20, {from: claimAssessor2});
+      await cr.claimAllPendingReward(20, {from: claimAssessor3});
+      await tf.unlockStakerUnlockableTokens(claimAssessor1);
+      await tf.unlockStakerUnlockableTokens(claimAssessor2);
+      await tf.unlockStakerUnlockableTokens(claimAssessor3);
 
       claimAssessor1Object.lockPeriodAfterRewardRecieved = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -1428,9 +1439,12 @@ contract('Claim: Assessment 2', function([
       member3Object.rewardRecieved =
         parseFloat(await cr.getRewardToBeDistributedByUser(member3)) / toWei(1);
 
-      await cr.claimAllPendingReward(20, { from: member1 });
-      await cr.claimAllPendingReward(20, { from: member2 });
-      await cr.claimAllPendingReward(20, { from: member3 });
+      await cr.claimAllPendingReward(20, {from: member1});
+      await cr.claimAllPendingReward(20, {from: member2});
+      await cr.claimAllPendingReward(20, {from: member3});
+      await tf.unlockStakerUnlockableTokens(member1);
+      await tf.unlockStakerUnlockableTokens(member2);
+      await tf.unlockStakerUnlockableTokens(member3);
 
       let balanceAfter = await dai.balanceOf(coverHolder3);
       let tokenBalanceAfter = parseFloat(await tk.balanceOf(coverHolder3));
@@ -1572,7 +1586,7 @@ contract('Claim: Assessment 2', function([
       }
 
       coverID = await qd.getAllCoversOfUser(coverHolder3);
-      await cl.submitClaim(coverID[0], { from: coverHolder3 });
+      await cl.submitClaim(coverID[0], {from: coverHolder3});
       claimID = (await cd.actualClaimLength()) - 1;
       APIID = await pd.allAPIcall((await pd.getApilCallLength()) - 1);
 
@@ -1586,9 +1600,9 @@ contract('Claim: Assessment 2', function([
         await tc.getLockedTokensValidity(claimAssessor3, CLA)
       );
 
-      await cl.submitCAVote(claimID, -1, { from: claimAssessor1 });
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor2 });
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor3 });
+      await cl.submitCAVote(claimID, -1, {from: claimAssessor1});
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor2});
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor3});
 
       claimAssessor1Object.newLockDate = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -1632,9 +1646,9 @@ contract('Claim: Assessment 2', function([
         toWei(1);
 
       // now member voting started
-      await cl.submitMemberVote(claimID, 1, { from: member1 });
-      await cl.submitMemberVote(claimID, 1, { from: member2 });
-      await cl.submitMemberVote(claimID, -1, { from: member3 });
+      await cl.submitMemberVote(claimID, 1, {from: member1});
+      await cl.submitMemberVote(claimID, 1, {from: member2});
+      await cl.submitMemberVote(claimID, -1, {from: member3});
 
       // to close the member voting
       maxVotingTime = await cd.maxVotingTime();
@@ -1650,9 +1664,9 @@ contract('Claim: Assessment 2', function([
       await p1.__callback(APIID, '');
 
       let proposalIds = [];
-      await cr.claimAllPendingReward(20, { from: claimAssessor1 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor2 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor3 });
+      await cr.claimAllPendingReward(20, {from: claimAssessor1});
+      await cr.claimAllPendingReward(20, {from: claimAssessor2});
+      await cr.claimAllPendingReward(20, {from: claimAssessor3});
 
       claimAssessor1Object.lockPeriodAfterRewardRecieved = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -1671,9 +1685,9 @@ contract('Claim: Assessment 2', function([
       member3Object.rewardRecieved =
         parseFloat(await cr.getRewardToBeDistributedByUser(member3)) / toWei(1);
 
-      await cr.claimAllPendingReward(20, { from: member1 });
-      await cr.claimAllPendingReward(20, { from: member2 });
-      await cr.claimAllPendingReward(20, { from: member3 });
+      await cr.claimAllPendingReward(20, {from: member1});
+      await cr.claimAllPendingReward(20, {from: member2});
+      await cr.claimAllPendingReward(20, {from: member3});
 
       let balanceAfter = parseFloat(await dai.balanceOf(coverHolder3));
       let tokenBalanceAfter = parseFloat(await tk.balanceOf(coverHolder3));
@@ -1800,8 +1814,8 @@ contract('Claim: Assessment 2', function([
       // await tc.lock(CLA, 30000 * toWei(1), validity, {from: claimAssessor2});
       // await tc.lock(CLA, 20000 * toWei(1), validity, {from: claimAssessor3});
 
-      await tc.lock(CLA, toWei(60000), validity, { from: claimAssessor4 });
-      await tc.lock(CLA, toWei(50000), validity, { from: claimAssessor5 });
+      await tc.lock(CLA, toWei(60000), validity, {from: claimAssessor4});
+      await tc.lock(CLA, toWei(50000), validity, {from: claimAssessor5});
 
       for (let i = 0; i < UWarray.length; i++) {
         UWTotalBalanceBefore[i] =
@@ -1828,7 +1842,7 @@ contract('Claim: Assessment 2', function([
       }
 
       coverID = await qd.getAllCoversOfUser(coverHolder1);
-      await cl.submitClaim(coverID[0], { from: coverHolder1 });
+      await cl.submitClaim(coverID[0], {from: coverHolder1});
       claimID = (await cd.actualClaimLength()) - 1;
       APIID = await pd.allAPIcall((await pd.getApilCallLength()) - 1);
 
@@ -1847,11 +1861,11 @@ contract('Claim: Assessment 2', function([
       claimAssessor5Object.initialDate = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor5, CLA)
       );
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor1 });
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor2 });
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor3 });
-      await cl.submitCAVote(claimID, -1, { from: claimAssessor4 });
-      await cl.submitCAVote(claimID, -1, { from: claimAssessor5 });
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor1});
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor2});
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor3});
+      await cl.submitCAVote(claimID, -1, {from: claimAssessor4});
+      await cl.submitCAVote(claimID, -1, {from: claimAssessor5});
 
       claimAssessor1Object.newLockDate = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -1907,9 +1921,9 @@ contract('Claim: Assessment 2', function([
         toWei(1);
 
       // now member voting started
-      await cl.submitMemberVote(claimID, 1, { from: member1 });
-      await cl.submitMemberVote(claimID, 1, { from: member2 });
-      await cl.submitMemberVote(claimID, 1, { from: member3 });
+      await cl.submitMemberVote(claimID, 1, {from: member1});
+      await cl.submitMemberVote(claimID, 1, {from: member2});
+      await cl.submitMemberVote(claimID, 1, {from: member3});
 
       // to close the member voting
       maxVotingTime = await cd.maxVotingTime();
@@ -1925,11 +1939,11 @@ contract('Claim: Assessment 2', function([
       await p1.__callback(APIID, '');
 
       let proposalIds = [];
-      await cr.claimAllPendingReward(20, { from: claimAssessor1 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor2 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor3 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor4 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor5 });
+      await cr.claimAllPendingReward(20, {from: claimAssessor1});
+      await cr.claimAllPendingReward(20, {from: claimAssessor2});
+      await cr.claimAllPendingReward(20, {from: claimAssessor3});
+      await cr.claimAllPendingReward(20, {from: claimAssessor4});
+      await cr.claimAllPendingReward(20, {from: claimAssessor5});
 
       claimAssessor1Object.lockPeriodAfterRewardRecieved = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -1954,9 +1968,9 @@ contract('Claim: Assessment 2', function([
       member3Object.rewardRecieved =
         parseFloat(await cr.getRewardToBeDistributedByUser(member3)) / toWei(1);
 
-      await cr.claimAllPendingReward(20, { from: member1 });
-      await cr.claimAllPendingReward(20, { from: member2 });
-      await cr.claimAllPendingReward(20, { from: member3 });
+      await cr.claimAllPendingReward(20, {from: member1});
+      await cr.claimAllPendingReward(20, {from: member2});
+      await cr.claimAllPendingReward(20, {from: member3});
 
       let balanceAfter = parseFloat(await web3.eth.getBalance(coverHolder1));
       let tokenBalanceAfter = parseFloat(await tk.balanceOf(coverHolder1));
@@ -2132,7 +2146,7 @@ contract('Claim: Assessment 2', function([
       }
 
       coverID = await qd.getAllCoversOfUser(coverHolder1);
-      await cl.submitClaim(coverID[0], { from: coverHolder1 });
+      await cl.submitClaim(coverID[0], {from: coverHolder1});
       claimID = (await cd.actualClaimLength()) - 1;
       APIID = await pd.allAPIcall((await pd.getApilCallLength()) - 1);
 
@@ -2151,11 +2165,11 @@ contract('Claim: Assessment 2', function([
       claimAssessor5Object.initialDate = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor5, CLA)
       );
-      await cl.submitCAVote(claimID, -1, { from: claimAssessor1 });
-      await cl.submitCAVote(claimID, -1, { from: claimAssessor2 });
-      await cl.submitCAVote(claimID, -1, { from: claimAssessor3 });
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor4 });
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor5 });
+      await cl.submitCAVote(claimID, -1, {from: claimAssessor1});
+      await cl.submitCAVote(claimID, -1, {from: claimAssessor2});
+      await cl.submitCAVote(claimID, -1, {from: claimAssessor3});
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor4});
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor5});
 
       claimAssessor1Object.newLockDate = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -2211,9 +2225,9 @@ contract('Claim: Assessment 2', function([
         toWei(1);
 
       // now member voting started
-      await cl.submitMemberVote(claimID, 1, { from: member1 });
-      await cl.submitMemberVote(claimID, 1, { from: member2 });
-      await cl.submitMemberVote(claimID, 1, { from: member3 });
+      await cl.submitMemberVote(claimID, 1, {from: member1});
+      await cl.submitMemberVote(claimID, 1, {from: member2});
+      await cl.submitMemberVote(claimID, 1, {from: member3});
 
       // to close the member voting
       maxVotingTime = await cd.maxVotingTime();
@@ -2229,11 +2243,11 @@ contract('Claim: Assessment 2', function([
       await p1.__callback(APIID, '');
 
       let proposalIds = [];
-      await cr.claimAllPendingReward(20, { from: claimAssessor1 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor2 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor3 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor4 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor5 });
+      await cr.claimAllPendingReward(20, {from: claimAssessor1});
+      await cr.claimAllPendingReward(20, {from: claimAssessor2});
+      await cr.claimAllPendingReward(20, {from: claimAssessor3});
+      await cr.claimAllPendingReward(20, {from: claimAssessor4});
+      await cr.claimAllPendingReward(20, {from: claimAssessor5});
 
       claimAssessor1Object.lockPeriodAfterRewardRecieved = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -2258,9 +2272,9 @@ contract('Claim: Assessment 2', function([
       member3Object.rewardRecieved =
         parseFloat(await cr.getRewardToBeDistributedByUser(member3)) / toWei(1);
 
-      await cr.claimAllPendingReward(20, { from: member1 });
-      await cr.claimAllPendingReward(20, { from: member2 });
-      await cr.claimAllPendingReward(20, { from: member3 });
+      await cr.claimAllPendingReward(20, {from: member1});
+      await cr.claimAllPendingReward(20, {from: member2});
+      await cr.claimAllPendingReward(20, {from: member3});
 
       let balanceAfter = parseFloat(await web3.eth.getBalance(coverHolder1));
       let tokenBalanceAfter = parseFloat(await tk.balanceOf(coverHolder1));
@@ -2444,7 +2458,7 @@ contract('Claim: Assessment 2', function([
       // await tc.lock(CLA, 50000 * toWei(1), validity, {from: claimAssessor5});
 
       coverID = await qd.getAllCoversOfUser(coverHolder2);
-      await cl.submitClaim(coverID[0], { from: coverHolder2 });
+      await cl.submitClaim(coverID[0], {from: coverHolder2});
       claimID = (await cd.actualClaimLength()) - 1;
       APIID = await pd.allAPIcall((await pd.getApilCallLength()) - 1);
 
@@ -2461,10 +2475,10 @@ contract('Claim: Assessment 2', function([
         await tc.getLockedTokensValidity(claimAssessor4, CLA)
       );
 
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor1 });
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor2 });
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor3 });
-      await cl.submitCAVote(claimID, -1, { from: claimAssessor4 });
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor1});
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor2});
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor3});
+      await cl.submitCAVote(claimID, -1, {from: claimAssessor4});
 
       claimAssessor1Object.newLockDate = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -2514,11 +2528,11 @@ contract('Claim: Assessment 2', function([
         toWei(1);
 
       // now member voting started
-      await cl.submitMemberVote(claimID, -1, { from: member1 });
-      await cl.submitMemberVote(claimID, -1, { from: member2 });
-      await cl.submitMemberVote(claimID, -1, { from: member3 });
-      await cl.submitMemberVote(claimID, -1, { from: member4 });
-      await cl.submitMemberVote(claimID, 1, { from: member5 });
+      await cl.submitMemberVote(claimID, -1, {from: member1});
+      await cl.submitMemberVote(claimID, -1, {from: member2});
+      await cl.submitMemberVote(claimID, -1, {from: member3});
+      await cl.submitMemberVote(claimID, -1, {from: member4});
+      await cl.submitMemberVote(claimID, 1, {from: member5});
 
       // to close the member voting
       maxVotingTime = await cd.maxVotingTime();
@@ -2534,10 +2548,10 @@ contract('Claim: Assessment 2', function([
       await p1.__callback(APIID, '');
 
       let proposalIds = [];
-      await cr.claimAllPendingReward(20, { from: claimAssessor1 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor2 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor3 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor4 });
+      await cr.claimAllPendingReward(20, {from: claimAssessor1});
+      await cr.claimAllPendingReward(20, {from: claimAssessor2});
+      await cr.claimAllPendingReward(20, {from: claimAssessor3});
+      await cr.claimAllPendingReward(20, {from: claimAssessor4});
 
       claimAssessor1Object.lockPeriodAfterRewardRecieved = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -2563,11 +2577,11 @@ contract('Claim: Assessment 2', function([
       member5Object.rewardRecieved =
         parseFloat(await cr.getRewardToBeDistributedByUser(member5)) / toWei(1);
 
-      await cr.claimAllPendingReward(20, { from: member1 });
-      await cr.claimAllPendingReward(20, { from: member2 });
-      await cr.claimAllPendingReward(20, { from: member3 });
-      await cr.claimAllPendingReward(20, { from: member4 });
-      await cr.claimAllPendingReward(20, { from: member5 });
+      await cr.claimAllPendingReward(20, {from: member1});
+      await cr.claimAllPendingReward(20, {from: member2});
+      await cr.claimAllPendingReward(20, {from: member3});
+      await cr.claimAllPendingReward(20, {from: member4});
+      await cr.claimAllPendingReward(20, {from: member5});
 
       let balanceAfter = parseFloat(await dai.balanceOf(coverHolder2));
       let tokenBalanceAfter = parseFloat(await tk.balanceOf(coverHolder2));
@@ -2735,7 +2749,7 @@ contract('Claim: Assessment 2', function([
       }
 
       coverID = await qd.getAllCoversOfUser(coverHolder2);
-      await cl.submitClaim(coverID[0], { from: coverHolder2 });
+      await cl.submitClaim(coverID[0], {from: coverHolder2});
       claimID = (await cd.actualClaimLength()) - 1;
       APIID = await pd.allAPIcall((await pd.getApilCallLength()) - 1);
 
@@ -2752,10 +2766,10 @@ contract('Claim: Assessment 2', function([
         await tc.getLockedTokensValidity(claimAssessor4, CLA)
       );
 
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor1 });
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor2 });
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor3 });
-      await cl.submitCAVote(claimID, -1, { from: claimAssessor4 });
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor1});
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor2});
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor3});
+      await cl.submitCAVote(claimID, -1, {from: claimAssessor4});
 
       claimAssessor1Object.newLockDate = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -2805,11 +2819,11 @@ contract('Claim: Assessment 2', function([
         toWei(1);
 
       // now member voting started
-      await cl.submitMemberVote(claimID, 1, { from: member1 });
-      await cl.submitMemberVote(claimID, 1, { from: member2 });
-      await cl.submitMemberVote(claimID, 1, { from: member3 });
-      await cl.submitMemberVote(claimID, 1, { from: member4 });
-      await cl.submitMemberVote(claimID, -1, { from: member5 });
+      await cl.submitMemberVote(claimID, 1, {from: member1});
+      await cl.submitMemberVote(claimID, 1, {from: member2});
+      await cl.submitMemberVote(claimID, 1, {from: member3});
+      await cl.submitMemberVote(claimID, 1, {from: member4});
+      await cl.submitMemberVote(claimID, -1, {from: member5});
 
       // to close the member voting
       maxVotingTime = await cd.maxVotingTime();
@@ -2825,10 +2839,10 @@ contract('Claim: Assessment 2', function([
       await p1.__callback(APIID, '');
 
       let proposalIds = [];
-      await cr.claimAllPendingReward(20, { from: claimAssessor1 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor2 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor3 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor4 });
+      await cr.claimAllPendingReward(20, {from: claimAssessor1});
+      await cr.claimAllPendingReward(20, {from: claimAssessor2});
+      await cr.claimAllPendingReward(20, {from: claimAssessor3});
+      await cr.claimAllPendingReward(20, {from: claimAssessor4});
 
       claimAssessor1Object.lockPeriodAfterRewardRecieved = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -2854,11 +2868,11 @@ contract('Claim: Assessment 2', function([
       member5Object.rewardRecieved =
         parseFloat(await cr.getRewardToBeDistributedByUser(member5)) / toWei(1);
 
-      await cr.claimAllPendingReward(20, { from: member1 });
-      await cr.claimAllPendingReward(20, { from: member2 });
-      await cr.claimAllPendingReward(20, { from: member3 });
-      await cr.claimAllPendingReward(20, { from: member4 });
-      await cr.claimAllPendingReward(20, { from: member5 });
+      await cr.claimAllPendingReward(20, {from: member1});
+      await cr.claimAllPendingReward(20, {from: member2});
+      await cr.claimAllPendingReward(20, {from: member3});
+      await cr.claimAllPendingReward(20, {from: member4});
+      await cr.claimAllPendingReward(20, {from: member5});
 
       let balanceAfter = parseFloat(await dai.balanceOf(coverHolder2));
       let tokenBalanceAfter = parseFloat(await tk.balanceOf(coverHolder2));
@@ -3011,7 +3025,7 @@ contract('Claim: Assessment 2', function([
         );
       }
       coverID = await qd.getAllCoversOfUser(coverHolder4);
-      await cl.submitClaim(coverID[0], { from: coverHolder4 });
+      await cl.submitClaim(coverID[0], {from: coverHolder4});
       claimID = (await cd.actualClaimLength()) - 1;
       APIID = await pd.allAPIcall((await pd.getApilCallLength()) - 1);
 
@@ -3031,11 +3045,11 @@ contract('Claim: Assessment 2', function([
         await tc.getLockedTokensValidity(claimAssessor5, CLA)
       );
 
-      await cl.submitCAVote(claimID, -1, { from: claimAssessor1 });
-      await cl.submitCAVote(claimID, -1, { from: claimAssessor2 });
-      await cl.submitCAVote(claimID, -1, { from: claimAssessor3 });
-      await cl.submitCAVote(claimID, -1, { from: claimAssessor4 });
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor5 });
+      await cl.submitCAVote(claimID, -1, {from: claimAssessor1});
+      await cl.submitCAVote(claimID, -1, {from: claimAssessor2});
+      await cl.submitCAVote(claimID, -1, {from: claimAssessor3});
+      await cl.submitCAVote(claimID, -1, {from: claimAssessor4});
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor5});
 
       claimAssessor1Object.newLockDate = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -3109,11 +3123,11 @@ contract('Claim: Assessment 2', function([
         toWei(1);
 
       let proposalIds = [];
-      await cr.claimAllPendingReward(20, { from: claimAssessor1 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor2 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor3 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor4 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor5 });
+      await cr.claimAllPendingReward(20, {from: claimAssessor1});
+      await cr.claimAllPendingReward(20, {from: claimAssessor2});
+      await cr.claimAllPendingReward(20, {from: claimAssessor3});
+      await cr.claimAllPendingReward(20, {from: claimAssessor4});
+      await cr.claimAllPendingReward(20, {from: claimAssessor5});
 
       claimAssessor1Object.lockPeriodAfterRewardRecieved = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -3269,7 +3283,7 @@ contract('Claim: Assessment 2', function([
       }
 
       coverID = await qd.getAllCoversOfUser(coverHolder4);
-      await cl.submitClaim(coverID[0], { from: coverHolder4 });
+      await cl.submitClaim(coverID[0], {from: coverHolder4});
       claimID = (await cd.actualClaimLength()) - 1;
       APIID = await pd.allAPIcall((await pd.getApilCallLength()) - 1);
 
@@ -3289,11 +3303,11 @@ contract('Claim: Assessment 2', function([
         await tc.getLockedTokensValidity(claimAssessor5, CLA)
       );
 
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor1 });
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor2 });
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor3 });
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor4 });
-      await cl.submitCAVote(claimID, -1, { from: claimAssessor5 });
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor1});
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor2});
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor3});
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor4});
+      await cl.submitCAVote(claimID, -1, {from: claimAssessor5});
 
       claimAssessor1Object.newLockDate = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -3367,11 +3381,11 @@ contract('Claim: Assessment 2', function([
         toWei(1);
 
       let proposalIds = [];
-      await cr.claimAllPendingReward(20, { from: claimAssessor1 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor2 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor3 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor4 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor5 });
+      await cr.claimAllPendingReward(20, {from: claimAssessor1});
+      await cr.claimAllPendingReward(20, {from: claimAssessor2});
+      await cr.claimAllPendingReward(20, {from: claimAssessor3});
+      await cr.claimAllPendingReward(20, {from: claimAssessor4});
+      await cr.claimAllPendingReward(20, {from: claimAssessor5});
 
       claimAssessor1Object.lockPeriodAfterRewardRecieved = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -3531,7 +3545,7 @@ contract('Claim: Assessment 2', function([
       }
 
       coverID = await qd.getAllCoversOfUser(coverHolder6);
-      await cl.submitClaim(coverID[0], { from: coverHolder6 });
+      await cl.submitClaim(coverID[0], {from: coverHolder6});
       claimID = (await cd.actualClaimLength()) - 1;
       APIID = await pd.allAPIcall((await pd.getApilCallLength()) - 1);
 
@@ -3545,9 +3559,9 @@ contract('Claim: Assessment 2', function([
         await tc.getLockedTokensValidity(claimAssessor3, CLA)
       );
 
-      await cl.submitCAVote(claimID, -1, { from: claimAssessor1 });
-      await cl.submitCAVote(claimID, -1, { from: claimAssessor2 });
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor3 });
+      await cl.submitCAVote(claimID, -1, {from: claimAssessor1});
+      await cl.submitCAVote(claimID, -1, {from: claimAssessor2});
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor3});
 
       claimAssessor1Object.newLockDate = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -3591,8 +3605,8 @@ contract('Claim: Assessment 2', function([
         toWei(1);
 
       // now member voting started
-      await cl.submitMemberVote(claimID, 1, { from: member1 });
-      await cl.submitMemberVote(claimID, 1, { from: member2 });
+      await cl.submitMemberVote(claimID, 1, {from: member1});
+      await cl.submitMemberVote(claimID, 1, {from: member2});
 
       // to close the member voting
       maxVotingTime = await cd.maxVotingTime();
@@ -3608,9 +3622,9 @@ contract('Claim: Assessment 2', function([
       await p1.__callback(APIID, '');
 
       let proposalIds = [];
-      await cr.claimAllPendingReward(20, { from: claimAssessor1 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor2 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor3 });
+      await cr.claimAllPendingReward(20, {from: claimAssessor1});
+      await cr.claimAllPendingReward(20, {from: claimAssessor2});
+      await cr.claimAllPendingReward(20, {from: claimAssessor3});
 
       claimAssessor1Object.lockPeriodAfterRewardRecieved = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -3627,8 +3641,8 @@ contract('Claim: Assessment 2', function([
       member2Object.rewardRecieved =
         parseFloat(await cr.getRewardToBeDistributedByUser(member2)) / toWei(1);
 
-      await cr.claimAllPendingReward(20, { from: member1 });
-      await cr.claimAllPendingReward(20, { from: member2 });
+      await cr.claimAllPendingReward(20, {from: member1});
+      await cr.claimAllPendingReward(20, {from: member2});
 
       let balanceAfter = parseFloat(await dai.balanceOf(coverHolder6));
       let tokenBalanceAfter = parseFloat(await tk.balanceOf(coverHolder6));
@@ -3773,7 +3787,7 @@ contract('Claim: Assessment 2', function([
       }
 
       coverID = await qd.getAllCoversOfUser(coverHolder6);
-      await cl.submitClaim(coverID[0], { from: coverHolder6 });
+      await cl.submitClaim(coverID[0], {from: coverHolder6});
       claimID = (await cd.actualClaimLength()) - 1;
       APIID = await pd.allAPIcall((await pd.getApilCallLength()) - 1);
 
@@ -3787,9 +3801,9 @@ contract('Claim: Assessment 2', function([
         await tc.getLockedTokensValidity(claimAssessor3, CLA)
       );
 
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor1 });
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor2 });
-      await cl.submitCAVote(claimID, -1, { from: claimAssessor3 });
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor1});
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor2});
+      await cl.submitCAVote(claimID, -1, {from: claimAssessor3});
 
       claimAssessor1Object.newLockDate = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -3833,8 +3847,8 @@ contract('Claim: Assessment 2', function([
         toWei(1);
 
       // now member voting started
-      await cl.submitMemberVote(claimID, 1, { from: member1 });
-      await cl.submitMemberVote(claimID, 1, { from: member2 });
+      await cl.submitMemberVote(claimID, 1, {from: member1});
+      await cl.submitMemberVote(claimID, 1, {from: member2});
 
       // to close the member voting
       maxVotingTime = await cd.maxVotingTime();
@@ -3850,9 +3864,9 @@ contract('Claim: Assessment 2', function([
       await p1.__callback(APIID, '');
 
       let proposalIds = [];
-      await cr.claimAllPendingReward(20, { from: claimAssessor1 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor2 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor3 });
+      await cr.claimAllPendingReward(20, {from: claimAssessor1});
+      await cr.claimAllPendingReward(20, {from: claimAssessor2});
+      await cr.claimAllPendingReward(20, {from: claimAssessor3});
 
       claimAssessor1Object.lockPeriodAfterRewardRecieved = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -3869,8 +3883,8 @@ contract('Claim: Assessment 2', function([
       member2Object.rewardRecieved =
         parseFloat(await cr.getRewardToBeDistributedByUser(member2)) / toWei(1);
 
-      await cr.claimAllPendingReward(20, { from: member1 });
-      await cr.claimAllPendingReward(20, { from: member2 });
+      await cr.claimAllPendingReward(20, {from: member1});
+      await cr.claimAllPendingReward(20, {from: member2});
 
       let balanceAfter = parseFloat(await dai.balanceOf(coverHolder6));
       let tokenBalanceAfter = parseFloat(await tk.balanceOf(coverHolder6));
@@ -4011,7 +4025,7 @@ contract('Claim: Assessment 2', function([
       }
 
       coverID = await qd.getAllCoversOfUser(coverHolder7);
-      await cl.submitClaim(coverID[0], { from: coverHolder7 });
+      await cl.submitClaim(coverID[0], {from: coverHolder7});
       claimID = (await cd.actualClaimLength()) - 1;
       APIID = await pd.allAPIcall((await pd.getApilCallLength()) - 1);
 
@@ -4037,8 +4051,8 @@ contract('Claim: Assessment 2', function([
       await p1.__callback(APIID, '');
 
       // now member voting started
-      await cl.submitMemberVote(claimID, 1, { from: member1 });
-      await cl.submitMemberVote(claimID, 1, { from: member2 });
+      await cl.submitMemberVote(claimID, 1, {from: member1});
+      await cl.submitMemberVote(claimID, 1, {from: member2});
 
       // to close the member voting
       maxVotingTime = await cd.maxVotingTime();
@@ -4060,8 +4074,8 @@ contract('Claim: Assessment 2', function([
       member2Object.rewardRecieved =
         parseFloat(await cr.getRewardToBeDistributedByUser(member2)) / toWei(1);
 
-      await cr.claimAllPendingReward(20, { from: member1 });
-      await cr.claimAllPendingReward(20, { from: member2 });
+      await cr.claimAllPendingReward(20, {from: member1});
+      await cr.claimAllPendingReward(20, {from: member2});
 
       let balanceAfter = parseFloat(await dai.balanceOf(coverHolder7));
       let tokenBalanceAfter = parseFloat(await tk.balanceOf(coverHolder7));
@@ -4176,7 +4190,7 @@ contract('Claim: Assessment 2', function([
       }
 
       coverID = await qd.getAllCoversOfUser(coverHolder7);
-      await cl.submitClaim(coverID[0], { from: coverHolder7 });
+      await cl.submitClaim(coverID[0], {from: coverHolder7});
       claimID = (await cd.actualClaimLength()) - 1;
       APIID = await pd.allAPIcall((await pd.getApilCallLength()) - 1);
 
@@ -4195,11 +4209,11 @@ contract('Claim: Assessment 2', function([
       claimAssessor5Object.initialDate = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor5, CLA)
       );
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor1 });
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor2 });
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor3 });
-      await cl.submitCAVote(claimID, -1, { from: claimAssessor4 });
-      await cl.submitCAVote(claimID, -1, { from: claimAssessor5 });
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor1});
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor2});
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor3});
+      await cl.submitCAVote(claimID, -1, {from: claimAssessor4});
+      await cl.submitCAVote(claimID, -1, {from: claimAssessor5});
 
       claimAssessor1Object.newLockDate = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -4255,9 +4269,9 @@ contract('Claim: Assessment 2', function([
         toWei(1);
 
       // now member voting started
-      await cl.submitMemberVote(claimID, 1, { from: member1 });
-      await cl.submitMemberVote(claimID, 1, { from: member2 });
-      await cl.submitMemberVote(claimID, 1, { from: member3 });
+      await cl.submitMemberVote(claimID, 1, {from: member1});
+      await cl.submitMemberVote(claimID, 1, {from: member2});
+      await cl.submitMemberVote(claimID, 1, {from: member3});
 
       // to close the member voting
       maxVotingTime = await cd.maxVotingTime();
@@ -4273,11 +4287,11 @@ contract('Claim: Assessment 2', function([
       await p1.__callback(APIID, '');
 
       let proposalIds = [];
-      await cr.claimAllPendingReward(20, { from: claimAssessor1 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor2 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor3 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor4 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor5 });
+      await cr.claimAllPendingReward(20, {from: claimAssessor1});
+      await cr.claimAllPendingReward(20, {from: claimAssessor2});
+      await cr.claimAllPendingReward(20, {from: claimAssessor3});
+      await cr.claimAllPendingReward(20, {from: claimAssessor4});
+      await cr.claimAllPendingReward(20, {from: claimAssessor5});
 
       claimAssessor1Object.lockPeriodAfterRewardRecieved = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -4302,9 +4316,9 @@ contract('Claim: Assessment 2', function([
       member3Object.rewardRecieved =
         parseFloat(await cr.getRewardToBeDistributedByUser(member3)) / toWei(1);
 
-      await cr.claimAllPendingReward(20, { from: member1 });
-      await cr.claimAllPendingReward(20, { from: member2 });
-      await cr.claimAllPendingReward(20, { from: member3 });
+      await cr.claimAllPendingReward(20, {from: member1});
+      await cr.claimAllPendingReward(20, {from: member2});
+      await cr.claimAllPendingReward(20, {from: member3});
 
       let balanceAfter = parseFloat(await web3.eth.getBalance(coverHolder7));
       let tokenBalanceAfter = parseFloat(await tk.balanceOf(coverHolder7));
@@ -4472,7 +4486,7 @@ contract('Claim: Assessment 2', function([
       }
 
       coverID = await qd.getAllCoversOfUser(coverHolder8);
-      await cl.submitClaim(coverID[0], { from: coverHolder8 });
+      await cl.submitClaim(coverID[0], {from: coverHolder8});
       claimID = (await cd.actualClaimLength()) - 1;
       APIID = await pd.allAPIcall((await pd.getApilCallLength()) - 1);
 
@@ -4491,11 +4505,11 @@ contract('Claim: Assessment 2', function([
       claimAssessor5Object.initialDate = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor5, CLA)
       );
-      await cl.submitCAVote(claimID, -1, { from: claimAssessor1 });
-      await cl.submitCAVote(claimID, -1, { from: claimAssessor2 });
-      await cl.submitCAVote(claimID, -1, { from: claimAssessor3 });
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor4 });
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor5 });
+      await cl.submitCAVote(claimID, -1, {from: claimAssessor1});
+      await cl.submitCAVote(claimID, -1, {from: claimAssessor2});
+      await cl.submitCAVote(claimID, -1, {from: claimAssessor3});
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor4});
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor5});
 
       claimAssessor1Object.newLockDate = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -4551,9 +4565,9 @@ contract('Claim: Assessment 2', function([
         toWei(1);
 
       // now member voting started
-      await cl.submitMemberVote(claimID, 1, { from: member1 });
-      await cl.submitMemberVote(claimID, 1, { from: member2 });
-      await cl.submitMemberVote(claimID, 1, { from: member3 });
+      await cl.submitMemberVote(claimID, 1, {from: member1});
+      await cl.submitMemberVote(claimID, 1, {from: member2});
+      await cl.submitMemberVote(claimID, 1, {from: member3});
 
       // to close the member voting
       maxVotingTime = await cd.maxVotingTime();
@@ -4569,11 +4583,11 @@ contract('Claim: Assessment 2', function([
       await p1.__callback(APIID, '');
 
       let proposalIds = [];
-      await cr.claimAllPendingReward(20, { from: claimAssessor1 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor2 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor3 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor4 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor5 });
+      await cr.claimAllPendingReward(20, {from: claimAssessor1});
+      await cr.claimAllPendingReward(20, {from: claimAssessor2});
+      await cr.claimAllPendingReward(20, {from: claimAssessor3});
+      await cr.claimAllPendingReward(20, {from: claimAssessor4});
+      await cr.claimAllPendingReward(20, {from: claimAssessor5});
 
       claimAssessor1Object.lockPeriodAfterRewardRecieved = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -4598,9 +4612,9 @@ contract('Claim: Assessment 2', function([
       member3Object.rewardRecieved =
         parseFloat(await cr.getRewardToBeDistributedByUser(member3)) / toWei(1);
 
-      await cr.claimAllPendingReward(20, { from: member1 });
-      await cr.claimAllPendingReward(20, { from: member2 });
-      await cr.claimAllPendingReward(20, { from: member3 });
+      await cr.claimAllPendingReward(20, {from: member1});
+      await cr.claimAllPendingReward(20, {from: member2});
+      await cr.claimAllPendingReward(20, {from: member3});
 
       let balanceAfter = parseFloat(await dai.balanceOf(coverHolder8));
       let tokenBalanceAfter = parseFloat(await tk.balanceOf(coverHolder8));
@@ -4768,7 +4782,7 @@ contract('Claim: Assessment 2', function([
       }
 
       coverID = await qd.getAllCoversOfUser(coverHolder9);
-      await cl.submitClaim(coverID[0], { from: coverHolder9 });
+      await cl.submitClaim(coverID[0], {from: coverHolder9});
       claimID = (await cd.actualClaimLength()) - 1;
       APIID = await pd.allAPIcall((await pd.getApilCallLength()) - 1);
 
@@ -4778,8 +4792,8 @@ contract('Claim: Assessment 2', function([
       claimAssessor2Object.initialDate = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor2, CLA)
       );
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor1 });
-      await cl.submitCAVote(claimID, -1, { from: claimAssessor2 });
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor1});
+      await cl.submitCAVote(claimID, -1, {from: claimAssessor2});
 
       claimAssessor1Object.newLockDate = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -4817,12 +4831,12 @@ contract('Claim: Assessment 2', function([
         toWei(1);
 
       // now member voting started
-      await cl.submitMemberVote(claimID, -1, { from: member1 });
-      await cl.submitMemberVote(claimID, -1, { from: member2 });
-      await cl.submitMemberVote(claimID, -1, { from: member3 });
-      await cl.submitMemberVote(claimID, -1, { from: member4 });
-      await cl.submitMemberVote(claimID, 1, { from: member5 });
-      await cl.submitMemberVote(claimID, -1, { from: member6 });
+      await cl.submitMemberVote(claimID, -1, {from: member1});
+      await cl.submitMemberVote(claimID, -1, {from: member2});
+      await cl.submitMemberVote(claimID, -1, {from: member3});
+      await cl.submitMemberVote(claimID, -1, {from: member4});
+      await cl.submitMemberVote(claimID, 1, {from: member5});
+      await cl.submitMemberVote(claimID, -1, {from: member6});
 
       // to close the member voting
       maxVotingTime = await cd.maxVotingTime();
@@ -4838,8 +4852,8 @@ contract('Claim: Assessment 2', function([
       await p1.__callback(APIID, '');
 
       let proposalIds = [];
-      await cr.claimAllPendingReward(20, { from: claimAssessor1 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor2 });
+      await cr.claimAllPendingReward(20, {from: claimAssessor1});
+      await cr.claimAllPendingReward(20, {from: claimAssessor2});
 
       claimAssessor1Object.lockPeriodAfterRewardRecieved = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -4861,12 +4875,12 @@ contract('Claim: Assessment 2', function([
       member6Object.rewardRecieved =
         parseFloat(await cr.getRewardToBeDistributedByUser(member6)) / toWei(1);
 
-      await cr.claimAllPendingReward(20, { from: member1 });
-      await cr.claimAllPendingReward(20, { from: member2 });
-      await cr.claimAllPendingReward(20, { from: member3 });
-      await cr.claimAllPendingReward(20, { from: member4 });
-      await cr.claimAllPendingReward(20, { from: member5 });
-      await cr.claimAllPendingReward(20, { from: member6 });
+      await cr.claimAllPendingReward(20, {from: member1});
+      await cr.claimAllPendingReward(20, {from: member2});
+      await cr.claimAllPendingReward(20, {from: member3});
+      await cr.claimAllPendingReward(20, {from: member4});
+      await cr.claimAllPendingReward(20, {from: member5});
+      await cr.claimAllPendingReward(20, {from: member6});
 
       let balanceAfter = parseFloat(await web3.eth.getBalance(coverHolder9));
       let tokenBalanceAfter = parseFloat(await tk.balanceOf(coverHolder9));
@@ -5007,7 +5021,7 @@ contract('Claim: Assessment 2', function([
       }
 
       coverID = await qd.getAllCoversOfUser(coverHolder9);
-      await cl.submitClaim(coverID[0], { from: coverHolder9 });
+      await cl.submitClaim(coverID[0], {from: coverHolder9});
       APIID = await pd.allAPIcall((await pd.getApilCallLength()) - 1);
 
       claimID = (await cd.actualClaimLength()) - 1;
@@ -5018,8 +5032,8 @@ contract('Claim: Assessment 2', function([
         await tc.getLockedTokensValidity(claimAssessor2, CLA)
       );
 
-      await cl.submitCAVote(claimID, 1, { from: claimAssessor1 });
-      await cl.submitCAVote(claimID, -1, { from: claimAssessor2 });
+      await cl.submitCAVote(claimID, 1, {from: claimAssessor1});
+      await cl.submitCAVote(claimID, -1, {from: claimAssessor2});
 
       claimAssessor1Object.newLockDate = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -5057,12 +5071,12 @@ contract('Claim: Assessment 2', function([
         toWei(1);
 
       // now member voting started
-      await cl.submitMemberVote(claimID, 1, { from: member1 });
-      await cl.submitMemberVote(claimID, 1, { from: member2 });
-      await cl.submitMemberVote(claimID, 1, { from: member3 });
-      await cl.submitMemberVote(claimID, 1, { from: member4 });
-      await cl.submitMemberVote(claimID, -1, { from: member5 });
-      await cl.submitMemberVote(claimID, 1, { from: member6 });
+      await cl.submitMemberVote(claimID, 1, {from: member1});
+      await cl.submitMemberVote(claimID, 1, {from: member2});
+      await cl.submitMemberVote(claimID, 1, {from: member3});
+      await cl.submitMemberVote(claimID, 1, {from: member4});
+      await cl.submitMemberVote(claimID, -1, {from: member5});
+      await cl.submitMemberVote(claimID, 1, {from: member6});
 
       // to close the member voting
       maxVotingTime = await cd.maxVotingTime();
@@ -5078,8 +5092,8 @@ contract('Claim: Assessment 2', function([
       await p1.__callback(APIID, '');
 
       let proposalIds = [];
-      await cr.claimAllPendingReward(20, { from: claimAssessor1 });
-      await cr.claimAllPendingReward(20, { from: claimAssessor2 });
+      await cr.claimAllPendingReward(20, {from: claimAssessor1});
+      await cr.claimAllPendingReward(20, {from: claimAssessor2});
 
       claimAssessor1Object.lockPeriodAfterRewardRecieved = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -5106,15 +5120,15 @@ contract('Claim: Assessment 2', function([
       );
 
       // cannot withdraw/switch membership as it has not claimed Pending reward
-      await assertRevert(mr.withdrawMembership({ from: member1 }));
-      await assertRevert(mr.switchMembership(tc.address, { from: member1 }));
+      await assertRevert(mr.withdrawMembership({from: member1}));
+      await assertRevert(mr.switchMembership(tc.address, {from: member1}));
 
-      await cr.claimAllPendingReward(20, { from: member1 });
-      await cr.claimAllPendingReward(20, { from: member2 });
-      await cr.claimAllPendingReward(20, { from: member3 });
-      await cr.claimAllPendingReward(20, { from: member4 });
-      await cr.claimAllPendingReward(20, { from: member5 });
-      await cr.claimAllPendingReward(20, { from: member6 });
+      await cr.claimAllPendingReward(20, {from: member1});
+      await cr.claimAllPendingReward(20, {from: member2});
+      await cr.claimAllPendingReward(20, {from: member3});
+      await cr.claimAllPendingReward(20, {from: member4});
+      await cr.claimAllPendingReward(20, {from: member5});
+      await cr.claimAllPendingReward(20, {from: member6});
 
       let balanceAfter = parseFloat(await web3.eth.getBalance(coverHolder9));
       let tokenBalanceAfter = parseFloat(await tk.balanceOf(coverHolder9));
@@ -5191,7 +5205,7 @@ contract('Claim: Assessment 2', function([
   });
   describe('Burning 0 tokens of a staker', function() {
     it('18.24 successful', async function() {
-      tf.addStake(SC1, toWei(200), { from: underWriter6 });
+      tf.addStake(SC1, toWei(200), {from: underWriter6});
       coverID = await qd.getAllCoversOfUser(coverHolder5);
 
       await tf.burnStakerLockedToken(SC1, 0);

--- a/test/18_ClaimAssessment.test.js
+++ b/test/18_ClaimAssessment.test.js
@@ -1971,6 +1971,9 @@ contract('Claim: Assessment 2', function([
       await cr.claimAllPendingReward(20, {from: member1});
       await cr.claimAllPendingReward(20, {from: member2});
       await cr.claimAllPendingReward(20, {from: member3});
+      await tf.unlockStakerUnlockableTokens(member1);
+      await tf.unlockStakerUnlockableTokens(member2);
+      await tf.unlockStakerUnlockableTokens(member3);
 
       let balanceAfter = parseFloat(await web3.eth.getBalance(coverHolder1));
       let tokenBalanceAfter = parseFloat(await tk.balanceOf(coverHolder1));
@@ -2249,6 +2252,12 @@ contract('Claim: Assessment 2', function([
       await cr.claimAllPendingReward(20, {from: claimAssessor4});
       await cr.claimAllPendingReward(20, {from: claimAssessor5});
 
+      await tf.unlockStakerUnlockableTokens(claimAssessor1);
+      await tf.unlockStakerUnlockableTokens(claimAssessor2);
+      await tf.unlockStakerUnlockableTokens(claimAssessor3);
+      await tf.unlockStakerUnlockableTokens(claimAssessor4);
+      await tf.unlockStakerUnlockableTokens(claimAssessor5);
+
       claimAssessor1Object.lockPeriodAfterRewardRecieved = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
       );
@@ -2275,6 +2284,9 @@ contract('Claim: Assessment 2', function([
       await cr.claimAllPendingReward(20, {from: member1});
       await cr.claimAllPendingReward(20, {from: member2});
       await cr.claimAllPendingReward(20, {from: member3});
+      await tf.unlockStakerUnlockableTokens(member1);
+      await tf.unlockStakerUnlockableTokens(member2);
+      await tf.unlockStakerUnlockableTokens(member3);
 
       let balanceAfter = parseFloat(await web3.eth.getBalance(coverHolder1));
       let tokenBalanceAfter = parseFloat(await tk.balanceOf(coverHolder1));
@@ -2552,6 +2564,10 @@ contract('Claim: Assessment 2', function([
       await cr.claimAllPendingReward(20, {from: claimAssessor2});
       await cr.claimAllPendingReward(20, {from: claimAssessor3});
       await cr.claimAllPendingReward(20, {from: claimAssessor4});
+      await tf.unlockStakerUnlockableTokens(claimAssessor1);
+      await tf.unlockStakerUnlockableTokens(claimAssessor2);
+      await tf.unlockStakerUnlockableTokens(claimAssessor3);
+      await tf.unlockStakerUnlockableTokens(claimAssessor4);
 
       claimAssessor1Object.lockPeriodAfterRewardRecieved = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -2582,6 +2598,12 @@ contract('Claim: Assessment 2', function([
       await cr.claimAllPendingReward(20, {from: member3});
       await cr.claimAllPendingReward(20, {from: member4});
       await cr.claimAllPendingReward(20, {from: member5});
+
+      await tf.unlockStakerUnlockableTokens(member1);
+      await tf.unlockStakerUnlockableTokens(member2);
+      await tf.unlockStakerUnlockableTokens(member3);
+      await tf.unlockStakerUnlockableTokens(member4);
+      await tf.unlockStakerUnlockableTokens(member5);
 
       let balanceAfter = parseFloat(await dai.balanceOf(coverHolder2));
       let tokenBalanceAfter = parseFloat(await tk.balanceOf(coverHolder2));
@@ -2844,6 +2866,11 @@ contract('Claim: Assessment 2', function([
       await cr.claimAllPendingReward(20, {from: claimAssessor3});
       await cr.claimAllPendingReward(20, {from: claimAssessor4});
 
+      await tf.unlockStakerUnlockableTokens(claimAssessor1);
+      await tf.unlockStakerUnlockableTokens(claimAssessor2);
+      await tf.unlockStakerUnlockableTokens(claimAssessor3);
+      await tf.unlockStakerUnlockableTokens(claimAssessor4);
+
       claimAssessor1Object.lockPeriodAfterRewardRecieved = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
       );
@@ -2873,6 +2900,12 @@ contract('Claim: Assessment 2', function([
       await cr.claimAllPendingReward(20, {from: member3});
       await cr.claimAllPendingReward(20, {from: member4});
       await cr.claimAllPendingReward(20, {from: member5});
+
+      await tf.unlockStakerUnlockableTokens(member1);
+      await tf.unlockStakerUnlockableTokens(member2);
+      await tf.unlockStakerUnlockableTokens(member3);
+      await tf.unlockStakerUnlockableTokens(member4);
+      await tf.unlockStakerUnlockableTokens(member5);
 
       let balanceAfter = parseFloat(await dai.balanceOf(coverHolder2));
       let tokenBalanceAfter = parseFloat(await tk.balanceOf(coverHolder2));
@@ -3128,6 +3161,12 @@ contract('Claim: Assessment 2', function([
       await cr.claimAllPendingReward(20, {from: claimAssessor3});
       await cr.claimAllPendingReward(20, {from: claimAssessor4});
       await cr.claimAllPendingReward(20, {from: claimAssessor5});
+
+      await tf.unlockStakerUnlockableTokens(claimAssessor1);
+      await tf.unlockStakerUnlockableTokens(claimAssessor2);
+      await tf.unlockStakerUnlockableTokens(claimAssessor3);
+      await tf.unlockStakerUnlockableTokens(claimAssessor4);
+      await tf.unlockStakerUnlockableTokens(claimAssessor5);
 
       claimAssessor1Object.lockPeriodAfterRewardRecieved = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
@@ -3387,6 +3426,12 @@ contract('Claim: Assessment 2', function([
       await cr.claimAllPendingReward(20, {from: claimAssessor4});
       await cr.claimAllPendingReward(20, {from: claimAssessor5});
 
+      await tf.unlockStakerUnlockableTokens(claimAssessor1);
+      await tf.unlockStakerUnlockableTokens(claimAssessor2);
+      await tf.unlockStakerUnlockableTokens(claimAssessor3);
+      await tf.unlockStakerUnlockableTokens(claimAssessor4);
+      await tf.unlockStakerUnlockableTokens(claimAssessor5);
+
       claimAssessor1Object.lockPeriodAfterRewardRecieved = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
       );
@@ -3626,6 +3671,10 @@ contract('Claim: Assessment 2', function([
       await cr.claimAllPendingReward(20, {from: claimAssessor2});
       await cr.claimAllPendingReward(20, {from: claimAssessor3});
 
+      await tf.unlockStakerUnlockableTokens(claimAssessor1);
+      await tf.unlockStakerUnlockableTokens(claimAssessor2);
+      await tf.unlockStakerUnlockableTokens(claimAssessor3);
+
       claimAssessor1Object.lockPeriodAfterRewardRecieved = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
       );
@@ -3643,6 +3692,9 @@ contract('Claim: Assessment 2', function([
 
       await cr.claimAllPendingReward(20, {from: member1});
       await cr.claimAllPendingReward(20, {from: member2});
+
+      await tf.unlockStakerUnlockableTokens(member1);
+      await tf.unlockStakerUnlockableTokens(member2);
 
       let balanceAfter = parseFloat(await dai.balanceOf(coverHolder6));
       let tokenBalanceAfter = parseFloat(await tk.balanceOf(coverHolder6));
@@ -3868,6 +3920,10 @@ contract('Claim: Assessment 2', function([
       await cr.claimAllPendingReward(20, {from: claimAssessor2});
       await cr.claimAllPendingReward(20, {from: claimAssessor3});
 
+      await tf.unlockStakerUnlockableTokens(claimAssessor1);
+      await tf.unlockStakerUnlockableTokens(claimAssessor2);
+      await tf.unlockStakerUnlockableTokens(claimAssessor3);
+
       claimAssessor1Object.lockPeriodAfterRewardRecieved = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
       );
@@ -3885,6 +3941,9 @@ contract('Claim: Assessment 2', function([
 
       await cr.claimAllPendingReward(20, {from: member1});
       await cr.claimAllPendingReward(20, {from: member2});
+
+      await tf.unlockStakerUnlockableTokens(member1);
+      await tf.unlockStakerUnlockableTokens(member2);
 
       let balanceAfter = parseFloat(await dai.balanceOf(coverHolder6));
       let tokenBalanceAfter = parseFloat(await tk.balanceOf(coverHolder6));
@@ -4076,6 +4135,9 @@ contract('Claim: Assessment 2', function([
 
       await cr.claimAllPendingReward(20, {from: member1});
       await cr.claimAllPendingReward(20, {from: member2});
+
+      await tf.unlockStakerUnlockableTokens(member1);
+      await tf.unlockStakerUnlockableTokens(member2);
 
       let balanceAfter = parseFloat(await dai.balanceOf(coverHolder7));
       let tokenBalanceAfter = parseFloat(await tk.balanceOf(coverHolder7));
@@ -4293,6 +4355,12 @@ contract('Claim: Assessment 2', function([
       await cr.claimAllPendingReward(20, {from: claimAssessor4});
       await cr.claimAllPendingReward(20, {from: claimAssessor5});
 
+      await tf.unlockStakerUnlockableTokens(claimAssessor1);
+      await tf.unlockStakerUnlockableTokens(claimAssessor2);
+      await tf.unlockStakerUnlockableTokens(claimAssessor3);
+      await tf.unlockStakerUnlockableTokens(claimAssessor4);
+      await tf.unlockStakerUnlockableTokens(claimAssessor5);
+
       claimAssessor1Object.lockPeriodAfterRewardRecieved = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
       );
@@ -4319,6 +4387,10 @@ contract('Claim: Assessment 2', function([
       await cr.claimAllPendingReward(20, {from: member1});
       await cr.claimAllPendingReward(20, {from: member2});
       await cr.claimAllPendingReward(20, {from: member3});
+
+      await tf.unlockStakerUnlockableTokens(member1);
+      await tf.unlockStakerUnlockableTokens(member2);
+      await tf.unlockStakerUnlockableTokens(member3);
 
       let balanceAfter = parseFloat(await web3.eth.getBalance(coverHolder7));
       let tokenBalanceAfter = parseFloat(await tk.balanceOf(coverHolder7));
@@ -4589,6 +4661,12 @@ contract('Claim: Assessment 2', function([
       await cr.claimAllPendingReward(20, {from: claimAssessor4});
       await cr.claimAllPendingReward(20, {from: claimAssessor5});
 
+      await tf.unlockStakerUnlockableTokens(claimAssessor1);
+      await tf.unlockStakerUnlockableTokens(claimAssessor2);
+      await tf.unlockStakerUnlockableTokens(claimAssessor3);
+      await tf.unlockStakerUnlockableTokens(claimAssessor4);
+      await tf.unlockStakerUnlockableTokens(claimAssessor5);
+
       claimAssessor1Object.lockPeriodAfterRewardRecieved = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
       );
@@ -4615,6 +4693,10 @@ contract('Claim: Assessment 2', function([
       await cr.claimAllPendingReward(20, {from: member1});
       await cr.claimAllPendingReward(20, {from: member2});
       await cr.claimAllPendingReward(20, {from: member3});
+
+      await tf.unlockStakerUnlockableTokens(member1);
+      await tf.unlockStakerUnlockableTokens(member2);
+      await tf.unlockStakerUnlockableTokens(member3);
 
       let balanceAfter = parseFloat(await dai.balanceOf(coverHolder8));
       let tokenBalanceAfter = parseFloat(await tk.balanceOf(coverHolder8));
@@ -4855,6 +4937,9 @@ contract('Claim: Assessment 2', function([
       await cr.claimAllPendingReward(20, {from: claimAssessor1});
       await cr.claimAllPendingReward(20, {from: claimAssessor2});
 
+      await tf.unlockStakerUnlockableTokens(claimAssessor1);
+      await tf.unlockStakerUnlockableTokens(claimAssessor2);
+
       claimAssessor1Object.lockPeriodAfterRewardRecieved = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)
       );
@@ -4881,6 +4966,13 @@ contract('Claim: Assessment 2', function([
       await cr.claimAllPendingReward(20, {from: member4});
       await cr.claimAllPendingReward(20, {from: member5});
       await cr.claimAllPendingReward(20, {from: member6});
+
+      await tf.unlockStakerUnlockableTokens(member1);
+      await tf.unlockStakerUnlockableTokens(member2);
+      await tf.unlockStakerUnlockableTokens(member3);
+      await tf.unlockStakerUnlockableTokens(member4);
+      await tf.unlockStakerUnlockableTokens(member5);
+      await tf.unlockStakerUnlockableTokens(member6);
 
       let balanceAfter = parseFloat(await web3.eth.getBalance(coverHolder9));
       let tokenBalanceAfter = parseFloat(await tk.balanceOf(coverHolder9));
@@ -5094,6 +5186,9 @@ contract('Claim: Assessment 2', function([
       let proposalIds = [];
       await cr.claimAllPendingReward(20, {from: claimAssessor1});
       await cr.claimAllPendingReward(20, {from: claimAssessor2});
+
+      await tf.unlockStakerUnlockableTokens(claimAssessor1);
+      await tf.unlockStakerUnlockableTokens(claimAssessor2);
 
       claimAssessor1Object.lockPeriodAfterRewardRecieved = parseFloat(
         await tc.getLockedTokensValidity(claimAssessor1, CLA)

--- a/test/22_UnlockFixes.test.js
+++ b/test/22_UnlockFixes.test.js
@@ -1,0 +1,251 @@
+const NXMToken = artifacts.require('NXMToken');
+const TokenFunctions = artifacts.require('TokenFunctionMock');
+const TokenController = artifacts.require('TokenController');
+const TokenData = artifacts.require('TokenDataMock');
+const MemberRoles = artifacts.require('MemberRoles');
+const NXMaster = artifacts.require('NXMaster');
+const ClaimsReward = artifacts.require('ClaimsReward');
+const Governance = artifacts.require('Governance');
+const QuotationDataMock = artifacts.require('QuotationDataMock');
+const Quotation = artifacts.require('Quotation');
+const Pool1 = artifacts.require('Pool1Mock');
+const MCR = artifacts.require('MCR');
+const {assertRevert} = require('./utils/assertRevert');
+const {advanceBlock} = require('./utils/advanceToBlock');
+const {ether, toHex, toWei} = require('./utils/ethTools');
+const {increaseTimeTo, duration} = require('./utils/increaseTime');
+const {latestTime} = require('./utils/latestTime');
+const gvProp = require('./utils/gvProposal.js').gvProposal;
+const encode = require('./utils/encoder.js').encode;
+const getQuoteValues = require('./utils/getQuote.js').getQuoteValues;
+const getValue = require('./utils/getMCRPerThreshold.js').getValue;
+const PoolData = artifacts.require('PoolDataMock');
+const Claims = artifacts.require('Claims');
+const ProposalCategory = artifacts.require('ProposalCategory');
+
+const coverDetails = [
+  1,
+  '3362445813369838',
+  '744892736679184',
+  '7972408607',
+  '7972408607000'
+];
+const coverPeriod = 61;
+
+const stakedContract = '0xd0a6e6c54dbc68db5db3a091b171a77407ff7ccf';
+const stakedContract2 = '0xee74110fb5a1007b06282e0de5d73a61bf41d9cd';
+let TokenFunctionNewCon;
+let tk;
+let tf;
+let tc;
+let td;
+let mr;
+let qd;
+let qt;
+let nxms;
+let cr;
+let P1;
+let mcr;
+let cl;
+let pd;
+let pc;
+const BN = web3.utils.BN;
+
+const BigNumber = web3.BigNumber;
+require('chai')
+  .use(require('chai-bignumber')(BigNumber))
+  .should();
+
+contract('unlock-fixes', function([
+  owner,
+  member1,
+  member2,
+  member3,
+  notMember
+]) {
+  const fee = ether(0.002);
+  const stakeTokens = ether(100);
+  const tokens = ether(300);
+  const UNLIMITED_ALLOWANCE = new BN((2).toString())
+    .pow(new BN((256).toString()))
+    .sub(new BN((1).toString()));
+  before(async function() {
+    await advanceBlock();
+    tk = await NXMToken.deployed();
+    tf = await TokenFunctions.deployed();
+    td = await TokenData.deployed();
+    nxms = await NXMaster.deployed();
+    tc = await TokenController.at(await nxms.getLatestAddress(toHex('TC')));
+    mr = await MemberRoles.at(await nxms.getLatestAddress('0x4d52'));
+    cr = await ClaimsReward.deployed();
+    qd = await QuotationDataMock.deployed();
+    qt = await Quotation.deployed();
+    P1 = await Pool1.deployed();
+    mcr = await MCR.deployed();
+    pd = await PoolData.deployed();
+    cl = await Claims.deployed();
+    pc = await ProposalCategory.at(await nxms.getLatestAddress(toHex('PC')));
+    await mr.addMembersBeforeLaunch([], []);
+    (await mr.launched()).should.be.equal(true);
+    await mr.payJoiningFee(member1, {from: member1, value: fee});
+    await mr.kycVerdict(member1, true);
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: member1});
+    await mr.payJoiningFee(member2, {from: member2, value: fee});
+    await mr.kycVerdict(member2, true);
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: member2});
+    await mr.payJoiningFee(member3, {from: member3, value: fee});
+    await mr.kycVerdict(member3, true);
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE, {from: member3});
+    await tk.transfer(member1, tokens);
+    await tk.transfer(member2, tokens);
+    await tk.transfer(member3, tokens);
+    await P1.mint(await nxms.getLatestAddress(toHex('CR')), toWei(10));
+
+    await tk.approve(tc.address, UNLIMITED_ALLOWANCE);
+
+    await mcr.addMCRData(
+      await getValue(toWei(2), pd, mcr),
+      toWei(100),
+      toWei(2),
+      ['0x455448', '0x444149'],
+      [100, 65407],
+      20181011
+    );
+    (await pd.capReached()).toString().should.be.equal((1).toString());
+  });
+
+  describe('Stake Tokens', function() {
+    describe('fixes related to tokenFunctions', function() {
+      it('While buying cover after upgrading, cover note locked for correct time', async function() {
+        coverDetails[4] = 7972408607001;
+        var vrsdata = await getQuoteValues(
+          coverDetails,
+          toHex('ETH'),
+          coverPeriod,
+          stakedContract,
+          qt.address
+        );
+        await P1.makeCoverBegin(
+          stakedContract,
+          toHex('ETH'),
+          coverDetails,
+          coverPeriod,
+          vrsdata[0],
+          vrsdata[1],
+          vrsdata[2],
+          {from: owner, value: coverDetails[1]}
+        );
+
+        let validUntil = await qd.getValidityOfCover(1);
+        let cp = await qd.getCoverPeriod(1);
+        let nowTime = validUntil - cp * 24 * 3600;
+        let reason = await tc.lockReason(owner, 0);
+        let lockedValidity = await tc.locked(owner, reason);
+
+        let nowTime1 =
+          lockedValidity[1] -
+          cp * 24 * 3600 -
+          (await td.lockTokenTimeAfterCoverExp());
+
+        nowTime1.should.be.equal(nowTime);
+      });
+
+      it('Should not able to unlock CN if deposited', async function() {
+        let time = await latestTime();
+        time = time + (await duration.days(61));
+        await increaseTimeTo(time);
+        let coverID = (await qd.getCoverLength()) - 1;
+        await cl.submitClaim(coverID);
+
+        await assertRevert(qt.expireCover(coverID));
+      });
+    });
+  });
+  describe('Restrict lock,extend increase lock amount to CLA', function() {
+    it('User can only be able to lock/extend/increase lock amount for CLA directly', async function() {
+      await assertRevert(tc.lock(toHex('ABCD'), toWei(100), 10000000));
+      ((await tc.tokensLocked(owner, toHex('ABCD'))) / 1).should.be.equal(0);
+      await assertRevert(tc.extendLock(toHex('ABCD'), 100));
+      await assertRevert(tc.increaseLockAmount(toHex('ABCD'), toWei(1)));
+    });
+    it('Lock under CLA and unlock it via unlock function', async function() {
+      await tc.lock(toHex('CLA'), toWei(100), 30 * 24 * 3600, {from: member2});
+      ((await tc.tokensLocked(member2, toHex('CLA'))) / 1).should.be.equal(
+        toWei(100) / 1
+      );
+
+      let time = await latestTime();
+      time = time + (await duration.days(30));
+      await increaseTimeTo(time);
+
+      let beforeBalance = await tk.balanceOf(member2);
+
+      await tc.unlock(member2, {from: member2});
+
+      let afterBalance = await tk.balanceOf(member2);
+      ((afterBalance - beforeBalance) / 1).should.be.equal(toWei(100) / 1);
+    });
+
+    it('Should push reason while locking tokens and should remove reason when release all tokens', async function() {
+      await tf.addStake(stakedContract2, stakeTokens, {from: member3});
+      let reason = await tc.lockReason(member3, 0);
+      let time = await latestTime();
+      time = time + (await duration.days(250));
+      await increaseTimeTo(time);
+      await tf.unlockStakerUnlockableTokens(member3, {from: member3});
+      await assertRevert(tc.lockReason(member3, 0));
+    });
+  });
+  describe('Create new category to upgrade uint parameter in TC', function() {
+    it('Added a proposal category to update min CA lock time', async function() {
+      let gv = await Governance.at(await nxms.getLatestAddress(toHex('GV')));
+      let c1 = await pc.totalCategories();
+      let actionHash = encode(
+        'addCategory(string,uint,uint,uint,uint[],uint,string,address,bytes2,uint[])',
+        'Description',
+        1,
+        1,
+        0,
+        [1],
+        604800,
+        '',
+        tc.address,
+        toHex('EX'),
+        [0, 0, 0, 0]
+      );
+      let p1 = await gv.getProposalLength();
+      await gv.createProposalwithSolution(
+        'Add new category',
+        'Add new category',
+        'AddnewCategory',
+        3,
+        'Add new category',
+        actionHash
+      );
+      await gv.submitVote(p1.toNumber(), 1);
+      await gv.closeProposal(p1.toNumber());
+
+      actionHash = encode(
+        'updateUintParameters(bytes8,uint)',
+        toHex('MNCLT'),
+        35
+      );
+      p1 = await gv.getProposalLength();
+      await gv.createProposal(
+        'update minCALockTime',
+        'update minCALockTime',
+        'update minCALockTime',
+        0
+      );
+      await gv.categorizeProposal(p1.toNumber(), c1, 0);
+      await gv.submitProposalWithSolution(
+        p1.toNumber(),
+        'update minCALockTime',
+        actionHash
+      );
+      await gv.submitVote(p1.toNumber(), 1);
+      await gv.closeProposal(p1.toNumber());
+      assert.equal((await tc.minCALockTime()) / 1, 35 * 3600 * 24);
+    });
+  });
+});


### PR DESCRIPTION
Proposals passed #56, 57. 58.

What this includes:

Limiting functionality of lock, increase lock amount, extend lock for claims Assessment only. We have separate functions for RA and CN
Limiting unlock to internal functions only.
Addition of unlocking of CA tokens in function claimAllPendingRewards.
Fixing up of all spoiled records like Hugh's
Disallow deposited tokens from being unlocked. This also solves the problem of expiring covers after claim has been submitted.
Correction of lock time for cover notes. Initially current time was being added twice.