### PR TITLE
Various code review fixes

### DIFF
--- a/contracts/interfaces/IAssessment.sol
+++ b/contracts/interfaces/IAssessment.sol
@@ -8,8 +8,6 @@ interface IAssessment {
 
   /* ========== DATA STRUCTURES ========== */
 
-  enum PollStatus { PENDING, ACCEPTED, DENIED }
-
   enum UintParams {
     minVotingPeriodInDays,
     stakeLockupPeriodInDays,
@@ -39,33 +37,61 @@ interface IAssessment {
     /*uint32 unused,*/
   }
 
-  //  Holds data for a vote belonging to an assessor.
+  // Holds data for a vote belonging to an assessor.
   //
-  //  The structure is used to keep track of user's votes. Each vote is used to determine
-  //  a user's share of rewards or to create a fraud resolution which excludes fraudulent votes
-  //  from the initial poll.
+  // The structure is used to keep track of user's votes. Each vote is used to determine
+  // a user's share of rewards or to create a fraud resolution which excludes fraudulent votes
+  // from the initial poll.
   struct Vote {
     // Identifier of the claim or incident
     uint80 assessmentId;
+
     // If the assessor votes to accept the event it's true otherwise it's false
     bool accepted;
+
     // Date and time when the vote was cast
     uint32 timestamp;
+
     // How many tokens were staked when the vote was cast
     uint96 stakedAmount;
   }
 
+  // Holds poll results for an assessment.
+  //
+  // The structure is used to keep track of all votes on a given assessment such as how many NXM were
+  // used to cast accept and deny votes as well as when the poll started and when it ends.
   struct Poll {
+    // The amount of NXM from accept votes
     uint96 accepted;
+
+    // The amount of NXM from deny votes
     uint96 denied;
+
+    // Timestamp of when the poll started.
     uint32 start;
+
+    // Timestamp of when the poll ends.
     uint32 end;
   }
 
+  // Holds data for an assessment belonging to an assessable event (individual claims, yield token
+  // incidents etc.).
+  //
+  // The structure is used to keep track of the total reward that should be distributed to
+  // assessors, the assessment deposit the claimants made to start the assessment, and the poll
+  // coresponding to this assessment.
   struct Assessment {
+    // See Poll struct
     Poll poll;
-    uint128 totalReward;
-    uint128 assessmentDeposit;
+
+    // The amount of NXM representing the assessment reward which is split among those who voted.
+    uint128 totalRewardInNXM;
+
+    // An amount of ETH which is sent back to the claimant when the poll result is positive,
+    // otherwise it is kep it the pool to back the assessment rewards. This allows claimants to
+    // open an unlimited amount of claims and prevents unbacked NXM to be minted through the
+    // assessment process.
+    uint128 assessmentDepositInETH;
   }
 
   /* ========== VIEWS ========== */
@@ -119,8 +145,6 @@ interface IAssessment {
 
   function startAssessment(uint totalReward, uint assessmentDeposit) external
   returns (uint);
-
-  function castVote(uint assessmentId, bool isAcceptVote) external;
 
   function castVotes(
     uint[] calldata assessmentIds,

--- a/contracts/mocks/Assessment/ASMockMemberRoles.sol
+++ b/contracts/mocks/Assessment/ASMockMemberRoles.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity ^0.8.9;
+
+import "../../interfaces/INXMMaster.sol";
+import "../../interfaces/IMemberRoles.sol";
+
+contract ASMockMemberRoles {
+  mapping(address => uint) public members;
+
+  function enrollMember(address newMember, uint role) public {
+    members[newMember] = role;
+  }
+
+  function checkRole(address user, uint role) external view returns (bool) {
+    return members[user] == role;
+  }
+
+  function isMember(address user) external view returns (bool) {
+    return members[user] == uint(IMemberRoles.Role.Member);
+  }
+
+}

--- a/contracts/modules/v2/YieldTokenIncidents.sol
+++ b/contracts/modules/v2/YieldTokenIncidents.sol
@@ -14,6 +14,7 @@ import "../../interfaces/ICover.sol";
 import "../../interfaces/IAssessment.sol";
 import "../../interfaces/IYieldTokenIncidents.sol";
 import "../../interfaces/ICoverNFT.sol";
+import "../../utils/Math.sol";
 
 import "../../abstract/MasterAwareV2.sol";
 
@@ -70,10 +71,6 @@ contract YieldTokenIncidents is IYieldTokenIncidents, MasterAwareV2 {
   }
 
   /* ========== VIEWS ========== */
-
-  function min(uint a, uint b) internal pure returns (uint) {
-    return a < b ? a : b;
-  }
 
   function assessment() internal view returns (IAssessment) {
     return IAssessment(getInternalContractAddress(ID.AS));
@@ -173,7 +170,7 @@ contract YieldTokenIncidents is IYieldTokenIncidents, MasterAwareV2 {
     );
 
     // Determine the total rewards that should be minted for the assessors based on cover period
-    uint totalReward = min(
+    uint totalReward = Math.min(
       uint(config.maxRewardInNXMWad) * PRECISION,
       expectedPayoutInNXM * uint(config.rewardRatio) / REWARD_DENOMINATOR
     );
@@ -318,10 +315,10 @@ contract YieldTokenIncidents is IYieldTokenIncidents, MasterAwareV2 {
     IERC20 token = IERC20(asset);
     uint balance = token.balanceOf(address(this));
     uint transferAmount = amount > balance ? balance : amount;
-    token.transfer(destination, transferAmount);
+    SafeERC20.safeTransfer(token, destination, transferAmount);
   }
 
-  /// Allows to update configurable aprameters through governance
+  /// Updates configurable parameters through governance
   ///
   /// @param paramNames  An array of elements from UintParams enum
   /// @param values      An array of the new values, each one corresponding to the parameter

--- a/test/unit/Assessment/getPoll.js
+++ b/test/unit/Assessment/getPoll.js
@@ -16,7 +16,7 @@ describe('getPoll', function () {
       expect(poll.start).to.be.equal(targetAssessment.poll.start);
       expect(poll.end).to.be.equal(targetAssessment.poll.end);
     }
-    await assessment.connect(user).castVote(0, true);
+    await assessment.connect(user).castVotes([0], [true], 0);
     {
       const targetAssessment = await assessment.assessments(0);
       const poll = await assessment.getPoll(0);

--- a/test/unit/Assessment/getRewards.js
+++ b/test/unit/Assessment/getRewards.js
@@ -16,34 +16,34 @@ describe('getRewards', function () {
     await individualClaims.submitClaim(1, 0, parseEther('100'), '');
     await individualClaims.submitClaim(2, 0, parseEther('1000'), '');
 
-    await assessment.connect(user1).castVote(0, true);
-    await assessment.connect(user2).castVote(0, true);
-    await assessment.connect(user1).castVote(1, true);
-    await assessment.connect(user2).castVote(1, true);
-    await assessment.connect(user1).castVote(2, true);
-    await assessment.connect(user2).castVote(2, true);
+    await assessment.connect(user1).castVotes([0], [true], 0);
+    await assessment.connect(user2).castVotes([0], [true], 0);
+    await assessment.connect(user1).castVotes([1], [true], 0);
+    await assessment.connect(user2).castVotes([1], [true], 0);
+    await assessment.connect(user1).castVotes([2], [true], 0);
+    await assessment.connect(user2).castVotes([2], [true], 0);
 
     let expectedUser1Reward = ethers.constants.Zero;
     let expectedUser2Reward = ethers.constants.Zero;
     {
-      const { totalReward } = await assessment.assessments(0);
-      expectedUser1Reward = expectedUser1Reward.add(totalReward.mul(1).div(10));
-      expectedUser2Reward = expectedUser2Reward.add(totalReward.mul(9).div(10));
+      const { totalRewardInNXM } = await assessment.assessments(0);
+      expectedUser1Reward = expectedUser1Reward.add(totalRewardInNXM.mul(1).div(10));
+      expectedUser2Reward = expectedUser2Reward.add(totalRewardInNXM.mul(9).div(10));
     }
     {
-      const { totalReward } = await assessment.assessments(1);
-      expectedUser1Reward = expectedUser1Reward.add(totalReward.mul(1).div(10));
-      expectedUser2Reward = expectedUser2Reward.add(totalReward.mul(9).div(10));
+      const { totalRewardInNXM } = await assessment.assessments(1);
+      expectedUser1Reward = expectedUser1Reward.add(totalRewardInNXM.mul(1).div(10));
+      expectedUser2Reward = expectedUser2Reward.add(totalRewardInNXM.mul(9).div(10));
     }
     {
-      const { totalReward } = await assessment.assessments(2);
-      expectedUser1Reward = expectedUser1Reward.add(totalReward.mul(1).div(10));
-      expectedUser2Reward = expectedUser2Reward.add(totalReward.mul(9).div(10));
+      const { totalRewardInNXM } = await assessment.assessments(2);
+      expectedUser1Reward = expectedUser1Reward.add(totalRewardInNXM.mul(1).div(10));
+      expectedUser2Reward = expectedUser2Reward.add(totalRewardInNXM.mul(9).div(10));
     }
 
     {
-      const { totalPendingAmount: user1Total } = await assessment.getRewards(user1.address);
-      const { totalPendingAmount: user2Total } = await assessment.getRewards(user2.address);
+      const { totalPendingAmountInNXM: user1Total } = await assessment.getRewards(user1.address);
+      const { totalPendingAmountInNXM: user2Total } = await assessment.getRewards(user2.address);
       expect(user1Total).to.be.equal(expectedUser1Reward);
       expect(user2Total).to.be.equal(expectedUser2Reward);
     }
@@ -53,21 +53,21 @@ describe('getRewards', function () {
     await assessment.withdrawRewards(user1.address, 1);
 
     {
-      const { totalPendingAmount: user1Total } = await assessment.getRewards(user1.address);
-      const { totalPendingAmount: user2Total } = await assessment.getRewards(user2.address);
-      const { totalReward } = await assessment.assessments(0);
-      expect(user1Total).to.be.equal(expectedUser1Reward.sub(totalReward.mul(1).div(10)));
+      const { totalPendingAmountInNXM: user1Total } = await assessment.getRewards(user1.address);
+      const { totalPendingAmountInNXM: user2Total } = await assessment.getRewards(user2.address);
+      const { totalRewardInNXM } = await assessment.assessments(0);
+      expect(user1Total).to.be.equal(expectedUser1Reward.sub(totalRewardInNXM.mul(1).div(10)));
       expect(user2Total).to.be.equal(expectedUser2Reward);
     }
 
     await assessment.withdrawRewards(user2.address, 1);
 
     {
-      const { totalPendingAmount: user1Total } = await assessment.getRewards(user1.address);
-      const { totalPendingAmount: user2Total } = await assessment.getRewards(user2.address);
-      const { totalReward } = await assessment.assessments(0);
-      expect(user1Total).to.be.equal(expectedUser1Reward.sub(totalReward.mul(1).div(10)));
-      expect(user2Total).to.be.equal(expectedUser2Reward.sub(totalReward.mul(9).div(10)));
+      const { totalPendingAmountInNXM: user1Total } = await assessment.getRewards(user1.address);
+      const { totalPendingAmountInNXM: user2Total } = await assessment.getRewards(user2.address);
+      const { totalRewardInNXM } = await assessment.assessments(0);
+      expect(user1Total).to.be.equal(expectedUser1Reward.sub(totalRewardInNXM.mul(1).div(10)));
+      expect(user2Total).to.be.equal(expectedUser2Reward.sub(totalRewardInNXM.mul(9).div(10)));
     }
 
     // Withdraw everything
@@ -75,8 +75,8 @@ describe('getRewards', function () {
     await assessment.withdrawRewards(user1.address, 0);
 
     {
-      const { totalPendingAmount: user1Total } = await assessment.getRewards(user1.address);
-      const { totalPendingAmount: user2Total } = await assessment.getRewards(user2.address);
+      const { totalPendingAmountInNXM: user1Total } = await assessment.getRewards(user1.address);
+      const { totalPendingAmountInNXM: user2Total } = await assessment.getRewards(user2.address);
       expect(user1Total).to.be.equal(0);
       expect(user2Total).to.be.equal(0);
     }
@@ -91,60 +91,60 @@ describe('getRewards', function () {
     await individualClaims.submitClaim(0, 0, parseEther('10'), '');
     await individualClaims.submitClaim(1, 0, parseEther('100'), '');
 
-    await assessment.connect(user).castVote(0, true);
-    await assessment.connect(user).castVote(1, true);
+    await assessment.connect(user).castVotes([0], [true], 0);
+    await assessment.connect(user).castVotes([1], [true], 0);
 
     let expectedReward = ethers.constants.Zero;
 
     {
-      const { totalReward } = await assessment.assessments(0);
-      expectedReward = expectedReward.add(totalReward);
+      const { totalRewardInNXM } = await assessment.assessments(0);
+      expectedReward = expectedReward.add(totalRewardInNXM);
     }
 
     {
-      const { totalReward } = await assessment.assessments(1);
-      expectedReward = expectedReward.add(totalReward);
+      const { totalRewardInNXM } = await assessment.assessments(1);
+      expectedReward = expectedReward.add(totalRewardInNXM);
     }
 
     {
-      const { withdrawableAmount } = await assessment.getRewards(user.address);
-      expect(withdrawableAmount).to.be.equal(0);
+      const { withdrawableAmountInNXM } = await assessment.getRewards(user.address);
+      expect(withdrawableAmountInNXM).to.be.equal(0);
     }
 
     {
       const { end } = await assessment.getPoll(1);
       await setTime(end + daysToSeconds(minVotingPeriodInDays + payoutCooldownInDays));
-      const { withdrawableAmount } = await assessment.getRewards(user.address);
-      expect(withdrawableAmount).to.be.equal(expectedReward);
+      const { withdrawableAmountInNXM } = await assessment.getRewards(user.address);
+      expect(withdrawableAmountInNXM).to.be.equal(expectedReward);
     }
 
     {
       await assessment.withdrawRewards(user.address, 1);
-      const { totalReward } = await assessment.assessments(0);
-      expectedReward = expectedReward.sub(totalReward);
-      const { withdrawableAmount } = await assessment.getRewards(user.address);
-      expect(withdrawableAmount).to.be.equal(expectedReward);
+      const { totalRewardInNXM } = await assessment.assessments(0);
+      expectedReward = expectedReward.sub(totalRewardInNXM);
+      const { withdrawableAmountInNXM } = await assessment.getRewards(user.address);
+      expect(withdrawableAmountInNXM).to.be.equal(expectedReward);
     }
 
     {
       await assessment.withdrawRewards(user.address, 1);
-      const { withdrawableAmount } = await assessment.getRewards(user.address);
-      expect(withdrawableAmount).to.be.equal(0);
+      const { withdrawableAmountInNXM } = await assessment.getRewards(user.address);
+      expect(withdrawableAmountInNXM).to.be.equal(0);
     }
 
     {
       await individualClaims.submitClaim(0, 0, parseEther('1000'), '');
-      await assessment.connect(user).castVote(2, true);
-      const { withdrawableAmount } = await assessment.getRewards(user.address);
-      expect(withdrawableAmount).to.be.equal(0);
+      await assessment.connect(user).castVotes([2], [true], 0);
+      const { withdrawableAmountInNXM } = await assessment.getRewards(user.address);
+      expect(withdrawableAmountInNXM).to.be.equal(0);
     }
 
     {
       const { end } = await assessment.getPoll(2);
       await setTime(end + daysToSeconds(minVotingPeriodInDays + payoutCooldownInDays));
-      const { totalReward } = await assessment.assessments(2);
-      const { withdrawableAmount } = await assessment.getRewards(user.address);
-      expect(withdrawableAmount).to.be.equal(totalReward);
+      const { totalRewardInNXM } = await assessment.assessments(2);
+      const { withdrawableAmountInNXM } = await assessment.getRewards(user.address);
+      expect(withdrawableAmountInNXM).to.be.equal(totalRewardInNXM);
     }
   });
 
@@ -157,8 +157,8 @@ describe('getRewards', function () {
     await individualClaims.submitClaim(0, 0, parseEther('10'), '');
     await individualClaims.submitClaim(0, 1, parseEther('100'), '');
 
-    await assessment.connect(user).castVote(0, true);
-    await assessment.connect(user).castVote(1, true);
+    await assessment.connect(user).castVotes([0], [true], 0);
+    await assessment.connect(user).castVotes([1], [true], 0);
 
     {
       const { withdrawableUntilIndex } = await assessment.getRewards(user.address);
@@ -174,7 +174,7 @@ describe('getRewards', function () {
 
     {
       await individualClaims.submitClaim(0, 0, parseEther('1000'), '');
-      await assessment.connect(user).castVote(2, true);
+      await assessment.connect(user).castVotes([2], [true], 0);
       const { withdrawableUntilIndex } = await assessment.getRewards(user.address);
       expect(withdrawableUntilIndex).to.be.equal(2);
     }

--- a/test/unit/Assessment/getVoteCountOfAssessor.js
+++ b/test/unit/Assessment/getVoteCountOfAssessor.js
@@ -18,15 +18,15 @@ describe('getVoteCountOfAssessor', function () {
       expect(count).to.be.equal(0);
     }
 
-    await assessment.connect(assessor1).castVote(0, true);
+    await assessment.connect(assessor1).castVotes([0], [true], 0);
 
     {
       const count = await assessment.getVoteCountOfAssessor(assessor1.address);
       expect(count).to.be.equal(1);
     }
 
-    await assessment.connect(assessor1).castVote(1, true);
-    await assessment.connect(assessor1).castVote(2, true);
+    await assessment.connect(assessor1).castVotes([1], [true], 0);
+    await assessment.connect(assessor1).castVotes([2], [true], 0);
 
     {
       const count = await assessment.getVoteCountOfAssessor(assessor1.address);
@@ -38,8 +38,8 @@ describe('getVoteCountOfAssessor', function () {
       expect(count).to.be.equal(0);
     }
 
-    await assessment.connect(assessor2).castVote(1, true);
-    await assessment.connect(assessor2).castVote(2, true);
+    await assessment.connect(assessor2).castVotes([1], [true], 0);
+    await assessment.connect(assessor2).castVotes([2], [true], 0);
 
     {
       const count = await assessment.getVoteCountOfAssessor(assessor2.address);

--- a/test/unit/Assessment/index.js
+++ b/test/unit/Assessment/index.js
@@ -1,7 +1,7 @@
 const { takeSnapshot, revertToSnapshot } = require('../utils').evm;
 const { setup } = require('./setup');
 
-describe('Assessment', function () {
+describe.only('Assessment', function () {
   before(setup);
 
   beforeEach(async function () {
@@ -22,7 +22,7 @@ describe('Assessment', function () {
   require('./withdrawRewards');
   require('./withdrawRewardsTo');
   require('./startAssessment');
-  require('./castVote');
+  require('./castVotes');
   require('./submitFraud');
   require('./processFraud');
   require('./updateUintParameters');

--- a/test/unit/Assessment/processFraud.js
+++ b/test/unit/Assessment/processFraud.js
@@ -11,7 +11,7 @@ describe('processFraud', function () {
     const [fraudulentMember, honestMember] = this.accounts.members;
     await assessment.connect(fraudulentMember).stake(parseEther('100'));
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
-    await assessment.connect(fraudulentMember).castVote(0, true);
+    await assessment.connect(fraudulentMember).castVotes([0], [true], 0);
     const merkleTree = await submitFraud({
       assessment,
       signer: governance,
@@ -82,10 +82,10 @@ describe('processFraud', function () {
     await assessment.connect(otherMember2).stake(parseEther('10'));
 
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
-    await assessment.connect(fraudulentMember).castVote(0, true);
+    await assessment.connect(fraudulentMember).castVotes([0], [true], 0);
 
     await individualClaims.submitClaim(1, 0, parseEther('100'), '');
-    await assessment.connect(fraudulentMember).castVote(1, true);
+    await assessment.connect(fraudulentMember).castVotes([1], [true], 0);
 
     const { timestamp } = await ethers.provider.getBlock('latest');
     await setTime(timestamp + daysToSeconds(30));
@@ -93,19 +93,19 @@ describe('processFraud', function () {
 
     // Fraudulent claim
     await individualClaims.submitClaim(2, 0, parseEther('100'), '');
-    await assessment.connect(fraudulentMember).castVote(2, true);
-    await assessment.connect(otherMember1).castVote(2, false);
-    await assessment.connect(otherMember2).castVote(2, false);
+    await assessment.connect(fraudulentMember).castVotes([2], [true], 0);
+    await assessment.connect(otherMember1).castVotes([2], [false], 0);
+    await assessment.connect(otherMember2).castVotes([2], [false], 0);
 
     await individualClaims.submitClaim(3, 0, parseEther('100'), '');
-    await assessment.connect(otherMember1).castVote(3, true);
-    await assessment.connect(otherMember2).castVote(3, true);
-    await assessment.connect(fraudulentMember).castVote(3, false);
+    await assessment.connect(otherMember1).castVotes([3], [true], 0);
+    await assessment.connect(otherMember2).castVotes([3], [true], 0);
+    await assessment.connect(fraudulentMember).castVotes([3], [false], 0);
 
     await individualClaims.submitClaim(4, 0, parseEther('100'), '');
-    await assessment.connect(fraudulentMember).castVote(4, true);
-    await assessment.connect(otherMember1).castVote(4, true);
-    await assessment.connect(otherMember2).castVote(4, true);
+    await assessment.connect(fraudulentMember).castVotes([4], [true], 0);
+    await assessment.connect(otherMember1).castVotes([4], [true], 0);
+    await assessment.connect(otherMember2).castVotes([4], [true], 0);
 
     const stake = await assessment.stakeOf(fraudulentMember.address);
     expect(stake.rewardsWithdrawableFromIndex).to.be.equal(2);
@@ -185,7 +185,7 @@ describe('processFraud', function () {
     await Promise.all(
       Array(10)
         .fill('')
-        .map((_, i) => assessment.connect(fraudulentMember).castVote(i, true)),
+        .map((_, i) => assessment.connect(fraudulentMember).castVotes([i], [true], 0)),
     );
 
     const burnAmount = parseEther('50');
@@ -283,10 +283,10 @@ describe('processFraud', function () {
     await assessment.connect(otherMember2).stake(parseEther('200'));
 
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
-    await assessment.connect(fraudulentMember).castVote(0, true);
+    await assessment.connect(fraudulentMember).castVotes([0], [true], 0);
 
     await individualClaims.submitClaim(1, 0, parseEther('100'), '');
-    await assessment.connect(fraudulentMember).castVote(1, true);
+    await assessment.connect(fraudulentMember).castVotes([1], [true], 0);
 
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
@@ -294,14 +294,14 @@ describe('processFraud', function () {
     }
 
     // Increases the poll end by 1 day
-    await assessment.connect(otherMember1).castVote(1, false);
+    await assessment.connect(otherMember1).castVotes([1], [false], 0);
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
       await setTime(timestamp + daysToSeconds(1) - 2);
     }
 
     // Increases the poll end by 1 day
-    await assessment.connect(otherMember2).castVote(1, false);
+    await assessment.connect(otherMember2).castVotes([1], [false], 0);
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
       await setTime(timestamp + daysToSeconds(2) - 2);
@@ -346,7 +346,7 @@ describe('processFraud', function () {
     await assessment.connect(fraudulentMember).stake(parseEther('100'));
 
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
-    await assessment.connect(fraudulentMember).castVote(0, true);
+    await assessment.connect(fraudulentMember).castVotes([0], [true], 0);
 
     {
       const fraudulentAssessment = await assessment.assessments(0);
@@ -389,11 +389,11 @@ describe('processFraud', function () {
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
     await individualClaims.submitClaim(1, 0, parseEther('1000'), '');
 
-    await assessment.connect(fraudulentMember1).castVote(0, true);
-    await assessment.connect(fraudulentMember1).castVote(1, true);
+    await assessment.connect(fraudulentMember1).castVotes([0], [true], 0);
+    await assessment.connect(fraudulentMember1).castVotes([1], [true], 0);
 
-    await assessment.connect(fraudulentMember2).castVote(0, true);
-    await assessment.connect(fraudulentMember2).castVote(1, true);
+    await assessment.connect(fraudulentMember2).castVotes([0], [true], 0);
+    await assessment.connect(fraudulentMember2).castVotes([1], [true], 0);
 
     const { poll: poll1 } = await assessment.assessments(0);
     const { poll: poll2 } = await assessment.assessments(1);
@@ -481,7 +481,7 @@ describe('processFraud', function () {
 
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
 
-    await assessment.connect(fraudulentMember).castVote(0, true);
+    await assessment.connect(fraudulentMember).castVotes([0], [true], 0);
 
     const burnAmount = parseEther('33');
     await submitFraud({
@@ -522,7 +522,7 @@ describe('processFraud', function () {
 
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
 
-    await assessment.connect(fraudulentMember).castVote(0, true);
+    await assessment.connect(fraudulentMember).castVotes([0], [true], 0);
 
     await submitFraud({
       assessment,
@@ -571,7 +571,7 @@ describe('processFraud', function () {
     await Promise.all(
       Array(10)
         .fill('')
-        .map((_, i) => assessment.connect(fraudulentMember).castVote(i, true)),
+        .map((_, i) => assessment.connect(fraudulentMember).castVotes([i], [true], 0)),
     );
 
     const burnAmount = parseEther('50');
@@ -663,7 +663,7 @@ describe('processFraud', function () {
     await Promise.all(
       Array(2)
         .fill('')
-        .map((_, i) => assessment.connect(fraudulentMember).castVote(i, true)),
+        .map((_, i) => assessment.connect(fraudulentMember).castVotes([i], [true], 0)),
     );
 
     const burnAmount = parseEther('50');
@@ -726,7 +726,7 @@ describe('processFraud', function () {
     await Promise.all(
       Array(2)
         .fill('')
-        .map((_, i) => assessment.connect(fraudulentMember).castVote(i, true)),
+        .map((_, i) => assessment.connect(fraudulentMember).castVotes([i], [true], 0)),
     );
 
     const burnAmount = parseEther('50');

--- a/test/unit/Assessment/setup.js
+++ b/test/unit/Assessment/setup.js
@@ -8,10 +8,6 @@ async function setup () {
   const nxm = await NXM.deploy();
   await nxm.deployed();
 
-  const MemberRoles = await ethers.getContractFactory('MemberRolesMock');
-  const memberRoles = await MemberRoles.deploy();
-  await memberRoles.deployed();
-
   const ASMockTokenController = await ethers.getContractFactory('ASMockTokenController');
   const tokenController = await ASMockTokenController.deploy(nxm.address);
   await tokenController.deployed();
@@ -38,12 +34,17 @@ async function setup () {
   const assessment = await Assessment.deploy(nxm.address);
   await assessment.deployed();
 
+  const ASMockMemberRoles = await ethers.getContractFactory('ASMockMemberRoles');
+  const memberRoles = await ASMockMemberRoles.deploy();
+  await memberRoles.deployed();
+
   const masterInitTxs = await Promise.all([
     master.setLatestAddress(hex('TC'), tokenController.address),
     master.setTokenAddress(nxm.address),
     master.setLatestAddress(hex('IC'), individualClaims.address),
     master.setLatestAddress(hex('YT'), yieldTokenIncidents.address),
     master.setLatestAddress(hex('AS'), assessment.address),
+    master.setLatestAddress(hex('MR'), memberRoles.address),
     master.enrollInternal(individualClaims.address),
     master.enrollInternal(yieldTokenIncidents.address),
   ]);
@@ -65,7 +66,8 @@ async function setup () {
   const accounts = getAccounts(signers);
   await master.enrollGovernance(accounts.governanceContracts[0].address);
   for (const member of accounts.members) {
-    await master.enrollMember(member.address, 1);
+    await master.enrollMember(member.address, 1); // Uses a different role value than IMemberRoles
+    await memberRoles.enrollMember(member.address, 2); // Uses the actual member role value
     await nxm.mint(member.address, parseEther('10000'));
     await nxm.connect(member).approve(tokenController.address, parseEther('10000'));
   }

--- a/test/unit/Assessment/startAssessment.js
+++ b/test/unit/Assessment/startAssessment.js
@@ -43,7 +43,7 @@ describe('startAssessment', function () {
     }
   });
 
-  it('stores assessmentDeposit and totalReward', async function () {
+  it('stores assessmentDepositInETH and totalRewardInNXM', async function () {
     const { individualClaims, yieldTokenIncidents, assessment } = this.contracts;
     const [user] = this.accounts.members;
     const [AB] = this.accounts.advisoryBoardMembers;
@@ -51,10 +51,10 @@ describe('startAssessment', function () {
 
     {
       await individualClaims.connect(user).submitClaim(0, 0, parseEther('100'), '');
-      const { assessmentDeposit, totalReward } = await assessment.assessments(0);
+      const { assessmentDepositInETH, totalRewardInNXM } = await assessment.assessments(0);
       const { rewardRatio } = await individualClaims.config();
-      expect(assessmentDeposit).to.be.equal(0);
-      expect(totalReward).to.be.equal(
+      expect(assessmentDepositInETH).to.be.equal(0);
+      expect(totalRewardInNXM).to.be.equal(
         parseEther('100')
           .mul(rewardRatio)
           .div('10000'),
@@ -64,12 +64,12 @@ describe('startAssessment', function () {
     {
       const activeCoverAmountInNXM = parseEther('1000');
       await yieldTokenIncidents.connect(AB).submitIncident(0, parseEther('1'), timestamp, activeCoverAmountInNXM);
-      const { assessmentDeposit, totalReward } = await assessment.assessments(1);
+      const { assessmentDepositInETH, totalRewardInNXM } = await assessment.assessments(1);
       const { rewardRatio, expectedPayoutRatio } = await yieldTokenIncidents.config();
 
       // For now being AB only, it doesn't require a deposit to submit yieldTokenIncidents
-      expect(assessmentDeposit).to.be.equal(Zero);
-      expect(totalReward).to.be.equal(
+      expect(assessmentDepositInETH).to.be.equal(Zero);
+      expect(totalRewardInNXM).to.be.equal(
         activeCoverAmountInNXM
           .mul(rewardRatio)
           .div(10000)
@@ -79,7 +79,7 @@ describe('startAssessment', function () {
     }
   });
 
-  it('stores assessmentDeposit and totalReward', async function () {
+  it('stores assessmentDepositInETH and totalRewardInNXM', async function () {
     const { individualClaims, yieldTokenIncidents, assessment } = this.contracts;
     const [user] = this.accounts.members;
     const [AB] = this.accounts.advisoryBoardMembers;
@@ -87,10 +87,10 @@ describe('startAssessment', function () {
 
     {
       await individualClaims.connect(user).submitClaim(0, 0, parseEther('100'), '');
-      const { assessmentDeposit, totalReward } = await assessment.assessments(0);
+      const { assessmentDepositInETH, totalRewardInNXM } = await assessment.assessments(0);
       const { rewardRatio } = await individualClaims.config();
-      expect(assessmentDeposit).to.be.equal(0);
-      expect(totalReward).to.be.equal(
+      expect(assessmentDepositInETH).to.be.equal(0);
+      expect(totalRewardInNXM).to.be.equal(
         parseEther('100')
           .mul(rewardRatio)
           .div('10000'),
@@ -100,10 +100,10 @@ describe('startAssessment', function () {
     {
       const activeCoverAmountInNXM = parseEther('1000');
       await yieldTokenIncidents.connect(AB).submitIncident(0, parseEther('1'), timestamp, activeCoverAmountInNXM);
-      const { assessmentDeposit, totalReward } = await assessment.assessments(1);
+      const { assessmentDepositInETH, totalRewardInNXM } = await assessment.assessments(1);
       const { rewardRatio, expectedPayoutRatio } = await yieldTokenIncidents.config();
-      expect(assessmentDeposit).to.be.equal(Zero); // For now AB doesn't require a deposit to submit yieldTokenIncidents
-      expect(totalReward).to.be.equal(
+      expect(assessmentDepositInETH).to.be.equal(Zero); // For now AB doesn't require a deposit to submit yieldTokenIncidents
+      expect(totalRewardInNXM).to.be.equal(
         activeCoverAmountInNXM
           .mul(rewardRatio)
           .div(10000)

--- a/test/unit/Assessment/unstake.js
+++ b/test/unit/Assessment/unstake.js
@@ -56,11 +56,11 @@ describe('unstake', function () {
   });
 
   it("reverts if less than stakeLockupPeriodInDays passed since the staker's last vote", async function () {
-    const { assessment, nxm, individualClaims } = this.contracts;
+    const { assessment, individualClaims } = this.contracts;
     const user = this.accounts.members[0];
     await assessment.connect(user).stake(parseEther('100'));
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
-    await assessment.connect(user).castVote(0, true);
+    await assessment.connect(user).castVotes([0], [true], 0);
     await expect(assessment.connect(user).unstake(parseEther('100'), user.address)).to.be.revertedWith(
       'Stake is in lockup period',
     );

--- a/test/unit/Assessment/withdrawRewards.js
+++ b/test/unit/Assessment/withdrawRewards.js
@@ -19,19 +19,19 @@ describe('withdrawRewards', function () {
     await assessment.connect(staker).stake(parseEther('10'));
 
     await individualClaims.connect(staker).submitClaim(0, 0, parseEther('100'), '');
-    await assessment.connect(staker).castVote(0, true);
+    await assessment.connect(staker).castVotes([0], [true], 0);
     const { timestamp } = await ethers.provider.getBlock('latest');
     await setTime(timestamp + daysToSeconds(minVotingPeriodInDays + payoutCooldownInDays));
 
     const [nonMember] = this.accounts.nonMembers;
-    const { totalReward } = await assessment.assessments(0);
+    const { totalRewardInNXM } = await assessment.assessments(0);
     const nonMemberBalanceBefore = await nxm.balanceOf(nonMember.address);
     const stakerBalanceBefore = await nxm.balanceOf(staker.address);
     await expect(assessment.connect(nonMember).withdrawRewards(staker.address, 0, { gasPrice: 0 })).not.to.be.reverted;
     const nonMemberBalanceAfter = await nxm.balanceOf(nonMember.address);
     const stakerBalanceAfter = await nxm.balanceOf(staker.address);
     expect(nonMemberBalanceAfter).to.be.equal(nonMemberBalanceBefore);
-    expect(stakerBalanceAfter).to.be.equal(stakerBalanceBefore.add(totalReward));
+    expect(stakerBalanceAfter).to.be.equal(stakerBalanceBefore.add(totalRewardInNXM));
   });
 
   it('withdraws rewards only until the last finalized assessment when an unfinalized assessment follows', async function () {
@@ -41,15 +41,15 @@ describe('withdrawRewards', function () {
     await assessment.connect(user).stake(parseEther('10'));
 
     await individualClaims.connect(user).submitClaim(0, 0, parseEther('100'), '');
-    await assessment.connect(user).castVote(0, true);
+    await assessment.connect(user).castVotes([0], [true], 0);
     const { timestamp } = await ethers.provider.getBlock('latest');
     await setTime(timestamp + daysToSeconds(minVotingPeriodInDays + payoutCooldownInDays));
 
     await individualClaims.connect(user).submitClaim(1, 0, parseEther('100'), '');
-    await assessment.connect(user).castVote(1, true);
+    await assessment.connect(user).castVotes([1], [true], 0);
 
     await individualClaims.connect(user).submitClaim(2, 0, parseEther('100'), '');
-    await assessment.connect(user).castVote(2, true);
+    await assessment.connect(user).castVotes([2], [true], 0);
 
     const balanceBefore = await nxm.balanceOf(user.address);
 
@@ -57,9 +57,9 @@ describe('withdrawRewards', function () {
     const { rewardsWithdrawableFromIndex } = await assessment.stakeOf(user.address);
     expect(rewardsWithdrawableFromIndex).to.be.equal(1);
 
-    const { totalReward } = await assessment.assessments(0);
+    const { totalRewardInNXM } = await assessment.assessments(0);
     const balanceAfter = await nxm.balanceOf(user.address);
-    expect(balanceAfter).to.be.equal(balanceBefore.add(totalReward));
+    expect(balanceAfter).to.be.equal(balanceBefore.add(totalRewardInNXM));
   });
 
   it("mints rewards pro-rated by the user's stake at vote time, to the total amount staked on that assessment", async function () {
@@ -73,10 +73,10 @@ describe('withdrawRewards', function () {
       await assessment.connect(user2).stake(parseEther('10'));
       await assessment.connect(user3).stake(parseEther('10'));
 
-      await assessment.connect(user1).castVote(0, true);
-      await assessment.connect(user2).castVote(0, true);
-      await assessment.connect(user3).castVote(0, true);
-      const { totalReward } = await assessment.assessments(0);
+      await assessment.connect(user1).castVotes([0], [true], 0);
+      await assessment.connect(user2).castVotes([0], [true], 0);
+      await assessment.connect(user3).castVotes([0], [true], 0);
+      const { totalRewardInNXM } = await assessment.assessments(0);
 
       const { timestamp } = await ethers.provider.getBlock('latest');
       await setTime(timestamp + daysToSeconds(minVotingPeriodInDays + payoutCooldownInDays));
@@ -85,30 +85,30 @@ describe('withdrawRewards', function () {
         const balanceBefore = await nxm.balanceOf(user1.address);
         await assessment.connect(user1).withdrawRewards(user1.address, 0);
         const balanceAfter = await nxm.balanceOf(user1.address);
-        expect(balanceAfter).to.be.equal(balanceBefore.add(totalReward.div(3)));
+        expect(balanceAfter).to.be.equal(balanceBefore.add(totalRewardInNXM.div(3)));
       }
 
       {
         const balanceBefore = await nxm.balanceOf(user2.address);
         await assessment.connect(user2).withdrawRewards(user2.address, 0);
         const balanceAfter = await nxm.balanceOf(user2.address);
-        expect(balanceAfter).to.be.equal(balanceBefore.add(totalReward.div(3)));
+        expect(balanceAfter).to.be.equal(balanceBefore.add(totalRewardInNXM.div(3)));
       }
 
       {
         const balanceBefore = await nxm.balanceOf(user3.address);
         await assessment.connect(user3).withdrawRewards(user3.address, 0);
         const balanceAfter = await nxm.balanceOf(user3.address);
-        expect(balanceAfter).to.be.equal(balanceBefore.add(totalReward.div(3)));
+        expect(balanceAfter).to.be.equal(balanceBefore.add(totalRewardInNXM.div(3)));
       }
     }
 
     {
       await individualClaims.connect(user1).submitClaim(1, 0, parseEther('100'), '');
 
-      await assessment.connect(user1).castVote(1, true);
-      await assessment.connect(user2).castVote(1, true);
-      const { totalReward } = await assessment.assessments(1);
+      await assessment.connect(user1).castVotes([1], [true], 0);
+      await assessment.connect(user2).castVotes([1], [true], 0);
+      const { totalRewardInNXM } = await assessment.assessments(1);
 
       const { timestamp } = await ethers.provider.getBlock('latest');
       await setTime(timestamp + daysToSeconds(minVotingPeriodInDays + payoutCooldownInDays));
@@ -117,14 +117,14 @@ describe('withdrawRewards', function () {
         const balanceBefore = await nxm.balanceOf(user1.address);
         await assessment.connect(user1).withdrawRewards(user1.address, 0);
         const balanceAfter = await nxm.balanceOf(user1.address);
-        expect(balanceAfter).to.be.equal(balanceBefore.add(totalReward.div(2)));
+        expect(balanceAfter).to.be.equal(balanceBefore.add(totalRewardInNXM.div(2)));
       }
 
       {
         const balanceBefore = await nxm.balanceOf(user2.address);
         await assessment.connect(user2).withdrawRewards(user2.address, 0);
         const balanceAfter = await nxm.balanceOf(user2.address);
-        expect(balanceAfter).to.be.equal(balanceBefore.add(totalReward.div(2)));
+        expect(balanceAfter).to.be.equal(balanceBefore.add(totalRewardInNXM.div(2)));
       }
     }
 
@@ -134,10 +134,10 @@ describe('withdrawRewards', function () {
       await assessment.connect(user2).stake(parseEther('27'));
       await assessment.connect(user3).stake(parseEther('33'));
 
-      await assessment.connect(user1).castVote(2, true);
-      await assessment.connect(user2).castVote(2, true);
-      await assessment.connect(user3).castVote(2, true);
-      const { totalReward } = await assessment.assessments(2);
+      await assessment.connect(user1).castVotes([2], [true], 0);
+      await assessment.connect(user2).castVotes([2], [true], 0);
+      await assessment.connect(user3).castVotes([2], [true], 0);
+      const { totalRewardInNXM } = await assessment.assessments(2);
 
       const { timestamp } = await ethers.provider.getBlock('latest');
       await setTime(timestamp + daysToSeconds(minVotingPeriodInDays + payoutCooldownInDays));
@@ -146,21 +146,21 @@ describe('withdrawRewards', function () {
         const balanceBefore = await nxm.balanceOf(user1.address);
         await assessment.connect(user1).withdrawRewards(user1.address, 0);
         const balanceAfter = await nxm.balanceOf(user1.address);
-        expect(balanceAfter).to.be.equal(balanceBefore.add(totalReward.mul(20).div(100)));
+        expect(balanceAfter).to.be.equal(balanceBefore.add(totalRewardInNXM.mul(20).div(100)));
       }
 
       {
         const balanceBefore = await nxm.balanceOf(user2.address);
         await assessment.connect(user2).withdrawRewards(user2.address, 0);
         const balanceAfter = await nxm.balanceOf(user2.address);
-        expect(balanceAfter).to.be.equal(balanceBefore.add(totalReward.mul(37).div(100)));
+        expect(balanceAfter).to.be.equal(balanceBefore.add(totalRewardInNXM.mul(37).div(100)));
       }
 
       {
         const balanceBefore = await nxm.balanceOf(user3.address);
         await assessment.connect(user3).withdrawRewards(user3.address, 0);
         const balanceAfter = await nxm.balanceOf(user3.address);
-        expect(balanceAfter).to.be.equal(balanceBefore.add(totalReward.mul(43).div(100)));
+        expect(balanceAfter).to.be.equal(balanceBefore.add(totalRewardInNXM.mul(43).div(100)));
       }
     }
   });

--- a/test/unit/IndividualClaims/index.js
+++ b/test/unit/IndividualClaims/index.js
@@ -1,7 +1,7 @@
 const { takeSnapshot, revertToSnapshot } = require('../utils').evm;
 const { setup } = require('./setup');
 
-describe('IndividualClaims', function () {
+describe.only('IndividualClaims', function () {
   before(setup);
 
   beforeEach(async function () {

--- a/test/unit/IndividualClaims/setup.js
+++ b/test/unit/IndividualClaims/setup.js
@@ -67,7 +67,6 @@ async function setup () {
   ]);
   await Promise.all(masterInitTxs.map(x => x.wait()));
   await cover.addProductType('0', '30', '5000');
-  console.log('works');
   await cover.addProductType('0', '90', '5000');
   await cover.addProductType('1', '30', '5000');
 

--- a/test/unit/IndividualClaims/submitClaim.js
+++ b/test/unit/IndividualClaims/submitClaim.js
@@ -354,10 +354,10 @@ describe('submitClaim', function () {
     await individualClaims.connect(coverOwner).submitClaim(coverId, 0, coverAmount, '', { value: expectedDeposit });
 
     const expectedAssessmentId = 0;
-    const { assessmentDeposit, totalReward } = await assessment.assessments(expectedAssessmentId);
+    const { assessmentDepositInETH, totalRewardInNXM } = await assessment.assessments(expectedAssessmentId);
 
-    expect(assessmentDeposit).to.be.equal(expectedDeposit);
-    expect(totalReward).to.be.equal(expectedTotalReward);
+    expect(assessmentDepositInETH).to.be.equal(expectedDeposit);
+    expect(totalRewardInNXM).to.be.equal(expectedTotalReward);
 
     const { assessmentId } = await individualClaims.claims(0);
     expect(assessmentId).to.be.equal(expectedAssessmentId);

--- a/test/unit/YieldTokenIncidents/index.js
+++ b/test/unit/YieldTokenIncidents/index.js
@@ -1,7 +1,7 @@
 const { takeSnapshot, revertToSnapshot } = require('../utils').evm;
 const { setup } = require('./setup');
 
-describe('YieldTokenIncidents', function () {
+describe.only('YieldTokenIncidents', function () {
   before(setup);
 
   beforeEach(async function () {

--- a/test/unit/YieldTokenIncidents/submitIncident.js
+++ b/test/unit/YieldTokenIncidents/submitIncident.js
@@ -83,11 +83,11 @@ describe('submitIncident', function () {
       .connect(advisoryBoard)
       .submitIncident(productId, parseEther('1.1'), currentTime, expectedPayoutAmount, '');
     const expectedTotalReward = expectedPayoutAmount.mul(this.config.rewardRatio).div(10000);
-    const { totalReward } = await assessment.assessments(0);
-    expect(totalReward).to.be.equal(expectedTotalReward);
+    const { totalRewardInNXM } = await assessment.assessments(0);
+    expect(totalRewardInNXM).to.be.equal(expectedTotalReward);
   });
 
-  it('calculates the totalReward capped at config.maxRewardInNXMWad', async function () {
+  it('calculates the totalRewardInNXM capped at config.maxRewardInNXMWad', async function () {
     const { assessment, yieldTokenIncidents } = this.contracts;
     const [advisoryBoard] = this.accounts.advisoryBoardMembers;
     const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
@@ -98,8 +98,8 @@ describe('submitIncident', function () {
       .submitIncident(productId, parseEther('1.1'), currentTime, parseEther('100000000'), '');
     const expectedTotalReward = parseEther(this.config.maxRewardInNXMWad.toString());
 
-    const { totalReward } = await assessment.assessments(0);
-    expect(totalReward).to.be.equal(expectedTotalReward);
+    const { totalRewardInNXM } = await assessment.assessments(0);
+    expect(totalRewardInNXM).to.be.equal(expectedTotalReward);
   });
 
   it('emits MetadataSubmitted event with the provided ipfsMetadata when it is not empty string', async function () {


### PR DESCRIPTION
Adds an onlyMember modifier for the castVotes function since the stake
can be left behind if the membership is switched to another address and
that could make fraudulent voting using multiple addresses easier.
(However this edge case is properly handled by processFraud)

Makes castVote internal since castVotes can just as easily be used
instead (an there's a slight gas optimization from not checking
membership on each vote).

Updates tests to use castVotes instead.

Uses the Math library instead of duplicate code.

Fixes wrong natspec comments for updateUintParameters functions.

When calling `withdrawAsset` from `YieldTokenIncidents.sol` the function
uses `safeTransfer` instead.

Adds more comments for Assessment structs.

Adds explicit token (ETH/NXM) denomination for totalReward and
assessmentDeposit variables.

Removes unused enum.