### PR TITLE
Make sure stakingPoolAddress is emitted

### DIFF
--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -519,10 +519,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
     ProductInitializationParams[] memory productInitializationParams,
     uint depositAmount,
     uint trancheId
-  ) external returns (address stakingPoolAddress) {
-
-    emit StakingPoolCreated(stakingPoolAddress, manager, stakingPoolImplementation);
-
+  ) external returns (address) {
     CoverUtilsLib.PoolInitializationParams memory poolInitializationParams = CoverUtilsLib.PoolInitializationParams(
       stakingPoolCount++,
       manager,
@@ -531,7 +528,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
       maxPoolFee
     );
 
-    return CoverUtilsLib.createStakingPool(
+    address stakingPoolAddress = CoverUtilsLib.createStakingPool(
       _products,
       poolInitializationParams,
       productInitializationParams,
@@ -539,6 +536,10 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
       trancheId,
       master.getLatestAddress("PS")
     );
+
+    emit StakingPoolCreated(stakingPoolAddress, manager, stakingPoolImplementation);
+
+    return stakingPoolAddress;
   }
 
   function performStakeBurn(


### PR DESCRIPTION
Not sure if it was working using the previous declaration, but I assume
the event was emitted before the return value was initialized which
could have lead to stakingPoolAddress to be the 0 address. This should
make it obvious that never happens.