### PR TITLE
Fix proxy code hash used in staking pools addresses

### DIFF
--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -92,7 +92,8 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
     IQuotationData _quotationData,
     IProductsV1 _productsV1,
     address _coverNFT,
-    address _stakingPoolImplementation
+    address _stakingPoolImplementation,
+    address coverProxyAddress
   ) {
 
     // initialize immutable fields only
@@ -100,7 +101,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
     productsV1 = _productsV1;
     coverNFT = _coverNFT;
 
-    stakingPoolProxyCodeHash = CoverUtilsLib.calculateProxyCodeHash();
+    stakingPoolProxyCodeHash = CoverUtilsLib.calculateProxyCodeHash(coverProxyAddress);
     stakingPoolImplementation = _stakingPoolImplementation;
   }
 

--- a/contracts/modules/cover/CoverUtilsLib.sol
+++ b/contracts/modules/cover/CoverUtilsLib.sol
@@ -104,11 +104,11 @@ library CoverUtilsLib {
     params.coverNFT.safeMint(params.toNewOwner, newCoverId);
   }
 
-  function calculateProxyCodeHash() external view returns (bytes32) {
+  function calculateProxyCodeHash(address coverProxyAddress) external view returns (bytes32) {
     return keccak256(
       abi.encodePacked(
       type(MinimalBeaconProxy).creationCode,
-      abi.encode(address(this))
+      abi.encode(coverProxyAddress)
     ));
   }
 

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -1,7 +1,6 @@
 const { accounts, artifacts, web3, ethers } = require('hardhat');
 const { ether } = require('@openzeppelin/test-helpers');
 const { parseEther } = ethers.utils;
-const { setupUniswap } = require('../utils');
 const { ContractTypes } = require('../utils').constants;
 const { hex } = require('../utils').helpers;
 const { proposalCategories } = require('../utils');
@@ -28,7 +27,6 @@ const web3ToEthers = (x, signers) => {
 };
 
 async function setup () {
-
   // external
   const ERC20BlacklistableMock = artifacts.require('ERC20BlacklistableMock');
   const OwnedUpgradeabilityProxy = artifacts.require('OwnedUpgradeabilityProxy');
@@ -118,7 +116,7 @@ async function setup () {
 
   const chainlinkDAI = await ChainlinkAggregatorMock.new();
   const chainlinkSteth = await ChainlinkAggregatorMock.new();
-  await chainlinkSteth.setLatestAnswer(new BN(1e18.toString()));
+  await chainlinkSteth.setLatestAnswer(new BN((1e18).toString()));
   const priceFeedOracle = await PriceFeedOracle.new(
     [dai.address, stETH.address],
     [chainlinkDAI.address, chainlinkSteth.address],
@@ -153,7 +151,7 @@ async function setup () {
     cowSettlement.address,
     owner, // _swapController,
     master.address,
-    weth.address
+    weth.address,
   );
 
   const productsV1 = await ProductsV1.new();
@@ -328,7 +326,8 @@ async function setup () {
     qd.address,
     productsV1.address,
     stakingPool.address,
-    coverNFT.address
+    coverNFT.address,
+    cover.address,
   ]);
   //
   // {

--- a/test/unit/Cover/setup.js
+++ b/test/unit/Cover/setup.js
@@ -33,13 +33,12 @@ async function setup () {
   const CoverUtilsLib = await ethers.getContractFactory('CoverUtilsLib');
   const ERC20CustomDecimalsMock = await ethers.getContractFactory('ERC20CustomDecimalsMock');
 
-
   const coverUtilsLib = await CoverUtilsLib.deploy();
 
   const Cover = await ethers.getContractFactory('Cover', {
     libraries: {
-      CoverUtilsLib: coverUtilsLib.address
-    }
+      CoverUtilsLib: coverUtilsLib.address,
+    },
   });
 
   const [owner] = await ethers.getSigners();
@@ -90,7 +89,8 @@ async function setup () {
     quotationData.address,
     ethers.constants.AddressZero,
     futureCoverNFTAddress,
-    stakingPool.address
+    stakingPool.address,
+    coverAddress,
   );
   await cover.deployed();
 
@@ -169,23 +169,29 @@ async function setup () {
   }
 
   // add products
-  await cover.connect(accounts.advisoryBoardMembers[0]).addProducts([
-    {
-      productType: '0',
-      productAddress: '0x0000000000000000000000000000000000000000',
-      coverAssets: parseInt('111', 2), // ETH DAI and USDC supported
-      initialPriceRatio: '1000', // 10%
-      capacityReductionRatio: '0',
-    },
-  ], ['']);
+  await cover.connect(accounts.advisoryBoardMembers[0]).addProducts(
+    [
+      {
+        productType: '0',
+        productAddress: '0x0000000000000000000000000000000000000000',
+        coverAssets: parseInt('111', 2), // ETH DAI and USDC supported
+        initialPriceRatio: '1000', // 10%
+        capacityReductionRatio: '0',
+      },
+    ],
+    [''],
+  );
 
-  await cover.connect(accounts.advisoryBoardMembers[0]).addProductTypes([
-    {
-      descriptionIpfsHash: 'my ipfs hash',
-      claimMethod: '1',
-      gracePeriodInDays: '120',
-    },
-  ], ['']);
+  await cover.connect(accounts.advisoryBoardMembers[0]).addProductTypes(
+    [
+      {
+        descriptionIpfsHash: 'my ipfs hash',
+        claimMethod: '1',
+        gracePeriodInDays: '120',
+      },
+    ],
+    [''],
+  );
 
   const capacityFactor = '10000';
 


### PR DESCRIPTION
It should be calculated using the proxy address, not the implementation
since it is run in the constructor of Cover.sol which is not aware of
its proxy address without explicitly passing it offchain.