### PR TITLE
Add pause modifiers to functions in assessment contracts

### DIFF
--- a/contracts/mocks/Assessment/ASMockIndividualClaims.sol
+++ b/contracts/mocks/Assessment/ASMockIndividualClaims.sol
@@ -18,11 +18,10 @@ contract ASMockIndividualClaims is MasterAwareV2 {
     token = INXMToken(tokenAddress);
   }
 
-  function initialize(address masterAddress) external {
+  function initialize() external {
     // The minimum cover premium per year is 2.6%. 20% of the cover premium is: 2.6% * 20% = 0.52%
     config.rewardRatio = 130; // 0.52%
     config.minAssessmentDepositRatio = 500; // 5% i.e. 0.05 ETH submission flat fee
-    master = INXMMaster(masterAddress);
   }
 
   function assessment() internal view returns (IAssessment) {

--- a/contracts/mocks/Assessment/ASMockYieldTokenIncidents.sol
+++ b/contracts/mocks/Assessment/ASMockYieldTokenIncidents.sol
@@ -20,11 +20,10 @@ contract ASMockYieldTokenIncidents is MasterAwareV2 {
 
   Configuration public config;
 
-  function initialize(address masterAddress) external {
+  function initialize() external {
     // The minimum cover premium per year is 2.6%. 20% of the cover premium is: 2.6% * 20% = 0.52%
     config.rewardRatio = 52; // 0.52%
     config.expectedPayoutRatio = 3000; // 30%
-    master = INXMMaster(masterAddress);
   }
 
   function assessment() internal view returns (IAssessment) {

--- a/contracts/modules/v2/CoverMigrator.sol
+++ b/contracts/modules/v2/CoverMigrator.sol
@@ -24,7 +24,7 @@ contract CoverMigrator is MasterAwareV2 {
   /// @dev Migrates covers for arNFT-like contracts that don't use Gateway.sol
   ///
   /// @param coverId          Legacy (V1) cover identifier
-  function submitClaim(uint coverId) external {
+  function submitClaim(uint coverId) external whenNotPaused {
     cover().migrateCoverFromOwner(coverId, msg.sender, tx.origin);
   }
 

--- a/contracts/modules/v2/YieldTokenIncidents.sol
+++ b/contracts/modules/v2/YieldTokenIncidents.sol
@@ -48,14 +48,25 @@ contract YieldTokenIncidents is IYieldTokenIncidents, MasterAwareV2 {
     coverNFT = ICoverNFT(coverNFTAddress);
   }
 
-  function initialize(address masterAddress) external {
+  function initialize() external {
+    Configuration memory currentConfig = config;
+    bool notInitialized = bytes32(
+      abi.encodePacked(
+        currentConfig.rewardRatio,
+        currentConfig.expectedPayoutRatio,
+        currentConfig.payoutDeductibleRatio,
+        currentConfig.payoutRedemptionPeriodInDays,
+        currentConfig.maxRewardInNXMWad
+      )
+    ) == bytes32(0);
+    require(notInitialized, "Already initialized");
+
     // The minimum cover premium per year is 2.6%. 20% of the cover premium is: 2.6% * 50% = 1.30%
     config.rewardRatio = 130; // 1.3%
     config.expectedPayoutRatio = 3000; // 30%
     config.payoutDeductibleRatio = 9000; // 90%
     config.payoutRedemptionPeriodInDays = 14; // days
     config.maxRewardInNXMWad = 50; // 50 NXM
-    master = INXMMaster(masterAddress);
   }
 
   /* ========== VIEWS ========== */
@@ -146,7 +157,7 @@ contract YieldTokenIncidents is IYieldTokenIncidents, MasterAwareV2 {
     uint32 date,
     uint expectedPayoutInNXM,
     string calldata ipfsMetadata
-  ) external onlyAdvisoryBoard override {
+  ) external override onlyAdvisoryBoard whenNotPaused {
     ICover coverContract = cover();
     Incident memory incident = Incident(
       0, // assessmentId
@@ -193,7 +204,7 @@ contract YieldTokenIncidents is IYieldTokenIncidents, MasterAwareV2 {
     uint depeggedTokens,
     address payable payoutAddress,
     bytes calldata optionalParams
-  ) external override returns (uint, uint8) {
+  ) external override whenNotPaused returns (uint, uint8) {
     require(
       coverNFT.isApprovedOrOwner(msg.sender, coverId),
       "Only the cover owner or approved addresses can redeem"
@@ -299,7 +310,11 @@ contract YieldTokenIncidents is IYieldTokenIncidents, MasterAwareV2 {
   /// @param asset        The ERC20 address of the asset that needs to be withdrawn.
   /// @param destination  The address where the assets are transfered.
   /// @param amount       The amount of assets that are need to be transfered.
-  function withdrawAsset(address asset, address destination, uint amount) external onlyGovernance {
+  function withdrawAsset(
+    address asset,
+    address destination,
+    uint amount
+  ) external onlyGovernance {
     IERC20 token = IERC20(asset);
     uint balance = token.balanceOf(address(this));
     uint transferAmount = amount > balance ? balance : amount;

--- a/test/unit/Assessment/index.js
+++ b/test/unit/Assessment/index.js
@@ -12,6 +12,7 @@ describe('Assessment', function () {
     await revertToSnapshot(this.snapshotId);
   });
 
+  require('./initialize');
   require('./stake');
   require('./unstake');
   require('./getRewards');

--- a/test/unit/Assessment/initialize.js
+++ b/test/unit/Assessment/initialize.js
@@ -1,0 +1,8 @@
+const { expect } = require('chai');
+
+describe('initialize', function () {
+  it('reverts if the contract was already initialized', async function () {
+    const { assessment } = this.contracts;
+    await expect(assessment.initialize()).to.be.revertedWith('Already initialized');
+  });
+});

--- a/test/unit/Assessment/setup.js
+++ b/test/unit/Assessment/setup.js
@@ -49,35 +49,17 @@ async function setup () {
   ]);
   await Promise.all(masterInitTxs.map(x => x.wait()));
 
-  {
-    const tx = await assessment.initialize(master.address);
-    await tx.wait();
-  }
+  await assessment.changeMasterAddress(master.address);
+  await individualClaims.changeMasterAddress(master.address);
+  await yieldTokenIncidents.changeMasterAddress(master.address);
 
-  {
-    const tx = await individualClaims.initialize(master.address);
-    await tx.wait();
-  }
+  await assessment.changeDependentContractAddress();
+  await individualClaims.changeDependentContractAddress();
+  await yieldTokenIncidents.changeDependentContractAddress();
 
-  {
-    const tx = await yieldTokenIncidents.initialize(master.address);
-    await tx.wait();
-  }
-
-  {
-    const tx = await assessment.changeDependentContractAddress();
-    await tx.wait();
-  }
-
-  {
-    const tx = await individualClaims.changeDependentContractAddress();
-    await tx.wait();
-  }
-
-  {
-    const tx = await yieldTokenIncidents.changeDependentContractAddress();
-    await tx.wait();
-  }
+  await assessment.initialize();
+  await individualClaims.initialize();
+  await yieldTokenIncidents.initialize();
 
   const signers = await ethers.getSigners();
   const accounts = getAccounts(signers);

--- a/test/unit/CoverMigrator/index.js
+++ b/test/unit/CoverMigrator/index.js
@@ -1,7 +1,7 @@
 const { takeSnapshot, revertToSnapshot } = require('../utils').evm;
 const { setup } = require('./setup');
 
-describe('IndividualClaims', function () {
+describe('CoverMigrator', function () {
   before(setup);
 
   beforeEach(async function () {
@@ -13,9 +13,4 @@ describe('IndividualClaims', function () {
   });
 
   require('./submitClaim');
-  require('./redeemClaimPayout');
-  require('./getAssessmentDepositAndReward');
-  require('./updateUintParameters');
-  require('./getClaimsToDisplay');
-  require('./getClaimsCount');
 });

--- a/test/unit/CoverMigrator/setup.js
+++ b/test/unit/CoverMigrator/setup.js
@@ -19,7 +19,10 @@ async function setup () {
   const distributor = await Distributor.deploy(coverMigrator.address);
   await distributor.deployed();
 
-  const masterInitTxs = await Promise.all([master.setLatestAddress(hex('CL'), coverMigrator.address)]);
+  const masterInitTxs = await Promise.all([
+    master.setLatestAddress(hex('CL'), coverMigrator.address),
+    master.setLatestAddress(hex('CO'), cover.address),
+  ]);
   await Promise.all(masterInitTxs.map(x => x.wait()));
 
   const changeMasterAddressTxs = await Promise.all([master.callChangeMaster(coverMigrator.address)]);
@@ -34,9 +37,6 @@ async function setup () {
   const accounts = getAccounts(signers);
   await master.enrollGovernance(accounts.governanceContracts[0].address);
 
-  const config = await coverMigrator.config();
-
-  this.config = config;
   this.accounts = accounts;
   this.contracts = {
     coverMigrator,

--- a/test/unit/CoverMigrator/submitClaim.js
+++ b/test/unit/CoverMigrator/submitClaim.js
@@ -14,7 +14,7 @@ describe('submitClaim', function () {
     }
 
     {
-      await coverMigrator.connect(coverOwner).submitClaim(444);
+      await distributor.connect(coverOwner).submitClaim(444);
       const migrateCoverFromOwnerCalledWith = await cover.migrateCoverFromOwnerCalledWith();
       expect(migrateCoverFromOwnerCalledWith.coverId).to.be.equal(444);
       expect(migrateCoverFromOwnerCalledWith.fromOwner).to.be.equal(distributor.address);

--- a/test/unit/IndividualClaims/index.js
+++ b/test/unit/IndividualClaims/index.js
@@ -12,6 +12,7 @@ describe('IndividualClaims', function () {
     await revertToSnapshot(this.snapshotId);
   });
 
+  require('./initialize');
   require('./submitClaim');
   require('./redeemClaimPayout');
   require('./getAssessmentDepositAndReward');

--- a/test/unit/IndividualClaims/initialize.js
+++ b/test/unit/IndividualClaims/initialize.js
@@ -1,0 +1,8 @@
+const { expect } = require('chai');
+
+describe('initialize', function () {
+  it('reverts if the contract was already initialized', async function () {
+    const { individualClaims } = this.contracts;
+    await expect(individualClaims.initialize()).to.be.revertedWith('Already initialized');
+  });
+});

--- a/test/unit/IndividualClaims/setup.js
+++ b/test/unit/IndividualClaims/setup.js
@@ -75,14 +75,9 @@ async function setup () {
   await cover.addProduct(['1', '0x2222222222222222222222222222222222222222', '1', '0', '0']);
   await cover.addProduct(['2', '0x3333333333333333333333333333333333333333', '1', '0', '0']);
 
-  {
-    const tx = await individualClaims.initialize(master.address);
-    await tx.wait();
-  }
-  {
-    const tx = await individualClaims.changeDependentContractAddress();
-    await tx.wait();
-  }
+  await individualClaims.changeMasterAddress(master.address);
+  await individualClaims.changeDependentContractAddress();
+  await individualClaims.initialize();
 
   const signers = await ethers.getSigners();
   const accounts = getAccounts(signers);

--- a/test/unit/YieldTokenIncidents/index.js
+++ b/test/unit/YieldTokenIncidents/index.js
@@ -12,6 +12,7 @@ describe('YieldTokenIncidents', function () {
     await revertToSnapshot(this.snapshotId);
   });
 
+  require('./initialize');
   require('./submitIncident');
   require('./redeemPayout');
   require('./withdrawAsset');

--- a/test/unit/YieldTokenIncidents/initialize.js
+++ b/test/unit/YieldTokenIncidents/initialize.js
@@ -1,0 +1,8 @@
+const { expect } = require('chai');
+
+describe('initialize', function () {
+  it('reverts if the contract was already initialized', async function () {
+    const { yieldTokenIncidents } = this.contracts;
+    await expect(yieldTokenIncidents.initialize()).to.be.revertedWith('Already initialized');
+  });
+});

--- a/test/unit/YieldTokenIncidents/setup.js
+++ b/test/unit/YieldTokenIncidents/setup.js
@@ -85,15 +85,9 @@ async function setup () {
 
   await cover.setActiveCoverAmountInNXM(2, parseEther('3500'));
 
-  {
-    const tx = await yieldTokenIncidents.initialize(master.address);
-    await tx.wait();
-  }
-
-  {
-    const tx = await yieldTokenIncidents.changeDependentContractAddress();
-    await tx.wait();
-  }
+  await yieldTokenIncidents.changeMasterAddress(master.address);
+  await yieldTokenIncidents.changeDependentContractAddress();
+  await yieldTokenIncidents.initialize();
 
   const signers = await ethers.getSigners();
   const accounts = getAccounts(signers);

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -7,6 +7,7 @@ describe('UNIT TESTS', function () {
   require('./Distributor');
   require('./Assessment');
   require('./Cover');
+  require('./CoverMigrator');
   require('./IndividualClaims');
   require('./YieldTokenIncidents');
   require('./StakingPool');


### PR DESCRIPTION
Also fixes CoverMigrator units tests and prevents calling intitializers
for the second time which could allow anyone to reset the config back to
the initial state if it were to be changed through governance.