### PR TITLE
Auto-generate tests to increase coverage

### DIFF
--- a/test/21_ClaimsDataMock.firefly.test.js
+++ b/test/21_ClaimsDataMock.firefly.test.js
@@ -1,0 +1,31 @@
+// This is the automatically generated test file for contract: ClaimsDataMock
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const ClaimsDataMock = artifacts.require('ClaimsDataMock');
+const {assertRevert} = require('./utils/assertRevert');
+
+contract('ClaimsDataMock', (accounts) => {
+	// Coverage imporvement tests for ClaimsDataMock
+	describe('ClaimsDataMockBlackboxTest', () => {
+		it('call func setpendingClaimStart with blackbox random args', async () => {
+			const obj = await ClaimsDataMock.new();
+			const arg0 = "110772705976589183854191158578678617448739389744711223478168516898589387215075";
+			await assertRevert(obj.setpendingClaimStart(arg0));
+		});
+
+		it('call func addClaimVotemember with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await ClaimsDataMock.new();
+			const arg0 = "4011642190602083527064334297918495208205478292203514141685801723076513808966";
+			const arg1 = "24169771776117735479654509731832932411266089910549138814941102373495574798845";
+			await assertRevert(obj.addClaimVotemember(arg0, arg1));
+		});
+
+	});
+});

--- a/test/22_ClaimsReward.firefly.test.js
+++ b/test/22_ClaimsReward.firefly.test.js
@@ -1,0 +1,34 @@
+// This is the automatically generated test file for contract: ClaimsReward
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const ClaimsReward = artifacts.require('ClaimsReward');
+const {assertRevert} = require('./utils/assertRevert');
+
+contract('ClaimsReward', (accounts) => {
+	// Coverage imporvement tests for ClaimsReward
+	describe('ClaimsRewardBlackboxTest', () => {
+		it('call func getRewardToBeGiven with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await ClaimsReward.new();
+			const arg0 = "58102126683887842840195786054041603212454529026736966244268302915296507097407";
+			const arg1 = "81722059336739439848300333059437520690107129960834267036902770013631590329940";
+			const arg2 = "66611268526484428184855834628428101646419429294533795562113944205673084489626";
+			await assertRevert(obj.getRewardToBeGiven(arg0, arg1, arg2));
+		});
+
+		it('call func _claimStakeCommission with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await ClaimsReward.new();
+			const arg0 = "80920097935507539518005182320930946670424102393564801648116909328920553726093";
+			const arg1 = "0xe5a7e952d14de532f9adb47ec8570678083e78b0";
+			await assertRevert(obj._claimStakeCommission(arg0, arg1));
+		});
+
+	});
+});

--- a/test/23_ExchangeMock.firefly.test.js
+++ b/test/23_ExchangeMock.firefly.test.js
@@ -1,0 +1,31 @@
+// This is the automatically generated test file for contract: ExchangeMock
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const ExchangeMock = artifacts.require('ExchangeMock');
+const {assertRevert} = require('./utils/assertRevert');
+
+contract('ExchangeMock', (accounts) => {
+	// Coverage imporvement tests for ExchangeMock
+	describe('ExchangeMockBlackboxTest', () => {
+		it('call func ethToTokenSwapInput with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await ExchangeMock.new("0x4d6084bb2d14db2dab2f2df0e968230b09e2d7a6", "0x2ba550ec54cbaee5d4aa7ab101b0d0ff7ed8178f");
+			const arg0 = "112164380260512549052717020384748891734165041653544042583861324749578344516937";
+			const arg1 = "105769999680658345000489474414902320462614632991227828901126744300419493971290";
+			await assertRevert(obj.ethToTokenSwapInput(arg0, arg1));
+		});
+
+		it('call func rateFactor with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await ExchangeMock.new("0x5254847cd4a4714d6c48fe38c6101490efb3b21f", "0x8675a7ade29403066ef62e53a20035974f5d2e91");
+			await assertRevert(obj.rateFactor());
+		});
+
+	});
+});

--- a/test/24_FactoryMock.firefly.test.js
+++ b/test/24_FactoryMock.firefly.test.js
@@ -1,0 +1,24 @@
+// This is the automatically generated test file for contract: FactoryMock
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const FactoryMock = artifacts.require('FactoryMock');
+
+contract('FactoryMock', (accounts) => {
+	// Coverage imporvement tests for FactoryMock
+	describe('FactoryMockBlackboxTest', () => {
+		it('call func getToken with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await FactoryMock.new();
+			const arg0 = "0x7b6068a61d55568303078f0eb18aea6f18405f3d";
+			const res = await obj.getToken(arg0);
+			res.toString().should.be.equal("0x0000000000000000000000000000000000000000");
+		});
+
+	});
+});

--- a/test/25_Governance.firefly.test.js
+++ b/test/25_Governance.firefly.test.js
@@ -1,0 +1,132 @@
+// This is the automatically generated test file for contract: Governance
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const Governance = artifacts.require('Governance');
+const {assertRevert} = require('./utils/assertRevert');
+
+contract('Governance', (accounts) => {
+	// Coverage imporvement tests for Governance
+	describe('GovernanceBlackboxTest', () => {
+		it('call func ms with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await Governance.new();
+			const res = await obj.ms();
+			res.toString().should.be.equal("0x0000000000000000000000000000000000000000");
+		});
+
+		it('call func changeDependentContractAddress with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await Governance.new();
+			await assertRevert(obj.changeDependentContractAddress());
+		});
+
+		it('call func setDelegationStatus with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await Governance.new();
+			const arg0 = "false";
+			await assertRevert(obj.setDelegationStatus(arg0));
+		});
+
+		it('call func getUintParameters with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await Governance.new();
+			const arg0 = "0x864b11974d239f1b";
+			const res = await obj.getUintParameters(arg0);
+			expect(res).to.be.an('object');
+		});
+
+		it('call func updateProposal with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await Governance.new();
+			const arg0 = "44184787390246806700052258179334529073766633177985470422912529562798747109819";
+			const arg1 = "'c7KTq\\y jN{=QuZ\"(9b\"X6[l\''";
+			const arg2 = "\"SjOli4.KfxFw0c0wizWHya+vUwW27<LIr'\"";
+			const arg3 = "'Q+IFJ]jZ+ hju3\\ed.r*Zg,\"CuKDd][VSQIEM'";
+			await assertRevert(obj.updateProposal(arg0, arg1, arg2, arg3));
+		});
+
+		it('call func submitProposalWithSolution with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await Governance.new();
+			const arg0 = "78819691442755916025573851414633303759304114503734624336363522436903961168554";
+			const arg1 = "'t^Sgjr/bi8h1(p4x\"34Uk).D,\\6\'3\'(a*;;Hf7Xt_N#EOJ]LWNsbt4eRb:*4`R\\t{Os(t+HOrpdjs--L1Ciw4/)<\\Vd|^:.S\\vYLEw%|i1F<wXGy!;R{C_ p|(o5wHH1aat-9hS[|t[1p2KDM(VeUrM)W+=e,q/,(h<O`G=pA%ZnVL34'";
+			const arg2 = "0x7cdf32b48b5b870436d0557f30f6fc9931bc63122bcc707ed4a913a3d8997191dcfafc3f78cd50ce3ffb14c42ff27a7ac766e9cde3c7b8d3e98a4281d751255522b3b423a453602b412f824295b67925dcf653abdf246b8230b00d03911f70c4f8870c1ce8e64a9d6411b23695519b162fcc39cb645df597574f8ca5626e08bb6676518a1564927054c4408937c3f81f4690060f7df804cae96b70a5f7653c1ba49bf734fa4d";
+			await assertRevert(obj.submitProposalWithSolution(arg0, arg1, arg2));
+		});
+
+		it('call func addSolution with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await Governance.new();
+			const arg0 = "77903931179213654988115398157350028763741183345088561628243112422272310208117";
+			const arg1 = "'jS9\\3Z3*S`D=xcduR%uGy:)?3>Wrb=)}$N*=pD*eLj0*qD8'";
+			const arg2 = "0x72935bd559f36971b312773469e6cdc793023a0be31488e54fa908ff8656e987000ef195eb81a797773de0dbb39814d1f47992277a7a75598c1e60df6b9455f7714d8a7123c1e4f6a1573fc584564415865a29b9e76474b1446552bef9a1c77204104466eefd1b778f741775afd81940c769dd843fa01e0db6acdd22152be99574033f3bb9edc5545af641f02d8aff63e59edd5cf4a24557f50f5ed83880ad70de56ba7678061b6fa2774b3c34d0c028a62b5449602715c6e564103141";
+			const res = await obj.addSolution(arg0, arg1, arg2);
+			expect(res).to.be.an('object');
+		});
+
+		it('call func removeDelegation with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await Governance.new();
+			const arg0 = "0x9730f8d7809100201bb0159aa806d0a8c976f052";
+			await assertRevert(obj.removeDelegation(arg0));
+		});
+
+		it('call func getFollowers with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await Governance.new();
+			const arg0 = "0x493623d5b9f8e6a3962addf4c6ec89836ffd7d1e";
+			const res = await obj.getFollowers(arg0);
+			res.toString().should.be.equal("");
+		});
+
+		it('call func createProposalwithSolution with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await Governance.new();
+			const arg0 = "\"F`t)xKhbhhfX-;Tcb/o|wQq&9ZWrr7L}{\\5y/+@H}!&r?7w/egs|,pj>lcUv1C@'LH m`u@hD;!zksyKx^lF*!)nCGo@7L)#@A|h5cNm-{=i4s+qCSG!p$U*iC5PM FCb$F'6PG\"";
+			const arg1 = "'-a\"a%W/\')T]]{7^;L/8}/$&;N@u91ijf.O3b\'Pa-tB]TjDN2xl$a*\\[M7OlFFPBA/r&I.P<x68Efn^5c3AM*D_*&yOAdUe%C>$n+Wxpl>70J)U(-}@_@hb0qJ{>U|i{RC5}lL[iST7<\'OE53\'#O{AC6ra20poY)}E/j8!Xm)Y@8_A\"E8R uoNkzoa1am|VOX]1^2,'";
+			const arg2 = "\"P&^*>u:FYnN4FJlN(E'X1$mh/14e{ltKuZY2U;(,g6LEt+{*g&1F)qt,R$z,]+477)bAJ4y#Y`5c;2Ui(+(^C7E/_50CNh_'FMIv/9,$#ocz%nuW}Fbf7>>w@q}x:U26BgiWf:)idw{K/;9.wkS5!4}GTTb4Vssou5tJ^]gyS Jh.]z^b}XS8DSc%?5q63=F$LZlUb9d\"";
+			const arg3 = "13567141030323495396358047107302819261670439997839031338276361928517155684186";
+			const arg4 = "'GAxE<c;1eJRiM7jT($*/gvk&{c0q9-t>NW5*7Phe>i6Y/'";
+			const arg5 = "0x3f7606da326d75da61ce84caf0a11bd24d3ba12e333e904225f4df1d09d98d4a09be2842c88cc7a302f5d4d2aae51a367761de533b44f4587b8e333978c65d91dab21fc84b1f3171de8817cbf5e28c6a1454abd12942698a992d4ff8c58188839d3605a99c7b8fb043b86f66ccc3d6f52c68c36abe3bf49c";
+			await assertRevert(obj.createProposalwithSolution(arg0, arg1, arg2, arg3, arg4, arg5));
+		});
+
+		it('call func updateUintParameters with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await Governance.new();
+			const arg0 = "0x5ae58a93238d420e";
+			const arg1 = "34986735480573006292383858977626594732819038718920690174461351373030042817675";
+			await assertRevert(obj.updateUintParameters(arg0, arg1));
+		});
+
+		it('call func canCloseProposal with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await Governance.new();
+			const arg0 = "21055003456126480078325193029956041166410573060299165588126173018980927127188";
+			await assertRevert(obj.canCloseProposal(arg0));
+		});
+
+		it('call func proposalVoteTally with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await Governance.new();
+			const arg0 = "72940298825571747983778895299748578620432337268389128575975621315327704908789";
+			const res = await obj.proposalVoteTally(arg0);
+			res.toString().should.be.equal("0");
+		});
+
+		it('call func alreadyDelegated with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await Governance.new();
+			const arg0 = "0x9e25a1dd4ad0a372e224a624c98fa02e2803e4aa";
+			const res = await obj.alreadyDelegated(arg0);
+			res.toString().should.be.equal("false");
+		});
+
+	});
+});

--- a/test/26_GovernanceMock.firefly.test.js
+++ b/test/26_GovernanceMock.firefly.test.js
@@ -1,0 +1,32 @@
+// This is the automatically generated test file for contract: GovernanceMock
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const GovernanceMock = artifacts.require('GovernanceMock');
+
+contract('GovernanceMock', (accounts) => {
+	// Coverage imporvement tests for GovernanceMock
+	describe('GovernanceMockBlackboxTest', () => {
+		it('call func isOpenForDelegation with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await GovernanceMock.new();
+			const arg0 = "0x012115895c5e7783cbc44248fc7ead58b6d49fdc";
+			const res = await obj.isOpenForDelegation(arg0);
+			res.toString().should.be.equal("false");
+		});
+
+		it('call func proposalVoteTally with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await GovernanceMock.new();
+			const arg0 = "25754670974843739582484924235812428143341387358621712066819489138440085809717";
+			const res = await obj.proposalVoteTally(arg0);
+			res.toString().should.be.equal("0");
+		});
+
+	});
+});

--- a/test/27_MCR.firefly.test.js
+++ b/test/27_MCR.firefly.test.js
@@ -1,0 +1,23 @@
+// This is the automatically generated test file for contract: MCR
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const MCR = artifacts.require('MCR');
+const {assertRevert} = require('./utils/assertRevert');
+
+contract('MCR', (accounts) => {
+	// Coverage imporvement tests for MCR
+	describe('MCRBlackboxTest', () => {
+		it('call func changeDependentContractAddress with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await MCR.new();
+			await assertRevert(obj.changeDependentContractAddress());
+		});
+
+	});
+});

--- a/test/28_MemberRoles.firefly.test.js
+++ b/test/28_MemberRoles.firefly.test.js
@@ -1,0 +1,32 @@
+// This is the automatically generated test file for contract: MemberRoles
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const MemberRoles = artifacts.require('MemberRoles');
+const {assertInvalid} = require('./utils/assertInvalid');
+
+contract('MemberRoles', (accounts) => {
+	// Coverage imporvement tests for MemberRoles
+	describe('MemberRolesBlackboxTest', () => {
+		it('call func launchedOn with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await MemberRoles.new();
+			const res = await obj.launchedOn();
+			res.toString().should.be.equal("0");
+		});
+
+		it('call func memberAtIndex with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await MemberRoles.new();
+			const arg0 = "60757669020615360543459817708388636028228431451585199337683992662536095010908";
+			const arg1 = "50997788057121171331422221560286834229282346024105270218066439450806293528449";
+			await assertInvalid(obj.memberAtIndex(arg0, arg1));
+		});
+
+	});
+});

--- a/test/29_Migrations.firefly.test.js
+++ b/test/29_Migrations.firefly.test.js
@@ -20,13 +20,6 @@ contract('Migrations', (accounts) => {
 			await assertRevert(obj.upgrade(arg0));
 		});
 
-		it('call func owner with blackbox random args', async () => {
-			// Might adjust constructor accordingly
-			const obj = await Migrations.new();
-			const res = await obj.owner();
-			res.toString().should.be.equal("0x004B7D0721cbffcB87Aeae35Bf88196dd07281D1");
-		});
-
 		it('call func lastCompletedMigration with blackbox random args', async () => {
 			// Might adjust constructor accordingly
 			const obj = await Migrations.new();

--- a/test/29_Migrations.firefly.test.js
+++ b/test/29_Migrations.firefly.test.js
@@ -1,0 +1,38 @@
+// This is the automatically generated test file for contract: Migrations
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const Migrations = artifacts.require('Migrations');
+const {assertRevert} = require('./utils/assertRevert');
+
+contract('Migrations', (accounts) => {
+	// Coverage imporvement tests for Migrations
+	describe('MigrationsBlackboxTest', () => {
+		it('call func upgrade with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await Migrations.new();
+			const arg0 = "0xaa97e2aa39a09baf505634c7b6b82376687ecf18";
+			await assertRevert(obj.upgrade(arg0));
+		});
+
+		it('call func owner with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await Migrations.new();
+			const res = await obj.owner();
+			res.toString().should.be.equal("0x004B7D0721cbffcB87Aeae35Bf88196dd07281D1");
+		});
+
+		it('call func lastCompletedMigration with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await Migrations.new();
+			const res = await obj.lastCompletedMigration();
+			res.toString().should.be.equal("0");
+		});
+
+	});
+});

--- a/test/30_MockDAI.firefly.test.js
+++ b/test/30_MockDAI.firefly.test.js
@@ -1,0 +1,71 @@
+// This is the automatically generated test file for contract: MockDAI
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const MockDAI = artifacts.require('MockDAI');
+const {assertRevert} = require('./utils/assertRevert');
+
+contract('MockDAI', (accounts) => {
+	// Coverage imporvement tests for MockDAI
+	describe('MockDAIBlackboxTest', () => {
+		it('call func totalSupply with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await MockDAI.new();
+			const res = await obj.totalSupply();
+			res.toString().should.be.equal("999999000000000000000000");
+		});
+
+		it('call func decreaseAllowance with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await MockDAI.new();
+			const arg0 = "0x72af462e6063762ec54b5a1340f315ce3c35ffee";
+			const arg1 = "21421593508946576050319457260597768642568102943684974374986425480473388628679";
+			await assertRevert(obj.decreaseAllowance(arg0, arg1));
+		});
+
+		it('call func allowance with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await MockDAI.new();
+			const arg0 = "0xa97acef3691d742d743e7ccc4b6222190a93df9b";
+			const arg1 = "0x2c94c20d2fc81b0b881ea57c136dd4985c80ae26";
+			const res = await obj.allowance(arg0, arg1);
+			res.toString().should.be.equal("0");
+		});
+
+		it('call func symbol with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await MockDAI.new();
+			const res = await obj.symbol();
+			res.toString().should.be.equal("DAI");
+		});
+
+		it('call func decimals with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await MockDAI.new();
+			const res = await obj.decimals();
+			res.toString().should.be.equal("18");
+		});
+
+		it('call func increaseAllowance with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await MockDAI.new();
+			const arg0 = "0xf6f5864102eeb1810094d15077512579d5a7ffc1";
+			const arg1 = "28452427355439507092323481790512480715347575329867867435701903317635855889704";
+			const res = await obj.increaseAllowance(arg0, arg1);
+			expect(res).to.be.an('object');
+		});
+
+		it('call func name with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await MockDAI.new();
+			const res = await obj.name();
+			res.toString().should.be.equal("DAI");
+		});
+
+	});
+});

--- a/test/31_MockMKR.firefly.test.js
+++ b/test/31_MockMKR.firefly.test.js
@@ -1,0 +1,71 @@
+// This is the automatically generated test file for contract: MockMKR
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const MockMKR = artifacts.require('MockMKR');
+const {assertRevert} = require('./utils/assertRevert');
+
+contract('MockMKR', (accounts) => {
+	// Coverage imporvement tests for MockMKR
+	describe('MockMKRBlackboxTest', () => {
+		it('call func decreaseAllowance with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await MockMKR.new();
+			const arg0 = "0xd66e62b745b7b730847a199d941c48751b851e6a";
+			const arg1 = "104983416598992176469526264305694539719815726026371709561185972337338405442534";
+			await assertRevert(obj.decreaseAllowance(arg0, arg1));
+		});
+
+		it('call func increaseAllowance with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await MockMKR.new();
+			const arg0 = "0x76ce052e50fb541bb00e20e858917561e251c294";
+			const arg1 = "99016818864077790556233425110239357409833481614600012086033844075155470495700";
+			const res = await obj.increaseAllowance(arg0, arg1);
+			expect(res).to.be.an('object');
+		});
+
+		it('call func allowance with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await MockMKR.new();
+			const arg0 = "0xa323f6c48c5f30f059e4a146545608fb8ce94386";
+			const arg1 = "0x7c62c154cd979d93f2d9f8571769bcec3951b7ac";
+			const res = await obj.allowance(arg0, arg1);
+			res.toString().should.be.equal("0");
+		});
+
+		it('call func totalSupply with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await MockMKR.new();
+			const res = await obj.totalSupply();
+			res.toString().should.be.equal("999999000000000000000000");
+		});
+
+		it('call func decimals with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await MockMKR.new();
+			const res = await obj.decimals();
+			res.toString().should.be.equal("18");
+		});
+
+		it('call func name with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await MockMKR.new();
+			const res = await obj.name();
+			res.toString().should.be.equal("MKR");
+		});
+
+		it('call func symbol with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await MockMKR.new();
+			const res = await obj.symbol();
+			res.toString().should.be.equal("MKR");
+		});
+
+	});
+});

--- a/test/32_NewDataInternalContract.firefly.test.js
+++ b/test/32_NewDataInternalContract.firefly.test.js
@@ -1,0 +1,38 @@
+// This is the automatically generated test file for contract: NewDataInternalContract
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const NewDataInternalContract = artifacts.require('NewDataInternalContract');
+const {assertRevert} = require('./utils/assertRevert');
+
+contract('NewDataInternalContract', (accounts) => {
+	// Coverage imporvement tests for NewDataInternalContract
+	describe('NewDataInternalContractBlackboxTest', () => {
+		it('call func changeDependentContractAddress with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await NewDataInternalContract.new();
+			await assertRevert(obj.changeDependentContractAddress());
+		});
+
+		it('call func nxMasterAddress with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await NewDataInternalContract.new();
+			const res = await obj.nxMasterAddress();
+			res.toString().should.be.equal("0x0000000000000000000000000000000000000000");
+		});
+
+		it('call func changeMasterAddress with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await NewDataInternalContract.new();
+			const arg0 = "0x4b314b93f0418a9206318370f245d55e5ac88dd5";
+			const res = await obj.changeMasterAddress(arg0);
+			expect(res).to.be.an('object');
+		});
+
+	});
+});

--- a/test/33_NewInternalContract.firefly.test.js
+++ b/test/33_NewInternalContract.firefly.test.js
@@ -1,0 +1,38 @@
+// This is the automatically generated test file for contract: NewInternalContract
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const NewInternalContract = artifacts.require('NewInternalContract');
+const {assertRevert} = require('./utils/assertRevert');
+
+contract('NewInternalContract', (accounts) => {
+	// Coverage imporvement tests for NewInternalContract
+	describe('NewInternalContractBlackboxTest', () => {
+		it('call func nxMasterAddress with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await NewInternalContract.new();
+			const res = await obj.nxMasterAddress();
+			res.toString().should.be.equal("0x0000000000000000000000000000000000000000");
+		});
+
+		it('call func changeDependentContractAddress with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await NewInternalContract.new();
+			await assertRevert(obj.changeDependentContractAddress());
+		});
+
+		it('call func changeMasterAddress with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await NewInternalContract.new();
+			const arg0 = "0xa5f2370e06ecc52705fe9cbabf574ab388f6c6e8";
+			const res = await obj.changeMasterAddress(arg0);
+			expect(res).to.be.an('object');
+		});
+
+	});
+});

--- a/test/34_NewProxyInternalContract.firefly.test.js
+++ b/test/34_NewProxyInternalContract.firefly.test.js
@@ -1,0 +1,30 @@
+// This is the automatically generated test file for contract: NewProxyInternalContract
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const NewProxyInternalContract = artifacts.require('NewProxyInternalContract');
+const {assertRevert} = require('./utils/assertRevert');
+
+contract('NewProxyInternalContract', (accounts) => {
+	// Coverage imporvement tests for NewProxyInternalContract
+	describe('NewProxyInternalContractBlackboxTest', () => {
+		it('call func nxMasterAddress with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await NewProxyInternalContract.new();
+			const res = await obj.nxMasterAddress();
+			res.toString().should.be.equal("0x0000000000000000000000000000000000000000");
+		});
+
+		it('call func changeDependentContractAddress with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await NewProxyInternalContract.new();
+			await assertRevert(obj.changeDependentContractAddress());
+		});
+
+	});
+});

--- a/test/35_NXMaster.firefly.test.js
+++ b/test/35_NXMaster.firefly.test.js
@@ -1,0 +1,69 @@
+// This is the automatically generated test file for contract: NXMaster
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const NXMaster = artifacts.require('NXMaster');
+const {assertRevert} = require('./utils/assertRevert');
+
+contract('NXMaster', (accounts) => {
+	// Coverage imporvement tests for NXMaster
+	describe('NXMasterBlackboxTest', () => {
+		it('call func closeClaim with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await NXMaster.new();
+			const arg0 = "29521300311847926266206205964422162741429598024077478844719018473210777654093";
+			await assertRevert(obj.closeClaim(arg0));
+		});
+
+		it('call func updateOwnerParameters with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await NXMaster.new();
+			const arg0 = "0x8953f58c893aed0c";
+			const arg1 = "0x79317513fd5d665e16fedb092df9b27372264b56";
+			await assertRevert(obj.updateOwnerParameters(arg0, arg1));
+		});
+
+		it('call func contractsActive with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await NXMaster.new();
+			const arg0 = "0x53507c1d0793173094f598113c2019ebf7b15f81";
+			const res = await obj.contractsActive(arg0);
+			res.toString().should.be.equal("false");
+		});
+
+		it('call func getVersionData with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await NXMaster.new();
+			const res = await obj.getVersionData();
+			expect(res).to.be.an('object');
+		});
+
+		it('call func getOwnerParameters with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await NXMaster.new();
+			const arg0 = "0x51c15154b50deaaf";
+			const res = await obj.getOwnerParameters(arg0);
+			expect(res).to.be.an('object');
+		});
+
+		it('call func addNewVersion with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await NXMaster.new();
+			const arg0 = ["0x7433093624bb2abe88f5a65e8128648efbc2eb7c"];
+			await assertRevert(obj.addNewVersion(arg0));
+		});
+
+		it('call func updatePauseTime with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await NXMaster.new();
+			const arg0 = "1283585863236968758606414571008569607299240587202474903745982580009184591252";
+			await assertRevert(obj.updatePauseTime(arg0));
+		});
+
+	});
+});

--- a/test/36_NXMasterMock.firefly.test.js
+++ b/test/36_NXMasterMock.firefly.test.js
@@ -1,0 +1,48 @@
+// This is the automatically generated test file for contract: NXMasterMock
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const NXMasterMock = artifacts.require('NXMasterMock');
+const {assertRevert} = require('./utils/assertRevert');
+
+contract('NXMasterMock', (accounts) => {
+	// Coverage imporvement tests for NXMasterMock
+	describe('NXMasterMockBlackboxTest', () => {
+		it('call func addNewInternalContract with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await NXMasterMock.new();
+			const arg0 = "0x9495";
+			const arg1 = "0x365ffc2ec98c0b8d25b534f49f9fd236326cab57";
+			const arg2 = "115157969095469944535984955316038961074107920630897595909531747270204390967328";
+			await assertRevert(obj.addNewInternalContract(arg0, arg1, arg2));
+		});
+
+		it('call func isAuthorizedToGovern with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await NXMasterMock.new();
+			const arg0 = "0x1b9ddd59fff948cd9e48e51c69f9982d89a8cfe1";
+			await assertRevert(obj.isAuthorizedToGovern(arg0));
+		});
+
+		it('call func getVersionData with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await NXMasterMock.new();
+			const res = await obj.getVersionData();
+			expect(res).to.be.an('object');
+		});
+
+		it('call func addEmergencyPause with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await NXMasterMock.new();
+			const arg0 = "true";
+			const arg1 = "0x92cc385e";
+			await assertRevert(obj.addEmergencyPause(arg0, arg1));
+		});
+
+	});
+});

--- a/test/37_NXMDSValueMock.firefly.test.js
+++ b/test/37_NXMDSValueMock.firefly.test.js
@@ -1,0 +1,45 @@
+// This is the automatically generated test file for contract: NXMDSValueMock
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const NXMDSValueMock = artifacts.require('NXMDSValueMock');
+const {assertRevert} = require('./utils/assertRevert');
+
+contract('NXMDSValueMock', (accounts) => {
+	// Coverage imporvement tests for NXMDSValueMock
+	describe('NXMDSValueMockBlackboxTest', () => {
+		it('call func rate with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await NXMDSValueMock.new("0x8d7b0df3a484b4bab7f72a85f3832a692bd06e9a");
+			const res = await obj.rate();
+			res.toString().should.be.equal("8333333333333333");
+		});
+
+		it('call func setRate with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await NXMDSValueMock.new("0x2a99e2b4328e9ec31f5bbf784c55854b6c6101a8");
+			const arg0 = "58146220370576763314328325531277273411195321326792295318104306987325083382704";
+			await assertRevert(obj.setRate(arg0));
+		});
+
+		it('call func setZeroRate with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await NXMDSValueMock.new("0x344073d7f1e303ba748a38245666995d79100ea3");
+			const arg0 = "false";
+			await assertRevert(obj.setZeroRate(arg0));
+		});
+
+		it('call func owner with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await NXMDSValueMock.new("0x5614d258172718424e1dc82d17a32c9374039496");
+			const res = await obj.owner();
+			res.toString().should.be.equal("0x5614D258172718424E1dC82D17a32C9374039496");
+		});
+
+	});
+});

--- a/test/38_NXMToken.firefly.test.js
+++ b/test/38_NXMToken.firefly.test.js
@@ -1,0 +1,47 @@
+// This is the automatically generated test file for contract: NXMToken
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const NXMToken = artifacts.require('NXMToken');
+const {assertRevert} = require('./utils/assertRevert');
+
+contract('NXMToken', (accounts) => {
+	// Coverage imporvement tests for NXMToken
+	describe('NXMTokenBlackboxTest', () => {
+		it('call func name with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await NXMToken.new("0x8cf3fd75455d59295121102ad7370bf8d06d29af", "105318010547933383378187685729170711374613565520669044879449143665565687191971");
+			const res = await obj.name();
+			res.toString().should.be.equal("NXM");
+		});
+
+		it('call func changeOperator with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await NXMToken.new("0xa499ee1b836d36793e161b915b5cf5a9ab2fd726", "56909983753885279896975743449353785612536778178276241325198975606452454183914");
+			const arg0 = "0x2f2f2a425abee3b13e36b96f72636c4db308087c";
+			const res = await obj.changeOperator(arg0);
+			expect(res).to.be.an('object');
+		});
+
+		it('call func operator with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await NXMToken.new("0x11da725041cbefd929d053b789763c681d61c51c", "12791147698771601834948220516045633915584814674284466025255284081936197992835");
+			const res = await obj.operator();
+			res.toString().should.be.equal("0x0000000000000000000000000000000000000000");
+		});
+
+		it('call func decreaseAllowance with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await NXMToken.new("0x0847e4a587e5997cf6002dadbdaa8c02fce79f40", "20788608781557788096466706144397438915928542990703554658417294532226324880131");
+			const arg0 = "0x007668c2146e3ca1b0e2d5b95ee451159289356e";
+			const arg1 = "50181572319255987303679214408244896821071101389784638947024702137055417640135";
+			await assertRevert(obj.decreaseAllowance(arg0, arg1));
+		});
+
+	});
+});

--- a/test/39_OwnedUpgradeabilityProxy.firefly.test.js
+++ b/test/39_OwnedUpgradeabilityProxy.firefly.test.js
@@ -1,0 +1,24 @@
+// This is the automatically generated test file for contract: OwnedUpgradeabilityProxy
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const OwnedUpgradeabilityProxy = artifacts.require('OwnedUpgradeabilityProxy');
+
+contract('OwnedUpgradeabilityProxy', (accounts) => {
+	// Coverage imporvement tests for OwnedUpgradeabilityProxy
+	describe('OwnedUpgradeabilityProxyBlackboxTest', () => {
+		it('call func upgradeTo with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await OwnedUpgradeabilityProxy.new("0xce47831908cf7011b74d0d776899d7a982cc4316");
+			const arg0 = "0x04017ca8f3f361a7d5939b2ef38891e44e21cd9e";
+			const res = await obj.upgradeTo(arg0);
+			expect(res).to.be.an('object');
+		});
+
+	});
+});

--- a/test/40_Pool1Mock.firefly.test.js
+++ b/test/40_Pool1Mock.firefly.test.js
@@ -1,0 +1,66 @@
+// This is the automatically generated test file for contract: Pool1Mock
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const Pool1Mock = artifacts.require('Pool1Mock');
+const {assertRevert} = require('./utils/assertRevert');
+
+contract('Pool1Mock', (accounts) => {
+	// Coverage imporvement tests for Pool1Mock
+	describe('Pool1MockBlackboxTest', () => {
+		it('call func burnFrom with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await Pool1Mock.new();
+			const arg0 = "0xc8bf3030fac6cd11dfce84fd8e13be1751be6f80";
+			const arg1 = "51981400485029636672388488847341560449143949780382747201377489571407683768120";
+			await assertRevert(obj.burnFrom(arg0, arg1));
+		});
+
+		it('call func burnStakerLockedToken with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await Pool1Mock.new();
+			const arg0 = "97735620315966422331511309934772612539005382187534948848464016011294873587351";
+			const arg1 = "0x8e4e2885";
+			const arg2 = "12853055588312960797597707770721980229100165868977548809484816318578950846809";
+			await assertRevert(obj.burnStakerLockedToken(arg0, arg1, arg2));
+		});
+
+		it('call func changeMasterAddress with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await Pool1Mock.new();
+			const arg0 = "0xb35dfb8e873aa4c62fedb9a57edc49d1764e3d37";
+			const res = await obj.changeMasterAddress(arg0);
+			expect(res).to.be.an('object');
+		});
+
+		it('call func depositCN with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await Pool1Mock.new();
+			const arg0 = "109980450597582443215782614620060114351173938343400111047727023576647860738483";
+			await assertRevert(obj.depositCN(arg0));
+		});
+
+		it('call func __callback with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await Pool1Mock.new();
+			const arg0 = "0x4c73c02448c5c6c57bb91709b9e67ca8512ebcdf2442b4fd258283444dd290aa";
+			const arg1 = "'{}Gu#T|{{`TMSCS%YMIgj^UK[08<3*oWN|\'}H214R7<v.*Lo.!LQ_iG^,^ow+by)R1r<\"G[6F=;Hxu)*+X+X8c4VT\\WC5_|66x,R,`!Rt]w3d&`V!):.+(w7-:^PyelNpQU5eelsP%-6[;oWl$Vk\\$d2$Yv&<zjHJwEIFH@&Gi_;akY2,DSMWX)nR>{KdAl/nAQ|H=)!G(<Bp4Cl_*4c<WOaQ<?xlFyU,`*^)75ck'";
+			const arg2 = "0x3a23714788d0fd79adc621bf7d3aa30869aa7c63805481260ecb275da3d2ad1694547127cdfada30229ab98b2627cc20d5f44eac52e2f280d7df40bc3516d8a3ef3e6b30bab3bb1d3c2370b90a5900e684c20a149d751fbe6ca1f854e1bba48ed65478f6da16aa4cc340ba307fd1fb7a4cf6d07d8877f5352ed0489c16b5494bc1e378a56093885a50ea8957c02755e418558040856805ee3fc903474ea55cd24c70fbbcc5ccaa1196f11578777a273cebc6a2e4686e63fc75d10f55c2963393e6079af72cc41d15899c14cce6bfe9f9ea70";
+			const res = await obj.__callback(arg0, arg1, arg2);
+			expect(res).to.be.an('object');
+		});
+
+		it('call func sellNXMTokens with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await Pool1Mock.new();
+			const arg0 = "107608201356243731125152277225871289161554412728842240590486799452686526847554";
+			await assertRevert(obj.sellNXMTokens(arg0));
+		});
+
+	});
+});

--- a/test/41_Pool2.firefly.test.js
+++ b/test/41_Pool2.firefly.test.js
@@ -1,0 +1,24 @@
+// This is the automatically generated test file for contract: Pool2
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const Pool2 = artifacts.require('Pool2');
+
+contract('Pool2', (accounts) => {
+	// Coverage imporvement tests for Pool2
+	describe('Pool2BlackboxTest', () => {
+		it('call func changeMasterAddress with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await Pool2.new("0x041c83c8fcbb241d9a88b96991b8eb5401d597f2");
+			const arg0 = "0xc31fa8c602cdf6ba131693f10b23287a4e2aff97";
+			const res = await obj.changeMasterAddress(arg0);
+			expect(res).to.be.an('object');
+		});
+
+	});
+});

--- a/test/42_PoolDataMock.firefly.test.js
+++ b/test/42_PoolDataMock.firefly.test.js
@@ -1,0 +1,32 @@
+// This is the automatically generated test file for contract: PoolDataMock
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const PoolDataMock = artifacts.require('PoolDataMock');
+const {assertInvalid} = require('./utils/assertInvalid');
+
+contract('PoolDataMock', (accounts) => {
+	// Coverage imporvement tests for PoolDataMock
+	describe('PoolDataMockBlackboxTest', () => {
+		it('call func allMCRData with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await PoolDataMock.new("0x0ee60dc3be562b086b71762956c148106eaa562b", "0xc69d65d876cab2fe049e87b32a5fc2ca440d2c4d", "0xd1472fbe861d6d5ae43434846a706270ad1421e2");
+			const arg0 = "14619106044536873067210408454013400715426233116782078341216224560580263344759";
+			await assertInvalid(obj.allMCRData(arg0));
+		});
+
+		it('call func allAPIid with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await PoolDataMock.new("0x18a6143c4930c401c1aa75ea3a3e60a759f7b96e", "0xee1d80d3ac2b18e004379d86abdaf8c30caa6e0d", "0x1f9e5e60767c1e3faa14e89414d9c8a615e6c6a3");
+			const arg0 = "0x7bbe67d53a9a1842f402d75e5259d76637069962132e85fc145890e78ff6b00b";
+			const res = await obj.allAPIid(arg0);
+			expect(res).to.be.an('object');
+		});
+
+	});
+});

--- a/test/43_PooledStakingMock.firefly.test.js
+++ b/test/43_PooledStakingMock.firefly.test.js
@@ -1,0 +1,82 @@
+// This is the automatically generated test file for contract: PooledStakingMock
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const PooledStakingMock = artifacts.require('PooledStakingMock');
+const {assertInvalid} = require('./utils/assertInvalid');
+
+contract('PooledStakingMock', (accounts) => {
+	// Coverage imporvement tests for PooledStakingMock
+	describe('PooledStakingMockBlackboxTest', () => {
+		it('call func rewards with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await PooledStakingMock.new();
+			const arg0 = "106186880810849267837550111169288142720343475485080180758034036842250570152943";
+			const res = await obj.rewards(arg0);
+			expect(res).to.be.an('object');
+		});
+
+		it('call func stakerContractsArray with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await PooledStakingMock.new();
+			const arg0 = "0x2297198ca48dea7ce661d27b780e5a331dba1f1e";
+			const res = await obj.stakerContractsArray(arg0);
+			res.toString().should.be.equal("");
+		});
+
+		it('call func stakerContractPendingUnstakeTotal with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await PooledStakingMock.new();
+			const arg0 = "0x5355aba789dca56bb04cd9282becdb7b542890eb";
+			const arg1 = "0x56ba951c0f037721006ed8a543ad2a82611e002a";
+			const res = await obj.stakerContractPendingUnstakeTotal(arg0, arg1);
+			res.toString().should.be.equal("0");
+		});
+
+		it('call func unstakeRequestAtIndex with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await PooledStakingMock.new();
+			const arg0 = "24152439889652753902170171880852359023383760582843414152224740315271955076864";
+			const res = await obj.unstakeRequestAtIndex(arg0);
+			expect(res).to.be.an('object');
+		});
+
+		it('call func stakerContractAtIndex with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await PooledStakingMock.new();
+			const arg0 = "0x8fe362f4c34976777be22966e6ef72077c6836e7";
+			const arg1 = "72186387025932383987792649251365275585064578197577831866730542373267764487592";
+			await assertInvalid(obj.stakerContractAtIndex(arg0, arg1));
+		});
+
+		it('call func contractStakerCount with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await PooledStakingMock.new();
+			const arg0 = "0x450fd2da9f9993efdf6015cb6b0e8dfcf2cceefd";
+			const res = await obj.contractStakerCount(arg0);
+			res.toString().should.be.equal("0");
+		});
+
+		it('call func unstakeRequests with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await PooledStakingMock.new();
+			const arg0 = "35933286771651742402173494941203640595641116649347830359987611124700207388443";
+			const res = await obj.unstakeRequests(arg0);
+			expect(res).to.be.an('object');
+		});
+
+		it('call func stakerContractCount with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await PooledStakingMock.new();
+			const arg0 = "0xefead3bf266a9a34faa80eacbe5040f1a16ae9ac";
+			const res = await obj.stakerContractCount(arg0);
+			res.toString().should.be.equal("0");
+		});
+
+	});
+});

--- a/test/44_ProposalCategory.firefly.test.js
+++ b/test/44_ProposalCategory.firefly.test.js
@@ -1,0 +1,118 @@
+// This is the automatically generated test file for contract: ProposalCategory
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const ProposalCategory = artifacts.require('ProposalCategory');
+const {assertRevert} = require('./utils/assertRevert');
+
+contract('ProposalCategory', (accounts) => {
+	// Coverage imporvement tests for ProposalCategory
+	describe('ProposalCategoryBlackboxTest', () => {
+		it('call func categoryActionDetails with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await ProposalCategory.new();
+			const arg0 = "47509664389442843477775967605108857405646803624887729026470284308407408194846";
+			const res = await obj.categoryActionDetails(arg0);
+			expect(res).to.be.an('object');
+		});
+
+		it('call func updateCategory with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await ProposalCategory.new();
+			const arg0 = "15915375746220197535307861210154267709992629832189783496718704893643190016849";
+			const arg1 = "'dXp2xhCO5RiTQ7,NXp?4q2&{sHojra5T@'";
+			const arg2 = "48409311612675681723271481581346780700788063076202390866808528706711122031924";
+			const arg3 = "79065795043073223208899600811227064245672722556924226008253167069558662380413";
+			const arg4 = "82373502831103736070969826842172820180929189347818594807327307032317314248775";
+			const arg5 = ["27581206365086977431423440485739504911680675485945170243497798611501780565395"];
+			const arg6 = "22799325553842856143403236183161326357594552968154374609975245795546383885029";
+			const arg7 = "'Nd|OSG.2H<{Vs@Q*2Sf\\&uf]\\2B>?\"'";
+			const arg8 = "0x51793b07bbcba815f9145c918f57d4785594eac3";
+			const arg9 = "0x715d";
+			const arg10 = ["40090002867912816893605260993360413765923626591658615131123056133320114486474"];
+			await assertRevert(obj.updateCategory(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10));
+		});
+
+		it('call func changeDependentContractAddress with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await ProposalCategory.new();
+			await assertRevert(obj.changeDependentContractAddress());
+		});
+
+		it('call func updateCategoryActionHashes with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await ProposalCategory.new();
+			await assertRevert(obj.updateCategoryActionHashes());
+		});
+
+		it('call func editCategory with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await ProposalCategory.new();
+			const arg0 = "42671250279046160478439283899919407243810362288855142966353115514798559409241";
+			const arg1 = "'a3GFZ?3(]R&%%YPUI\\RQz!k&\"Lxb6[#3@7vz/9so/jO:m{<A//rsH-W@xyxiKQMQu76W^/>3:R=iuBxgQWktE&9\\vTRgRO:dWe\'*X+$iaB5l\\2U%5=|,qF3\"},6ID!:9.[:\\s;n35S=eRuJnQ0<{(K68,A![V^h{1os391)ZWNw\\zxUNO/)\\.>TVnDB{fee=,8v7W`b]f_Eqznm(Ld^q0FZ+-p.D*t}_YzmPf/[8\\5=`Nmr7R:a]$wk{?,-%,4'";
+			const arg2 = "6309147637073544705810611038904640567610564514852652982032069356426826840480";
+			const arg3 = "100125165220128772543471005587644607109118100394908713046005251435892424546700";
+			const arg4 = "6895940240575534146462917710640085588075616044711404592568935350908509084015";
+			const arg5 = ["40191265789076768176929878235911781463442365792996504210992292253727599247397"];
+			const arg6 = "111038329556809900177636882438475780000358998091710423343449034734330923483828";
+			const arg7 = "'^Lk10}*2)YKpnX0qP\':L?1cbWcMeeu+FCz\"hL_t(o+C67.=\\6Cx!:iM/p@j]PZCbhoZg.z+RA-^Aet&wZ0!o#N!qm=:[XKFhN8L90H ]+|_]2`lQ| `Nk)-<w8m6>f7\"NC%h7i{:+](^Tg6.(,S!}|TmWGTCJah4``\"]g'";
+			const arg8 = "0xcc2e9676d395527778a2bb2e4d99bd5c2f6100bc";
+			const arg9 = "0x2830";
+			const arg10 = ["50355390320575279624753653839197592986624812066653042647585405070184592461296"];
+			const arg11 = "'(=&rq e=!K*&c9b<|`>;bZCd\"IW(mY%([-;B:vq%X>1RW<<2-8%8Pto@iv{g:!ALvj-P?;yikC\"4{/z?t|HGA_HLXBs$lz}j,:rG/{67zW(BwM>Lj'";
+			await assertRevert(obj.editCategory(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11));
+		});
+
+		it('call func nxMasterAddress with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await ProposalCategory.new();
+			const res = await obj.nxMasterAddress();
+			res.toString().should.be.equal("0x0000000000000000000000000000000000000000");
+		});
+
+		it('call func isAuthorizedToGovern with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await ProposalCategory.new();
+			const arg0 = "0xacd7a4120df8cd18d3c94381f8dc491f010eadff";
+			await assertRevert(obj.isAuthorizedToGovern(arg0));
+		});
+
+		it('call func changeMasterAddress with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await ProposalCategory.new();
+			const arg0 = "0x392dc6e0c72d15d1b85805110146329583890382";
+			const res = await obj.changeMasterAddress(arg0);
+			expect(res).to.be.an('object');
+		});
+
+		it('call func categoryAction with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await ProposalCategory.new();
+			const arg0 = "71023468484266488792179545401608707891785454266371222432088055519588964326752";
+			const res = await obj.categoryAction(arg0);
+			expect(res).to.be.an('object');
+		});
+
+		it('call func addCategory with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await ProposalCategory.new();
+			const arg0 = "'Od{%Z9 zE>z\"LV{Zk\'zn|5tx5mAdETeDJV\\6QS tIR`P[Xa^h/W>rQG(@nA:nYVhZ#%Nc7*05;?ZYy4`\\:/\"Bnx1nE$jX;7kc;|DP)v|y_S:T?7R\":lJ#]y07nwp.RW!6?\'qgm'";
+			const arg1 = "34819646285261695191271858605740429270451880012910389957639327780579170255075";
+			const arg2 = "114819555288392204206169326330006776521835960179865219475152175703888186026551";
+			const arg3 = "68298175578665017992506543850789053649021169194023577304791937122897673119366";
+			const arg4 = ["111664144184234896553689924935881583702231399793401481728146392930888208107656"];
+			const arg5 = "20690083980496984530171210853898545520857453361951854837356954368619736344212";
+			const arg6 = "\"+9vRj=ugu&o&c7_O}'75flsuCK-%#KJ.BXA[&BY$x5_>WM1s5mIUG[RPGJ((hII3BdtD#pytIesFHN_!t}AM4Of7AjzD0[(rLB9P1e##YLkoa@J<(?FA0<)<Au293^=;WA^]Udy>C(rt,WtNci8S%tLLxmn+DKr<Xk?PHDw5rPa5%=38pTFw;QZX;TYNz>e:9_K&<:[h8ooE\"";
+			const arg7 = "0x43babfea9ddf63fcd54a58f9cd727375ca76fc02";
+			const arg8 = "0xc95b";
+			const arg9 = ["42215792641224869247018921109812386776346989806260912055599316395032687125731"];
+			await assertRevert(obj.addCategory(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9));
+		});
+
+	});
+});

--- a/test/45_ProposalCategoryMock.firefly.test.js
+++ b/test/45_ProposalCategoryMock.firefly.test.js
@@ -1,0 +1,31 @@
+// This is the automatically generated test file for contract: ProposalCategoryMock
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const ProposalCategoryMock = artifacts.require('ProposalCategoryMock');
+const {assertRevert} = require('./utils/assertRevert');
+
+contract('ProposalCategoryMock', (accounts) => {
+	// Coverage imporvement tests for ProposalCategoryMock
+	describe('ProposalCategoryMockBlackboxTest', () => {
+		it('call func nxMasterAddress with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await ProposalCategoryMock.new();
+			const res = await obj.nxMasterAddress();
+			res.toString().should.be.equal("0x0000000000000000000000000000000000000000");
+		});
+
+		it('call func isAuthorizedToGovern with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await ProposalCategoryMock.new();
+			const arg0 = "0x92cb65639807e2c11ab243f2a4ce17141dd94068";
+			await assertRevert(obj.isAuthorizedToGovern(arg0));
+		});
+
+	});
+});

--- a/test/46_Quotation.firefly.test.js
+++ b/test/46_Quotation.firefly.test.js
@@ -1,0 +1,58 @@
+// This is the automatically generated test file for contract: Quotation
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const Quotation = artifacts.require('Quotation');
+const {assertRevert} = require('./utils/assertRevert');
+const {assertInvalid} = require('./utils/assertInvalid');
+
+contract('Quotation', (accounts) => {
+	// Coverage imporvement tests for Quotation
+	describe('QuotationBlackboxTest', () => {
+		it('call func expireCover with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await Quotation.new();
+			const arg0 = "45245043694169641572197862589718334685367534174665645512775708849586664198615";
+			await assertRevert(obj.expireCover(arg0));
+		});
+
+		it('call func verifySign with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await Quotation.new();
+			const arg0 = ["38736900509558466448668448007376309605176426642541642521782009608738865358027"];
+			const arg1 = "62483";
+			const arg2 = "0x68ccfe39";
+			const arg3 = "0x1e9e26f4bdba7f589c0e21fa084632390e3f7284";
+			const arg4 = "240";
+			const arg5 = "0x4cad47fa832b08ecfe018b6ffd965bf87175c7bf69814141b355b58fe0082992";
+			const arg6 = "0x9d868a6f0337aa57754b189f9f3be6350ac5e3474a919886d90e605428a803fd";
+			await assertRevert(obj.verifySign(arg0, arg1, arg2, arg3, arg4, arg5, arg6));
+		});
+
+		it('call func getOrderHash with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await Quotation.new();
+			const arg0 = ["60602065396742230480688081058347384944091887782185106323341322608008949154112"];
+			const arg1 = "23899";
+			const arg2 = "0x16a0e65b";
+			const arg3 = "0x64573e7a023f619cdd011b304f90196788f92f59";
+			await assertInvalid(obj.getOrderHash(arg0, arg1, arg2, arg3));
+		});
+
+		it('call func isValidSignature with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await Quotation.new();
+			const arg0 = "0xb74216c1ec5e1f7f1f8c9e7ef428dd1fc1d76bf6ebeafdca9e2d55acf079b660";
+			const arg1 = "224";
+			const arg2 = "0x61db2e1e59004c0f7f14aaf363b9085c1b54dce9d0d1243f208113ce1a462728";
+			const arg3 = "0xe1b3eb9ffac20b3bcad307e006e8f0aa5ecb56731f5586dadcd89c12becd4238";
+			await assertRevert(obj.isValidSignature(arg0, arg1, arg2, arg3));
+		});
+
+	});
+});

--- a/test/47_QuotationDataMock.firefly.test.js
+++ b/test/47_QuotationDataMock.firefly.test.js
@@ -1,0 +1,59 @@
+// This is the automatically generated test file for contract: QuotationDataMock
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const QuotationDataMock = artifacts.require('QuotationDataMock');
+const {assertRevert} = require('./utils/assertRevert');
+const {assertInvalid} = require('./utils/assertInvalid');
+
+
+contract('QuotationDataMock', (accounts) => {
+	// Coverage imporvement tests for QuotationDataMock
+	describe('QuotationDataMockBlackboxTest', () => {
+		it('call func changeHoldedCoverPeriod with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await QuotationDataMock.new("0x96c25e69b2230267f107205d2e6e17959360dd35", "0x66509cf6ec47573263e22fbbfc72bb640ac821d7");
+			const arg0 = "66797225639873292688933947225741191736771951293467450948367372144234769446338";
+			const arg1 = "55721";
+			await assertInvalid(obj.changeHoldedCoverPeriod(arg0, arg1));
+		});
+
+		it('call func coverStatus with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await QuotationDataMock.new("0x02407817b6e352f0d7edd1d8ba405efb04ecddc9", "0xbcd6749a0d9fe759d8df106beee9e1549456f8c1");
+			const arg0 = "3759526765800819666104847515867474755443368950887155999660821587165581145160";
+			const res = await obj.coverStatus(arg0);
+			res.toString().should.be.equal("0");
+		});
+
+		it('call func changeInvestmentAssetAddress with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await QuotationDataMock.new("0x7facfd2000baae598d98d8b7390520218ee509de", "0x2c52d4d704a3a687389575e63244757cc10bd98d");
+			const arg0 = "0x313cd360";
+			const arg1 = "0xe7e2ea2bc80749aedaaff256ac4d0e2aae673eb1";
+			await assertRevert(obj.changeInvestmentAssetAddress(arg0, arg1));
+		});
+
+		it('call func userHoldedCover with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await QuotationDataMock.new("0xcdd8185938b892d61d6dc13c3e0240f14fe5cf8f", "0x6c2bd1861cf346a2ef674882a1b8246bdc549b58");
+			const arg0 = "0x9a12465c54ecfcc757359f9054848c8c2225f55b";
+			const arg1 = "49118743821803900844471807208247845013074043708788723347358151310687570457734";
+			await assertInvalid(obj.userHoldedCover(arg0, arg1));
+		});
+
+		it('call func changeCurrencyAssetAddress with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await QuotationDataMock.new("0x40000ddc2d9140f4c8e90e3f809d17ac216d3e54", "0x3a647548076cbb6b6bd7611ab3270a64d408a054");
+			const arg0 = "0x261abb9b";
+			const arg1 = "0xc0e8346f6729876b9bad5dd80893cc7d83c2228e";
+			await assertRevert(obj.changeCurrencyAssetAddress(arg0, arg1));
+		});
+
+	});
+});

--- a/test/48_TokenController.firefly.test.js
+++ b/test/48_TokenController.firefly.test.js
@@ -1,0 +1,33 @@
+// This is the automatically generated test file for contract: TokenController
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const TokenController = artifacts.require('TokenController');
+const {assertRevert} = require('./utils/assertRevert');
+
+contract('TokenController', (accounts) => {
+	// Coverage imporvement tests for TokenController
+	describe('TokenControllerBlackboxTest', () => {
+		it('call func operatorTransfer with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenController.new();
+			const arg0 = "0xbd29c2fd6fd63db51b6891419ced098d2deac4fa";
+			const arg1 = "0x25072718fdb5dd92c9abff34ee56dd0ac99b945b";
+			const arg2 = "35012473037026861661261321358651369094824671792642583269799540381825844739647";
+			await assertRevert(obj.operatorTransfer(arg0, arg1, arg2));
+		});
+
+		it('call func pooledStaking with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenController.new();
+			const res = await obj.pooledStaking();
+			res.toString().should.be.equal("0x0000000000000000000000000000000000000000");
+		});
+
+	});
+});

--- a/test/49_TokenDataMock.firefly.test.js
+++ b/test/49_TokenDataMock.firefly.test.js
@@ -1,0 +1,250 @@
+// This is the automatically generated test file for contract: TokenDataMock
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const TokenDataMock = artifacts.require('TokenDataMock');
+const {assertRevert} = require('./utils/assertRevert');
+const {assertInvalid} = require('./utils/assertInvalid');
+
+contract('TokenDataMock', (accounts) => {
+	// Coverage imporvement tests for TokenDataMock
+	describe('TokenDataMockBlackboxTest', () => {
+		it('call func pushUnlockableBeforeLastBurnTokens with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenDataMock.new("0x809c9cd4152a0eed837f554a15b50a10a6b5c484");
+			const arg0 = "0x08ed37cab1ced264be49e120307bcf01f502b048";
+			const arg1 = "565355103927223478371306396517062995051802743141233933225593509693188946290";
+			const arg2 = "28559367771620761262783162964650049896738024522747517447826872277866996735670";
+			await assertRevert(obj.pushUnlockableBeforeLastBurnTokens(arg0, arg1, arg2));
+		});
+
+		it('call func setLastCompletedStakeCommissionIndex with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenDataMock.new("0xf3b234075f40bd73a4b015eb1fe1eee1663e4d76");
+			const arg0 = "0xbe52de5a02cefd10a1f4a07e4aa5c5955cbc184b";
+			const arg1 = "35705552743728425182149078288036583962878706546623121257207831892566511497279";
+			await assertRevert(obj.setLastCompletedStakeCommissionIndex(arg0, arg1));
+		});
+
+		it('call func setUnlockableBeforeLastBurnTokens with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenDataMock.new("0xbc627b0ffde5dadab2147b956ab4d6352582aa19");
+			const arg0 = "0xb9a2ab900e6e72b5fe82972f29fb4b8ff44c93c9";
+			const arg1 = "75755292152084597661195464800208573116379766415773610248311076623488170045091";
+			const arg2 = "108116049175541183645101649312009467108218144978663464808374657455702449827397";
+			await assertRevert(obj.setUnlockableBeforeLastBurnTokens(arg0, arg1, arg2));
+		});
+
+		it('call func stakedContractCurrentBurnIndex with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenDataMock.new("0x4b395dc16fa65d2c9baee0d914d189bd1c070381");
+			const arg0 = "0xef62692bd83266ad2f12b79495a7e083f9cbea5d";
+			const res = await obj.stakedContractCurrentBurnIndex(arg0);
+			res.toString().should.be.equal("0");
+		});
+
+		it('call func getStakedContractStakerByIndex with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenDataMock.new("0xd86ebcde617c87f8a5676c14b7e5facb69761543");
+			const arg0 = "0x20f8835d634dfe675c26fcb0dabfa4a892f1353a";
+			const arg1 = "82296449572580137360628407226380988668890692340029243416661056241455819866112";
+			await assertInvalid(obj.getStakedContractStakerByIndex(arg0, arg1));
+		});
+
+		it('call func pushRedeemedStakeCommissions with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenDataMock.new("0x5d39460acfa59a555bc6155d4439c6a8eebec065");
+			const arg0 = "0x835be35b72f405c55e9f40f8cc1f41948fd4a59b";
+			const arg1 = "74141587928406929212254956017059318280983351957300721747189786490345150817623";
+			const arg2 = "88745951205852450748270559488883904989576114368483095949050833422116910668028";
+			await assertRevert(obj.pushRedeemedStakeCommissions(arg0, arg1, arg2));
+		});
+
+		it('call func getStakedContractStakersLength with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenDataMock.new("0x9d40b1008fefff21403745b794ec1e2758437355");
+			const arg0 = "0x851a7a3acbe12c32beaa3f7f3ba60b288c28e96b";
+			const res = await obj.getStakedContractStakersLength(arg0);
+			res.toString().should.be.equal("0");
+		});
+
+		it('call func pushEarnedStakeCommissions with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenDataMock.new("0x7c359041ee2c507f8169db9f0020ccd72d18b45d");
+			const arg0 = "0xdbf2331e1944b4146bbb6a3858aac9d50c42c156";
+			const arg1 = "0xb0a0eba74b4b5f894f16110d5cf1b6ad2241d3b7";
+			const arg2 = "47888026508284659329967600250826540518152187838991892202721633397516600261869";
+			const arg3 = "93260874223523559218292380673116666316520281460469789324076655889267881304833";
+			await assertRevert(obj.pushEarnedStakeCommissions(arg0, arg1, arg2, arg3));
+		});
+
+		it('call func getStakerStakedBurnedByIndex with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenDataMock.new("0xe7957ed79e3abd64e65d19e5c85b1122d1b27bfb");
+			const arg0 = "0x590a7393735b12a7b9fbd47819adf085bf2ceb04";
+			const arg1 = "39806311060973886843250868264996718258772629485515121472426575411437320975301";
+			await assertInvalid(obj.getStakerStakedBurnedByIndex(arg0, arg1));
+		});
+
+		it('call func lastCompletedStakeCommission with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenDataMock.new("0x5c1560a145cd8d9eac928d5b8d17c0bd53388267");
+			const arg0 = "0xd0b4824d378983a0a310e1d6845919a984684926";
+			const res = await obj.lastCompletedStakeCommission(arg0);
+			res.toString().should.be.equal("0");
+		});
+
+		it('call func bookTime with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenDataMock.new("0x51b679c1bb103f22f37c339a6178643e25c85c9d");
+			const res = await obj.bookTime();
+			res.toString().should.be.equal("60");
+		});
+
+		it('call func getStakerEarnedStakeCommission with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenDataMock.new("0xf6a39d84f7d43887570a2795771106b96f05799f");
+			const arg0 = "0x1947668864cae5ac6917f7d4fe028dd98e923519";
+			const arg1 = "77482676761836510942014948444887398049997662772790119427010840175829116509337";
+			await assertInvalid(obj.getStakerEarnedStakeCommission(arg0, arg1));
+		});
+
+		it('call func stakerStakedContracts with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenDataMock.new("0x0d39d2f131821f95d82492e5c2f1bee8b7f5a6c4");
+			const arg0 = "0x08f23e131cbba7eb59ea9c65d7bf1cca97f53907";
+			const arg1 = "39132478568696480716039595101719675434520789984725259816351212457992588724682";
+			await assertInvalid(obj.stakerStakedContracts(arg0, arg1));
+		});
+
+		it('call func getStakerStakedContractByIndex with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenDataMock.new("0x113700780de81a8e51c95feca46a558f139f4913");
+			const arg0 = "0x74262eb784d1986ef8fa3efd55e9ab87eabffabe";
+			const arg1 = "35123064605399714224181972945495942205215307931509466875316013014097366647441";
+			await assertInvalid(obj.getStakerStakedContractByIndex(arg0, arg1));
+		});
+
+		it('call func getStakerStakedContractIndex with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenDataMock.new("0x2deb86b971ff1393953a197d5bdec553d95288d8");
+			const arg0 = "0xf57cba27094350dabd42532b37db776a244823a8";
+			const arg1 = "114217611193792911712363909399650152265200892455240038611659372375215113848679";
+			await assertInvalid(obj.getStakerStakedContractIndex(arg0, arg1));
+		});
+
+		it('call func updateUintParameters with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenDataMock.new("0x23f7058ca32898868a2d4918ff92bf730610b0b7");
+			const arg0 = "0x992c558600159986";
+			const arg1 = "69821730503560024802663140585764847717026904669745770024988508086667474562526";
+			await assertRevert(obj.updateUintParameters(arg0, arg1));
+		});
+
+		it('call func getStakerTotalReedmedStakeCommission with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenDataMock.new("0x771c5932895eb029099d95f0ae8438a26bfc30b2");
+			const arg0 = "0x5b9327e56d3119f246b7fca95e696a93ca891543";
+			const res = await obj.getStakerTotalReedmedStakeCommission(arg0);
+			res.toString().should.be.equal("0");
+		});
+
+		it('call func addStake with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenDataMock.new("0xcd35cbb381a404ef1c6100a37ab907133a092361");
+			const arg0 = "0xe92fa6e759bba4e9c84fbf8746aec75a36483310";
+			const arg1 = "0x67b47cf7f60bc48078fc0d79d137b514743781c3";
+			const arg2 = "21151066223425617746222461087210858873406125403658500613883792460739061740699";
+			await assertRevert(obj.addStake(arg0, arg1, arg2));
+		});
+
+		it('call func stakedContractStakeCommission with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenDataMock.new("0xb6b2563622c0fcb002141320808fb6f8755ae54f");
+			const arg0 = "0xc7468df6ddfaa52ffe884a9be7ec17128d416e9b";
+			const arg1 = "34519157755216046290510261378009617394069695158518009610992388373384324093729";
+			const res = await obj.stakedContractStakeCommission(arg0, arg1);
+			expect(res).to.be.an('object');
+		});
+
+		it('call func pushBurnedTokens with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenDataMock.new("0xa0ddf253aeebea9fe66dc68853e56e8255f63d3e");
+			const arg0 = "0x8fe2a27c31d28cefcf4da8ea77666c284ccd9a90";
+			const arg1 = "48043874534688548800704778295282529762169397544142854562758650739492596444837";
+			const arg2 = "44387408384046600272368205732790838229495903916544795782844115465803067226507";
+			await assertRevert(obj.pushBurnedTokens(arg0, arg1, arg2));
+		});
+
+		it('call func stakedContractStakers with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenDataMock.new("0xfc6fb383d7f0a2f959e8a438cee33c93cc1cb323");
+			const arg0 = "0x5f4faaa97235c1f15528b41186aa0b41eb6cf61e";
+			const arg1 = "13432512988405259883459207855384045929874133683474818104772574383657294526709";
+			await assertInvalid(obj.stakedContractStakers(arg0, arg1));
+		});
+
+		it('call func setStakedContractCurrentCommissionIndex with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenDataMock.new("0xf4f33c550e9bb8ae10c630d22e825bbd30ba48b0");
+			const arg0 = "0x8ddbd5502075aa51f5734a9d96b6e4f050f28d50";
+			const arg1 = "73567578842980781321913543035467716932195053654651755739188668666765822811945";
+			await assertRevert(obj.setStakedContractCurrentCommissionIndex(arg0, arg1));
+		});
+
+		it('call func getStakerTotalEarnedStakeCommission with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenDataMock.new("0x41545b018481b0ec394ed4276aea76503b848386");
+			const arg0 = "0x3ac5b521c4becad6409cc80628016bef3e9487e2";
+			const res = await obj.getStakerTotalEarnedStakeCommission(arg0);
+			res.toString().should.be.equal("0");
+		});
+
+		it('call func getStakerRedeemedStakeCommission with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenDataMock.new("0x2657a1cdde468045c9e8ad7dda07df1838942fe2");
+			const arg0 = "0x9f205e7c31694b0b88c18347279a6292594b7f42";
+			const arg1 = "84529025126007525583659571334626795969197180093180913257307759700503122867685";
+			await assertInvalid(obj.getStakerRedeemedStakeCommission(arg0, arg1));
+		});
+
+		it('call func stakedContractCurrentCommissionIndex with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenDataMock.new("0xa81365d2d388ff665890154254d58e171b7122b8");
+			const arg0 = "0xa761395dd5566e23adb88213640ae274acbbf21e";
+			res = await obj.stakedContractCurrentCommissionIndex(arg0);
+			res.toString().should.be.equal("0");
+		});
+
+		it('call func getStakerStakedUnlockableBeforeLastBurnByIndex with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenDataMock.new("0x13c101d7b8281030dcea41573bd696c84b5007b1");
+			const arg0 = "0x99566251835695b575cfc1348e387e78b48c79b1";
+			const arg1 = "81668157720265931093596367469548898389515106832776565544487842027757133553230";
+			await assertInvalid(obj.getStakerStakedUnlockableBeforeLastBurnByIndex(arg0, arg1));
+		});
+
+		it('call func pushUnlockedStakedTokens with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenDataMock.new("0xdacd2af566a0a4530fc2e1202c10c414d9a79bc9");
+			const arg0 = "0x18656bb2818d08fe5cfff5a5e24b1976c86b9197";
+			const arg1 = "108208937485365496076117588751163695800589805965899041371395983348902519024864";
+			const arg2 = "94433698679589020104913348919546636263078548953100804369252386289816627906305";
+			await assertRevert(obj.pushUnlockedStakedTokens(arg0, arg1, arg2));
+		});
+
+		it('call func setStakedContractCurrentBurnIndex with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenDataMock.new("0x965cd10c81927fd60d2bed08657848ac3de00483");
+			const arg0 = "0x738efc7145b9e67be9d456728b28d8ce43cc2bba";
+			const arg1 = "52883991494109930140477702287634513153982563750086610118141600713093149107083";
+			await assertRevert(obj.setStakedContractCurrentBurnIndex(arg0, arg1));
+		});
+
+	});
+});

--- a/test/50_TokenFunctionMock.firefly.test.js
+++ b/test/50_TokenFunctionMock.firefly.test.js
@@ -1,0 +1,96 @@
+// This is the automatically generated test file for contract: TokenFunctionMock
+// Other libraries might be imported here
+
+const fs = require('fs');
+const BigNumber = web3.BigNumber;
+require('chai')
+.use(require('chai-bignumber')(BigNumber))
+.should();
+
+const TokenFunctionMock = artifacts.require('TokenFunctionMock');
+const {assertRevert} = require('./utils/assertRevert');
+
+contract('TokenFunctionMock', (accounts) => {
+	// Coverage imporvement tests for TokenFunctionMock
+	describe('TokenFunctionMockBlackboxTest', () => {
+		it('call func deprecated_getStakerAllLockedTokens with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenFunctionMock.new();
+			const arg0 = "0x3829800571842d3bb7bd9bcd06fca39eb59b6a13";
+			await assertRevert(obj.deprecated_getStakerAllLockedTokens(arg0));
+		});
+
+		it('call func tk with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenFunctionMock.new();
+			const res = await obj.tk();
+			res.toString().should.be.equal("0x0000000000000000000000000000000000000000");
+		});
+
+		it('call func deprecated_getStakerUnlockableTokensOnSmartContract with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenFunctionMock.new();
+			const arg0 = "0x20395473f65471b6b7f89bb0b6c2e476be063b53";
+			const arg1 = "0x674f6f940a99d63208e938e3b4b0d7bd3481a4e8";
+			const arg2 = "84390122486368301964549245459137217502142817659927988528524318625217503214512";
+			await assertRevert(obj.deprecated_getStakerUnlockableTokensOnSmartContract(arg0, arg1, arg2));
+		});
+
+		it('call func deprecated_getStakerLockedTokensOnSmartContract with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenFunctionMock.new();
+			const arg0 = "0x0c91da1f6c41cf07e397fc2e3f5740b6aab5e1a0";
+			const arg1 = "0xf7caa41f8c80d22c9f47e4774ceb28bb87f708f6";
+			const arg2 = "18719034237583232813707961207380275763413782883894944796636194387092192894035";
+			await assertRevert(obj.deprecated_getStakerLockedTokensOnSmartContract(arg0, arg1, arg2));
+		});
+
+		it('call func _deprecated_getStakerUnlockableTokensOnSmartContract with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenFunctionMock.new();
+			const arg0 = "0x58ada0c01d1795ee9c98c9c756e1008efa2c02ce";
+			const arg1 = "0x1d486d326d5f4b06306983622d7bf34b349805c0";
+			const arg2 = "83767493624892200611650731092623794994976922433541733217564602508321314423780";
+			await assertRevert(obj._deprecated_getStakerUnlockableTokensOnSmartContract(arg0, arg1, arg2));
+		});
+
+		it('call func _deprecated_unlockableBeforeBurningAndCanBurn with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenFunctionMock.new();
+			const arg0 = "0x3e70b67262a6e0b9c1128dcb3f7886f579dfae49";
+			const arg1 = "0x5f676cb91a0d0671ba795f3d0b97ac866f5b9cb3";
+			const arg2 = "99912182287178481981829372837140991758512634857869518111112957120836258532079";
+			await assertRevert(obj._deprecated_unlockableBeforeBurningAndCanBurn(arg0, arg1, arg2));
+		});
+
+		it('call func deprecated_getStakerAllUnlockableStakedTokens with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenFunctionMock.new();
+			const arg0 = "0xd1056b702127f42be4c6f03b981ea3ec19e04942";
+			await assertRevert(obj.deprecated_getStakerAllUnlockableStakedTokens(arg0));
+		});
+
+		it('call func changeMasterAddress with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenFunctionMock.new();
+			const arg0 = "0xa40d2bcdd5b1f8ed88b1ae0a8c94aee3cff2cdec";
+			const res = await obj.changeMasterAddress(arg0);
+			expect(res).to.be.an('object');
+		});
+
+		it('call func deprecated_getTotalStakedTokensOnSmartContract with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenFunctionMock.new();
+			const arg0 = "0xf98174f516ad339d2bddd7bd93e0fdf3e97eb678";
+			await assertRevert(obj.deprecated_getTotalStakedTokensOnSmartContract(arg0));
+		});
+
+		it('call func deprecated_unlockStakerUnlockableTokens with blackbox random args', async () => {
+			// Might adjust constructor accordingly
+			const obj = await TokenFunctionMock.new();
+			const arg0 = "0xafd18e369774406b18e94a865cd676b3d3d78097";
+			await assertRevert(obj.deprecated_unlockStakerUnlockableTokens(arg0));
+		});
+
+	});
+});

--- a/test/utils/assertInvalid.js
+++ b/test/utils/assertInvalid.js
@@ -1,0 +1,17 @@
+async function assertInvalid(promise) {
+    try {
+      await promise;
+      throw null;
+    } catch (error) {
+      assert(error, `Expected an error but did not get one`);
+      assert(
+        error.message.includes('invalid') || error.message.includes('INVALID'),
+        `Expected an error containing "invalid" but got "${error.message}" instead`
+      );
+    }
+  }
+  
+  module.exports = {
+    assertInvalid
+  };
+  


### PR DESCRIPTION
This is a PR from Runtime Verification (https://runtimeverification.com), the developers of the Firefly tool (https://fireflyblockchain.com). We work in smart contract quality assurance, and have been working on the Firefly tool as an automated health-check and augmentation of users test-suites (https://fireflyblockchain.com/about.html).

We ran our tool on this repository, and found several places where there was low bytecode coverage. These additional tests were added by looking at those spots of low coverage and trying to improve them. We selected this repository in response to the search for bugs that Nexus Mutual has mounted via the Bug Bounty program: https://medium.com/nexus-mutual/announcing-the-first-nexus-mutual-bug-bounty-d16360dfe72

Here is the bytecode-level coverage report before: https://fireflyblockchain.com/app/report.html?reportId=9ad8e284-903a-4fea-b2da-fd15fba9c843,
and after: https://fireflyblockchain.com/app/report.html?reportId=e484504c-404d-4e26-a1ec-51db208d2bc2.

Here is a sample coverage report with a tour for explaining how to view them: https://fireflyblockchain.com/app/report.html?reportId=00000000-0000-0000-0000-000000000000.

In particular, you'll see that the coverage improves over the following contracts in this repository:

```
Claims:                     88
ClaimsDataMock:             91 -> 93
ClaimsReward:               77 -> 79
ExchangeMock:               86 -> 88
FactoryMock:                74 -> 91
Governance:                 40 -> 56
GovernanceMock:             90 -> 92
MCR:                        88 -> 89
MemberRoles:                84 -> 86
Migrations:                 25 -> 60
MockDAI:                    44 -> 89
MockMKR:                    45 -> 92
NXMDSValueMock:             69 -> 88
NXMToken:                   89 -> 95
NXMaster:                   57 -> 66
NXMasterMock:               73 -> 77
NewDataInternalContract:    71 -> 88
NewInternalContract:        71 -> 88
NewProxyInternalContract:   71 -> 77
OwnedUpgradeabilityProxy:   90 -> 91
Pool1Mock:                  80 -> 86
Pool2:                      87 -> 88
PoolDataMock:               91 -> 93
PooledStakingMock:          49 -> 57
ProposalCategory:           35 -> 58
ProposalCategoryMock:       90 -> 92
Quotation:                  82 -> 86
QuotationDataMock:          83 -> 92
TokenController:            87 -> 89
TokenDataMock:              29 -> 68
TokenFunctionMock:          58 -> 70
```

Note that Firefly measures bytecode coverage, not Solidity-line coverage, which several other tools measure. This means that when another tool may report full coverage, our tool will still consider some of the line-internal branches uncovered, which may explain some of the lower coverage numbers you see.