### PR TITLE
rename payoutAsset -> coverAsset

### DIFF
--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -43,7 +43,7 @@ struct PoolAllocation {
 
 struct CoverData {
   uint24 productId;
-  uint8 payoutAsset;
+  uint8 coverAsset;
   uint96 amountPaidOut;
 }
 
@@ -59,7 +59,7 @@ struct CoverSegment {
 struct BuyCoverParams {
   address owner;
   uint24 productId;
-  uint8 payoutAsset;
+  uint8 coverAsset;
   uint96 amount;
   uint32 period;
   uint maxPremiumInAsset;
@@ -119,7 +119,7 @@ interface ICover {
 
   function productTypes(uint id) external view returns (ProductType memory);
 
-  function isAssetSupported(uint32 payoutAssetsBitMap, uint8 payoutAsset) external view returns (bool);
+  function isAssetSupported(uint32 coverAssetsBitMap, uint8 coverAsset) external view returns (bool);
 
   function stakingPool(uint index) external view returns (IStakingPool);
 

--- a/contracts/interfaces/IIndividualClaims.sol
+++ b/contracts/interfaces/IIndividualClaims.sol
@@ -51,7 +51,7 @@ struct Claim {
   uint96 amount;
 
   // The index of of the asset address stored at addressOfAsset which is expected at payout.
-  uint8 payoutAsset;
+  uint8 coverAsset;
 
   // True if the payout is already redeemed. Prevents further payouts on the claim if it is
   // accepted.
@@ -94,7 +94,7 @@ interface IIndividualClaims {
     uint32 coverId,
     uint16 segmentId,
     uint96 amount,
-    uint8 payoutAsset,
+    uint8 coverAsset,
     bool payoutRedeemed
   );
 

--- a/contracts/interfaces/IYieldTokenIncidents.sol
+++ b/contracts/interfaces/IYieldTokenIncidents.sol
@@ -89,7 +89,7 @@ interface IYieldTokenIncidents {
     uint depeggedTokens,
     address payable payoutAddress,
     bytes calldata optionalParams
-  ) external returns (uint payoutAmount, uint8 payoutAsset);
+  ) external returns (uint payoutAmount, uint8 coverAsset);
 
   function updateUintParameters(UintParams[] calldata paramNames, uint[] calldata values) external;
 

--- a/contracts/mocks/Claims/CLMockCover.sol
+++ b/contracts/mocks/Claims/CLMockCover.sol
@@ -89,13 +89,13 @@ contract CLMockCover {
   function createMockCover(
     address owner,
     uint24 productId,
-    uint8 payoutAsset,
+    uint8 coverAsset,
     CoverSegment[] memory segments
   ) external payable returns (uint coverId) {
 
     coverData.push(CoverData(
         productId,
-        payoutAsset,
+        coverAsset,
         0
       ));
 

--- a/contracts/mocks/Incidents/ICMockCover.sol
+++ b/contracts/mocks/Incidents/ICMockCover.sol
@@ -68,13 +68,13 @@ contract ICMockCover {
   function createMockCover(
     address owner,
     uint24 productId,
-    uint8 payoutAsset,
+    uint8 coverAsset,
     CoverSegment[] memory segments
   ) external payable returns (uint coverId) {
 
     coverData.push(CoverData(
         productId,
-        payoutAsset,
+        coverAsset,
         0
       ));
 

--- a/contracts/modules/assessment/YieldTokenIncidents.sol
+++ b/contracts/modules/assessment/YieldTokenIncidents.sol
@@ -187,7 +187,7 @@ contract YieldTokenIncidents is IYieldTokenIncidents, MasterAwareV2 {
   /// @param incidentId      Index of the incident
   /// @param coverId         Index of the cover to be redeemed
   /// @param segmentId       Index of the cover's segment that's elidgible for redemption
-  /// @param depeggedTokens  The amount of depegged tokens to be swapped for the payoutAsset
+  /// @param depeggedTokens  The amount of depegged tokens to be swapped for the coverAsset
   /// @param payoutAddress   The addres where the payout must be sent to
   /// @param optionalParams  (Optional) Reserved for permit data which is still in draft phase.
   ///                        For tokens that already support it, use it by encoding the following
@@ -263,10 +263,10 @@ contract YieldTokenIncidents is IYieldTokenIncidents, MasterAwareV2 {
       {
         uint deductiblePriceBefore = uint(incident.priceBefore) *
           uint(config.payoutDeductibleRatio) / INCIDENT_PAYOUT_DEDUCTIBLE_DENOMINATOR;
-        (,uint payoutAssetDecimals) = IPool(
+        (,uint coverAssetDecimals) = IPool(
           internalContracts[uint(IMasterAwareV2.ID.P1)]
-        ).coverAssets(coverData.payoutAsset);
-        payoutAmount = depeggedTokens * deductiblePriceBefore / (10 ** uint(payoutAssetDecimals));
+        ).coverAssets(coverData.coverAsset);
+        payoutAmount = depeggedTokens * deductiblePriceBefore / (10 ** uint(coverAssetDecimals));
       }
 
       require(payoutAmount <= coverSegment.amount, "Payout exceeds covered amount");
@@ -299,14 +299,14 @@ contract YieldTokenIncidents is IYieldTokenIncidents, MasterAwareV2 {
     );
 
     IPool(internalContracts[uint(IMasterAwareV2.ID.P1)]).sendPayout(
-      coverData.payoutAsset,
+      coverData.coverAsset,
       payoutAddress,
       payoutAmount
     );
 
     emit IncidentPayoutRedeemed(msg.sender, payoutAmount, incidentId, coverId);
 
-    return (payoutAmount, coverData.payoutAsset);
+    return (payoutAmount, coverData.coverAsset);
   }
 
   /// Withdraws an amount of any asset held by this contract to a destination address.

--- a/contracts/modules/cover/CoverUtilsLib.sol
+++ b/contracts/modules/cover/CoverUtilsLib.sol
@@ -90,7 +90,7 @@ library CoverUtilsLib {
       _coverData.push(
         CoverData(
           uint24(productId),
-          currencyCode == "ETH" ? 0 : 1, // payoutAsset
+          currencyCode == "ETH" ? 0 : 1, // coverAsset
           0 // amountPaidOut
         )
       );
@@ -235,11 +235,11 @@ library CoverUtilsLib {
     }
 
     (
-    address payoutAsset,
+    address coverAsset,
     /*uint8 decimals*/
     ) = _pool.coverAssets(paymentAsset);
 
-    IERC20 token = IERC20(payoutAsset);
+    IERC20 token = IERC20(coverAsset);
     token.safeTransferFrom(msg.sender, address(_pool), premium);
 
     if (commission > 0) {

--- a/contracts/modules/cover/CoverViewer.sol
+++ b/contracts/modules/cover/CoverViewer.sol
@@ -21,8 +21,8 @@ contract CoverViewer {
     uint amountRemaining;
     uint coverStart;
     uint coverEnd;
-    uint8 payoutAsset;
-    string payoutAssetSymbol;
+    uint8 coverAsset;
+    string coverAssetSymbol;
     uint8 claimMethod;
     uint16 gracePeriodInDays;
   }
@@ -67,15 +67,15 @@ contract CoverViewer {
     Product memory product = cover().products(coverData.productId);
     ProductType memory productType = cover().productTypes(product.productType);
 
-    string memory payoutAssetSymbol;
-    if (coverData.payoutAsset == 0) {
-      payoutAssetSymbol = "ETH";
+    string memory coverAssetSymbol;
+    if (coverData.coverAsset == 0) {
+      coverAssetSymbol = "ETH";
     } else {
-      (address assetAddress,) = pool().coverAssets(coverData.payoutAsset);
+      (address assetAddress,) = pool().coverAssets(coverData.coverAsset);
       try IERC20Detailed(assetAddress).symbol() returns (string memory v) {
-        payoutAssetSymbol = v;
+        coverAssetSymbol = v;
       } catch {
-        // return payoutAssetSymbol as empty string and use coverData.payoutAsset instead in the UI
+        // return coverAssetSymbol as empty string and use coverData.coverAsset instead in the UI
       }
     }
 
@@ -87,8 +87,8 @@ contract CoverViewer {
       amountRemaining,
       coverStart,
       coverEnd,
-      coverData.payoutAsset,
-      payoutAssetSymbol,
+      coverData.coverAsset,
+      coverAssetSymbol,
       productType.claimMethod,
       productType.gracePeriodInDays
     );

--- a/test/unit/Assessment/helpers.js
+++ b/test/unit/Assessment/helpers.js
@@ -137,20 +137,20 @@ const getClaimStruct = ({
   amount,
   coverId,
   coverPeriod,
-  payoutAsset,
+  coverAsset,
   nxmPriceSnapshot,
   assessmentDepositRatio,
   payoutRedeemed,
-}) => [amount, coverId, coverPeriod, payoutAsset, nxmPriceSnapshot, assessmentDepositRatio, payoutRedeemed];
+}) => [amount, coverId, coverPeriod, coverAsset, nxmPriceSnapshot, assessmentDepositRatio, payoutRedeemed];
 
 const getIncidentStruct = ({
   productId,
   date,
-  payoutAsset,
+  coverAsset,
   activeCoverAmount,
   expectedPayoutRatio,
   assessmentDepositRatio,
-}) => [productId, date, payoutAsset, activeCoverAmount, expectedPayoutRatio, assessmentDepositRatio];
+}) => [productId, date, coverAsset, activeCoverAmount, expectedPayoutRatio, assessmentDepositRatio];
 
 module.exports = {
   STATUS,

--- a/test/unit/Cover/buyCover.js
+++ b/test/unit/Cover/buyCover.js
@@ -21,7 +21,7 @@ describe('buyCover', function () {
     } = this.accounts;
 
     const productId = 0;
-    const payoutAsset = 0; // ETH
+    const coverAsset = 0; // ETH
     const period = 3600 * 24 * 364; // 30 days
 
     const amount = parseEther('1000');
@@ -45,11 +45,11 @@ describe('buyCover', function () {
       {
         owner: coverBuyer1.address,
         productId,
-        payoutAsset,
+        coverAsset,
         amount,
         period,
         maxPremiumInAsset: expectedPremium,
-        paymentAsset: payoutAsset,
+        paymentAsset: coverAsset,
         payWitNXM: false,
         commissionRatio: parseEther('0'),
         commissionDestination: ZERO_ADDRESS,
@@ -65,7 +65,7 @@ describe('buyCover', function () {
     const expectedCoverId = '0';
 
     await assertCoverFields(cover, expectedCoverId,
-      { productId, payoutAsset, period, amount, targetPriceRatio });
+      { productId, coverAsset, period, amount, targetPriceRatio });
   });
 
   it('should purchase new cover using 2 staking pools', async function () {
@@ -78,7 +78,7 @@ describe('buyCover', function () {
     } = this.accounts;
 
     const productId = 0;
-    const payoutAsset = 0; // ETH
+    const coverAsset = 0; // ETH
     const period = 3600 * 24 * 28; // 30 days
 
     const amount = parseEther('1000');
@@ -107,11 +107,11 @@ describe('buyCover', function () {
       {
         owner: coverBuyer1.address,
         productId,
-        payoutAsset,
+        coverAsset,
         amount,
         period,
         maxPremiumInAsset: expectedPremium,
-        paymentAsset: payoutAsset,
+        paymentAsset: coverAsset,
         payWitNXM: false,
         commissionRatio: parseEther('0'),
         commissionDestination: ZERO_ADDRESS,
@@ -129,7 +129,7 @@ describe('buyCover', function () {
     const expectedCoverId = '0';
 
     await assertCoverFields(cover, expectedCoverId,
-      { productId, payoutAsset, period, amount, targetPriceRatio });
+      { productId, coverAsset, period, amount, targetPriceRatio });
   });
 
   it('should purchase new cover using NXM with commission', async function () {
@@ -142,7 +142,7 @@ describe('buyCover', function () {
     } = this.accounts;
 
     const productId = 0;
-    const payoutAsset = 0; // ETH
+    const coverAsset = 0; // ETH
     const period = 3600 * 24 * 30; // 30 days
 
     const amount = parseEther('1000');
@@ -173,11 +173,11 @@ describe('buyCover', function () {
       {
         owner: coverBuyer1.address,
         productId,
-        payoutAsset,
+        coverAsset,
         amount,
         period,
         maxPremiumInAsset: expectedPremium,
-        paymentAsset: payoutAsset,
+        paymentAsset: coverAsset,
         payWithNXM: true,
         commissionRatio: commissionRatio,
         commissionDestination: commissionReceiver.address,
@@ -201,7 +201,7 @@ describe('buyCover', function () {
     const expectedCoverId = '0';
 
     await assertCoverFields(cover, expectedCoverId,
-      { productId, payoutAsset, period, amount, targetPriceRatio });
+      { productId, coverAsset, period, amount, targetPriceRatio });
 
   });
 
@@ -216,7 +216,7 @@ describe('buyCover', function () {
     } = this.accounts;
 
     const productId = 0;
-    const payoutAsset = 1; // DAI
+    const coverAsset = 1; // DAI
     const period = 3600 * 24 * 30; // 30 days
 
     const amount = parseEther('1000');
@@ -247,11 +247,11 @@ describe('buyCover', function () {
       {
         owner: coverBuyer1.address,
         productId,
-        payoutAsset,
+        coverAsset,
         amount,
         period,
         maxPremiumInAsset: expectedPremium,
-        paymentAsset: payoutAsset,
+        paymentAsset: coverAsset,
         payWithNXM: false,
         commissionRatio: commissionRatio,
         commissionDestination: commissionReceiver.address,
@@ -275,7 +275,7 @@ describe('buyCover', function () {
     const expectedCoverId = '0';
 
     await assertCoverFields(cover, expectedCoverId,
-      { productId, payoutAsset, period, amount, targetPriceRatio });
+      { productId, coverAsset, period, amount, targetPriceRatio });
   });
 
 
@@ -290,7 +290,7 @@ describe('buyCover', function () {
     } = this.accounts;
 
     const productId = 0;
-    const payoutAsset = 2; // USDC
+    const coverAsset = 2; // USDC
     const period = 3600 * 24 * 30; // 30 days
 
     const amount = BigNumber.from(1000e6); // 6 decimals
@@ -321,11 +321,11 @@ describe('buyCover', function () {
       {
         owner: coverBuyer1.address,
         productId,
-        payoutAsset,
+        coverAsset,
         amount,
         period,
         maxPremiumInAsset: expectedPremium,
-        paymentAsset: payoutAsset,
+        paymentAsset: coverAsset,
         payWithNXM: false,
         commissionRatio: commissionRatio,
         commissionDestination: commissionReceiver.address,
@@ -349,7 +349,7 @@ describe('buyCover', function () {
     const expectedCoverId = '0';
 
     await assertCoverFields(cover, expectedCoverId,
-      { productId, payoutAsset, period, amount, targetPriceRatio });
+      { productId, coverAsset, period, amount, targetPriceRatio });
   });
 
   it('should revert for unavailable product', async function () {
@@ -361,7 +361,7 @@ describe('buyCover', function () {
     } = this.accounts;
 
     const productId = 1337;
-    const payoutAsset = 0; // ETH
+    const coverAsset = 0; // ETH
     const period = 3600 * 24 * 30; // 30 days
 
     const amount = parseEther('1000');
@@ -370,11 +370,11 @@ describe('buyCover', function () {
       {
         owner: coverBuyer1.address,
         productId,
-        payoutAsset,
+        coverAsset,
         amount,
         period,
         maxPremiumInAsset: '0',
-        paymentAsset: payoutAsset,
+        paymentAsset: coverAsset,
         payWitNXM: false,
         commissionRatio: parseEther('0'),
         commissionDestination: ZERO_ADDRESS,
@@ -396,7 +396,7 @@ describe('buyCover', function () {
     } = this.accounts;
 
     const productId = 0;
-    const payoutAsset = 10; // not ETH nor DAI nor USDC
+    const coverAsset = 10; // not ETH nor DAI nor USDC
     const period = 3600 * 24 * 30; // 30 days
 
     const amount = parseEther('1000');
@@ -405,11 +405,11 @@ describe('buyCover', function () {
       {
         owner: coverBuyer1.address,
         productId,
-        payoutAsset,
+        coverAsset,
         amount,
         period,
         maxPremiumInAsset: '0',
-        paymentAsset: payoutAsset,
+        paymentAsset: coverAsset,
         payWitNXM: false,
         commissionRatio: parseEther('0'),
         commissionDestination: ZERO_ADDRESS,
@@ -431,7 +431,7 @@ describe('buyCover', function () {
     } = this.accounts;
 
     const productId = 0;
-    const payoutAsset = 0; // ETH
+    const coverAsset = 0; // ETH
     const period = 3600 * 24 * 27; // 27 days
 
     const amount = parseEther('1000');
@@ -440,11 +440,11 @@ describe('buyCover', function () {
       {
         owner: coverBuyer1.address,
         productId,
-        payoutAsset,
+        coverAsset,
         amount,
         period,
         maxPremiumInAsset: '0',
-        paymentAsset: payoutAsset,
+        paymentAsset: coverAsset,
         payWitNXM: false,
         commissionRatio: parseEther('0'),
         commissionDestination: ZERO_ADDRESS,
@@ -466,7 +466,7 @@ describe('buyCover', function () {
     } = this.accounts;
 
     const productId = 0;
-    const payoutAsset = 0; // ETH
+    const coverAsset = 0; // ETH
     const period = 3600 * 24 * 366;
 
     const amount = parseEther('1000');
@@ -475,11 +475,11 @@ describe('buyCover', function () {
       {
         owner: coverBuyer1.address,
         productId,
-        payoutAsset,
+        coverAsset,
         amount,
         period,
         maxPremiumInAsset: '0',
-        paymentAsset: payoutAsset,
+        paymentAsset: coverAsset,
         payWitNXM: false,
         commissionRatio: parseEther('0'),
         commissionDestination: ZERO_ADDRESS,
@@ -501,7 +501,7 @@ describe('buyCover', function () {
     } = this.accounts;
 
     const productId = 0;
-    const payoutAsset = 0; // ETH
+    const coverAsset = 0; // ETH
     const period = 3600 * 24 * 30; // 30 days
 
     const amount = parseEther('1000');
@@ -510,11 +510,11 @@ describe('buyCover', function () {
       {
         owner: coverBuyer1.address,
         productId,
-        payoutAsset,
+        coverAsset,
         amount,
         period,
         maxPremiumInAsset: '0',
-        paymentAsset: payoutAsset,
+        paymentAsset: coverAsset,
         payWitNXM: false,
         commissionRatio: '2501',
         commissionDestination: ZERO_ADDRESS,
@@ -537,7 +537,7 @@ describe('buyCover', function () {
     } = this.accounts;
 
     const productId = 0;
-    const payoutAsset = 0; // ETH
+    const coverAsset = 0; // ETH
     const period = 3600 * 24 * 364; // 30 days
 
     const amount = BigNumber.from('0');
@@ -558,11 +558,11 @@ describe('buyCover', function () {
       {
         owner: coverBuyer1.address,
         productId,
-        payoutAsset,
+        coverAsset,
         amount,
         period,
         maxPremiumInAsset: expectedPremium,
-        paymentAsset: payoutAsset,
+        paymentAsset: coverAsset,
         payWitNXM: false,
         commissionRatio: parseEther('0'),
         commissionDestination: ZERO_ADDRESS,

--- a/test/unit/Cover/editCover.js
+++ b/test/unit/Cover/editCover.js
@@ -7,7 +7,7 @@ describe('editCover', function () {
 
   const coverBuyFixture = {
     productId: 0,
-    payoutAsset: 0, // ETH
+    coverAsset: 0, // ETH
     period: 3600 * 24 * 30, // 30 days
 
     amount: parseEther('1000'),
@@ -29,7 +29,7 @@ describe('editCover', function () {
 
     const {
       productId,
-      payoutAsset,
+      coverAsset,
       period,
       amount,
       priceDenominator,
@@ -50,11 +50,11 @@ describe('editCover', function () {
       {
         owner: coverBuyer1.address,
         productId,
-        payoutAsset,
+        coverAsset,
         amount: increasedAmount,
         period,
         maxPremiumInAsset: expectedEditPremium.add(1),
-        paymentAsset: payoutAsset,
+        paymentAsset: coverAsset,
         payWitNXM: false,
         commissionRatio: parseEther('0'),
         commissionDestination: ZERO_ADDRESS,
@@ -68,7 +68,7 @@ describe('editCover', function () {
     await tx.wait();
 
     await assertCoverFields(cover, expectedCoverId,
-      { productId, payoutAsset, period: period, amount: increasedAmount, targetPriceRatio, segmentId: '1' },
+      { productId, coverAsset, period: period, amount: increasedAmount, targetPriceRatio, segmentId: '1' },
     );
   });
 
@@ -82,7 +82,7 @@ describe('editCover', function () {
 
     const {
       productId,
-      payoutAsset,
+      coverAsset,
       period,
       amount,
       targetPriceRatio,
@@ -102,11 +102,11 @@ describe('editCover', function () {
       {
         owner: coverBuyer1.address,
         productId,
-        payoutAsset,
+        coverAsset,
         amount,
         period: increasedPeriod,
         maxPremiumInAsset: expectedEditPremium.add(10),
-        paymentAsset: payoutAsset,
+        paymentAsset: coverAsset,
         payWitNXM: false,
         commissionRatio: parseEther('0'),
         commissionDestination: ZERO_ADDRESS,
@@ -121,7 +121,7 @@ describe('editCover', function () {
     await tx.wait();
 
     await assertCoverFields(cover, expectedCoverId,
-      { productId, payoutAsset, period: increasedPeriod, amount: amount, targetPriceRatio, segmentId: '1' },
+      { productId, coverAsset, period: increasedPeriod, amount: amount, targetPriceRatio, segmentId: '1' },
     );
   });
 
@@ -135,7 +135,7 @@ describe('editCover', function () {
 
     const {
       productId,
-      payoutAsset,
+      coverAsset,
       period,
       amount,
       targetPriceRatio,
@@ -158,11 +158,11 @@ describe('editCover', function () {
       {
         owner: coverBuyer1.address,
         productId,
-        payoutAsset,
+        coverAsset,
         amount: increasedAmount,
         period: increasedPeriod,
         maxPremiumInAsset: expectedEditPremium.add(10),
-        paymentAsset: payoutAsset,
+        paymentAsset: coverAsset,
         payWitNXM: false,
         commissionRatio: parseEther('0'),
         commissionDestination: ZERO_ADDRESS,
@@ -177,7 +177,7 @@ describe('editCover', function () {
     await tx.wait();
 
     await assertCoverFields(cover, expectedCoverId,
-      { productId, payoutAsset, period: increasedPeriod, amount: increasedAmount, targetPriceRatio, segmentId: '1' },
+      { productId, coverAsset, period: increasedPeriod, amount: increasedAmount, targetPriceRatio, segmentId: '1' },
     );
   });
 
@@ -191,7 +191,7 @@ describe('editCover', function () {
 
     const {
       productId,
-      payoutAsset,
+      coverAsset,
       period,
       amount,
       targetPriceRatio,
@@ -214,11 +214,11 @@ describe('editCover', function () {
       {
         owner: coverBuyer1.address,
         productId,
-        payoutAsset,
+        coverAsset,
         amount: decreasedAmount,
         period: increasedPeriod,
         maxPremiumInAsset: expectedEditPremium,
-        paymentAsset: payoutAsset,
+        paymentAsset: coverAsset,
         payWitNXM: false,
         commissionRatio: parseEther('0'),
         commissionDestination: ZERO_ADDRESS,
@@ -233,7 +233,7 @@ describe('editCover', function () {
     await tx.wait();
 
     await assertCoverFields(cover, expectedCoverId,
-      { productId, payoutAsset, period: increasedPeriod, amount: decreasedAmount, targetPriceRatio, segmentId: '1' },
+      { productId, coverAsset, period: increasedPeriod, amount: decreasedAmount, targetPriceRatio, segmentId: '1' },
     );
   });
 
@@ -247,7 +247,7 @@ describe('editCover', function () {
 
     const {
       productId,
-      payoutAsset,
+      coverAsset,
       period,
       amount,
       targetPriceRatio,
@@ -267,11 +267,11 @@ describe('editCover', function () {
       {
         owner: coverBuyer1.address,
         productId,
-        payoutAsset,
+        coverAsset,
         amount: increasedAmount,
         period,
         maxPremiumInAsset: expectedEditPremium.add(10),
-        paymentAsset: payoutAsset,
+        paymentAsset: coverAsset,
         payWitNXM: false,
         commissionRatio: parseEther('0'),
         commissionDestination: ZERO_ADDRESS,
@@ -286,7 +286,7 @@ describe('editCover', function () {
     await tx.wait();
 
     await assertCoverFields(cover, expectedCoverId,
-      { productId, payoutAsset, period: period, amount: increasedAmount, targetPriceRatio, segmentId: '1' },
+      { productId, coverAsset, period: period, amount: increasedAmount, targetPriceRatio, segmentId: '1' },
     );
   });
 
@@ -300,7 +300,7 @@ describe('editCover', function () {
 
     const {
       productId,
-      payoutAsset,
+      coverAsset,
       amount,
       targetPriceRatio,
       priceDenominator,
@@ -320,11 +320,11 @@ describe('editCover', function () {
       {
         owner: coverBuyer1.address,
         productId,
-        payoutAsset,
+        coverAsset,
         amount: increasedAmount,
         period: periodTooLong,
         maxPremiumInAsset: expectedEditPremium,
-        paymentAsset: payoutAsset,
+        paymentAsset: coverAsset,
         payWitNXM: false,
         commissionRatio: parseEther('0'),
         commissionDestination: ZERO_ADDRESS,
@@ -346,7 +346,7 @@ describe('editCover', function () {
 
     const {
       productId,
-      payoutAsset,
+      coverAsset,
       amount,
       period,
       priceDenominator
@@ -366,11 +366,11 @@ describe('editCover', function () {
       {
         owner: coverBuyer1.address,
         productId,
-        payoutAsset,
+        coverAsset,
         amount: increasedAmount,
         period,
         maxPremiumInAsset: expectedEditPremium,
-        paymentAsset: payoutAsset,
+        paymentAsset: coverAsset,
         payWitNXM: false,
         commissionRatio: '2600', // too high
         commissionDestination: ZERO_ADDRESS,

--- a/test/unit/Cover/expireCover.js
+++ b/test/unit/Cover/expireCover.js
@@ -12,7 +12,7 @@ describe('expireCover', function () {
 
   const ethCoverBuyFixture = {
     productId: 0,
-    payoutAsset: 0, // ETH
+    coverAsset: 0, // ETH
     period: 3600 * 24 * 30, // 30 days
 
     amount: parseEther('1000'),
@@ -32,7 +32,7 @@ describe('expireCover', function () {
     } = this.accounts;
 
     const {
-      payoutAsset,
+      coverAsset,
     } = ethCoverBuyFixture;
 
     await cover.connect(emergencyAdmin).enableActiveCoverAmountTracking([], []);
@@ -47,7 +47,7 @@ describe('expireCover', function () {
 
     await cover.expireCover(0);
 
-    const activeCoverAmountAfterExpiry = await cover.totalActiveCoverInAsset(payoutAsset);
+    const activeCoverAmountAfterExpiry = await cover.totalActiveCoverInAsset(coverAsset);
     bnEqual(activeCoverAmountAfterExpiry, parseEther('0'));
 
     const segmentId = '0';

--- a/test/unit/Cover/helpers.js
+++ b/test/unit/Cover/helpers.js
@@ -57,14 +57,14 @@ async function createStakingPool (
 async function assertCoverFields (
   cover,
   coverId,
-  { productId, payoutAsset, period, amount, targetPriceRatio, segmentId = '0', amountPaidOut = '0' },
+  { productId, coverAsset, period, amount, targetPriceRatio, segmentId = '0', amountPaidOut = '0' },
 ) {
   const storedCoverData = await cover.coverData(coverId);
 
   const segment = await cover.coverSegments(coverId, segmentId);
 
   assert.equal(storedCoverData.productId, productId);
-  assert.equal(storedCoverData.payoutAsset, payoutAsset);
+  assert.equal(storedCoverData.coverAsset, coverAsset);
   bnEqual(storedCoverData.amountPaidOut, amountPaidOut);
   assert.equal(segment.period, period);
   assert.equal(segment.amount.toString(), amount.toString());
@@ -74,7 +74,7 @@ async function assertCoverFields (
 async function buyCoverOnOnePool (
   {
     productId,
-    payoutAsset,
+    coverAsset,
     period,
     amount,
     targetPriceRatio,
@@ -101,11 +101,11 @@ async function buyCoverOnOnePool (
     {
       owner: coverBuyer1.address,
       productId,
-      payoutAsset,
+      coverAsset,
       amount,
       period,
       maxPremiumInAsset: expectedPremium,
-      paymentAsset: payoutAsset,
+      paymentAsset: coverAsset,
       payWitNXM: false,
       commissionRatio: parseEther('0'),
       commissionDestination: ZERO_ADDRESS,

--- a/test/unit/Cover/performStakeBurn.js
+++ b/test/unit/Cover/performStakeBurn.js
@@ -10,7 +10,7 @@ describe('performStakeBurn', function () {
 
   const coverBuyFixture = {
     productId: 0,
-    payoutAsset: 0, // ETH
+    coverAsset: 0, // ETH
     period: 3600 * 24 * 30, // 30 days
 
     amount: parseEther('1000'),
@@ -32,7 +32,7 @@ describe('performStakeBurn', function () {
 
     const {
       productId,
-      payoutAsset,
+      coverAsset,
       period,
       amount,
       targetPriceRatio
@@ -64,7 +64,7 @@ describe('performStakeBurn', function () {
       expectedCoverId,
       {
         productId,
-        payoutAsset,
+        coverAsset,
         period: period,
         amount: remainingAmount,
         targetPriceRatio,
@@ -81,7 +81,7 @@ describe('performStakeBurn', function () {
     bnEqual(burnStakeCalledWith.period, period);
     bnEqual(burnStakeCalledWith.amount, expectedBurnAmount);
 
-    const activeCoverAmount = await cover.totalActiveCoverInAsset(payoutAsset);
+    const activeCoverAmount = await cover.totalActiveCoverInAsset(coverAsset);
     bnEqual(activeCoverAmount, amount.sub(burnAmount));
   });
 });

--- a/test/unit/Cover/totalActiveCoverInAsset.js
+++ b/test/unit/Cover/totalActiveCoverInAsset.js
@@ -11,7 +11,7 @@ describe('totalActiveCoverInAsset', function () {
 
   const ethCoverBuyFixture = {
     productId: 0,
-    payoutAsset: 0, // ETH
+    coverAsset: 0, // ETH
     period: 3600 * 24 * 30, // 30 days
 
     amount: parseEther('1000'),
@@ -25,7 +25,7 @@ describe('totalActiveCoverInAsset', function () {
 
   const daiCoverBuyFixture = {
     productId: 0,
-    payoutAsset: 1, // DAI
+    coverAsset: 1, // DAI
     period: 3600 * 24 * 30, // 30 days
 
     amount: parseEther('1000'),
@@ -46,7 +46,7 @@ describe('totalActiveCoverInAsset', function () {
 
 
     const {
-      payoutAsset,
+      coverAsset,
       amount,
     } = ethCoverBuyFixture;
 
@@ -56,7 +56,7 @@ describe('totalActiveCoverInAsset', function () {
 
     await buyCoverOnOnePool.call(this, ethCoverBuyFixture);
 
-    const activeCoverAmount = await cover.totalActiveCoverInAsset(payoutAsset);
+    const activeCoverAmount = await cover.totalActiveCoverInAsset(coverAsset);
     bnEqual(activeCoverAmount, amount);
   });
 
@@ -69,7 +69,7 @@ describe('totalActiveCoverInAsset', function () {
     } = this.accounts;
 
     const {
-      payoutAsset,
+      coverAsset,
       amount,
     } = daiCoverBuyFixture;
 
@@ -84,7 +84,7 @@ describe('totalActiveCoverInAsset', function () {
 
     await buyCoverOnOnePool.call(this, daiCoverBuyFixture);
 
-    const activeCoverAmount = await cover.totalActiveCoverInAsset(payoutAsset);
+    const activeCoverAmount = await cover.totalActiveCoverInAsset(coverAsset);
     bnEqual(activeCoverAmount, amount);
   });
 

--- a/test/unit/IndividualClaims/helpers.js
+++ b/test/unit/IndividualClaims/helpers.js
@@ -31,12 +31,12 @@ const submitClaim = ({ accounts, contracts, config }) => async ({
   segmentId = 0,
   amount = parseEther('1'),
   coverPeriod = 0,
-  payoutAsset = 0,
+  coverAsset = 0,
   ipfsMetadata = '',
   sender,
   value,
 }) => {
-  const [deposit] = await contracts.individualClaims.getAssessmentDepositAndReward(amount, coverPeriod, payoutAsset);
+  const [deposit] = await contracts.individualClaims.getAssessmentDepositAndReward(amount, coverPeriod, coverAsset);
   return await contracts.individualClaims
     .connect(sender || accounts[0])
     .submitClaim(coverId, segmentId, amount, ipfsMetadata, {
@@ -54,20 +54,20 @@ const getClaimDetailsStruct = ({
   amount,
   coverId,
   coverPeriod,
-  payoutAsset,
+  coverAsset,
   nxmPriceSnapshot,
   minAssessmentDepositRatio,
   payoutRedeemed,
-}) => [amount, coverId, coverPeriod, payoutAsset, nxmPriceSnapshot, minAssessmentDepositRatio, payoutRedeemed];
+}) => [amount, coverId, coverPeriod, coverAsset, nxmPriceSnapshot, minAssessmentDepositRatio, payoutRedeemed];
 
 const getIncidentDetailsStruct = ({
   productId,
   date,
-  payoutAsset,
+  coverAsset,
   activeCoverAmount,
   expectedPayoutRatio,
   minAssessmentDepositRatio,
-}) => [productId, date, payoutAsset, activeCoverAmount, expectedPayoutRatio, minAssessmentDepositRatio];
+}) => [productId, date, coverAsset, activeCoverAmount, expectedPayoutRatio, minAssessmentDepositRatio];
 
 module.exports = {
   ASSET,

--- a/test/unit/IndividualClaims/submitClaim.js
+++ b/test/unit/IndividualClaims/submitClaim.js
@@ -138,7 +138,7 @@ describe('submitClaim', function () {
     const [coverOwner] = this.accounts.members;
     const coverPeriod = daysToSeconds(30);
     const coverAmount = parseEther('100');
-    const payoutAsset = ASSET.ETH;
+    const coverAsset = ASSET.ETH;
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
       await cover.createMockCover(
@@ -150,7 +150,7 @@ describe('submitClaim', function () {
     }
     const coverId = 0;
 
-    const [deposit] = await individualClaims.getAssessmentDepositAndReward(coverAmount, coverPeriod, payoutAsset);
+    const [deposit] = await individualClaims.getAssessmentDepositAndReward(coverAmount, coverPeriod, coverAsset);
     await expect(
       individualClaims.connect(coverOwner).submitClaim(coverId, 0, coverAmount, '', {
         value: deposit.div('2'),
@@ -163,9 +163,9 @@ describe('submitClaim', function () {
     const [coverOwner] = this.accounts.members;
     const coverPeriod = daysToSeconds(30);
     const coverAmount = parseEther('100');
-    const payoutAsset = ASSET.ETH;
+    const coverAsset = ASSET.ETH;
 
-    const [deposit] = await individualClaims.getAssessmentDepositAndReward(coverAmount, coverPeriod, payoutAsset);
+    const [deposit] = await individualClaims.getAssessmentDepositAndReward(coverAmount, coverPeriod, coverAsset);
 
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
@@ -224,7 +224,7 @@ describe('submitClaim', function () {
     const [coverOwner] = this.accounts.members;
     const coverPeriod = daysToSeconds(30);
     const coverAmount = parseEther('100');
-    const payoutAsset = ASSET.ETH;
+    const coverAsset = ASSET.ETH;
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
       await cover.createMockCover(
@@ -239,7 +239,7 @@ describe('submitClaim', function () {
     }
     const coverId = 0;
 
-    const [deposit] = await individualClaims.getAssessmentDepositAndReward(coverAmount, coverPeriod, payoutAsset);
+    const [deposit] = await individualClaims.getAssessmentDepositAndReward(coverAmount, coverPeriod, coverAsset);
 
     await expect(
       individualClaims.connect(coverOwner).submitClaim(coverId, 0, coverAmount.add('1'), '', {
@@ -260,7 +260,7 @@ describe('submitClaim', function () {
     const [coverOwner] = this.accounts.members;
     const coverPeriod = daysToSeconds(30);
     const coverAmount = parseEther('100');
-    const payoutAsset = ASSET.ETH;
+    const coverAsset = ASSET.ETH;
     const { timestamp } = await ethers.provider.getBlock('latest');
     await cover.createMockCover(
       coverOwner.address,
@@ -273,7 +273,7 @@ describe('submitClaim', function () {
     );
     const coverId = 0;
 
-    const [deposit] = await individualClaims.getAssessmentDepositAndReward(coverAmount, coverPeriod, payoutAsset);
+    const [deposit] = await individualClaims.getAssessmentDepositAndReward(coverAmount, coverPeriod, coverAsset);
 
     await expect(
       individualClaims.connect(coverOwner).submitClaim(coverId, 1, coverAmount, '', {
@@ -292,14 +292,14 @@ describe('submitClaim', function () {
     const [coverOwner] = this.accounts.members;
     const coverPeriod = daysToSeconds(30);
     const coverAmount = parseEther('100');
-    const payoutAsset = ASSET.ETH;
+    const coverAsset = ASSET.ETH;
     const { gracePeriodInDays } = await cover.productTypes(0);
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
       await cover.createMockCover(
         coverOwner.address,
         0, // productId
-        payoutAsset,
+        coverAsset,
         [
           [coverAmount, timestamp + 1, coverPeriod, 0, false, 0],
           [coverAmount, timestamp + coverPeriod + 1, coverPeriod, 0, false, 0],
@@ -312,7 +312,7 @@ describe('submitClaim', function () {
     await setTime(currentTime + coverPeriod + daysToSeconds(gracePeriodInDays) + 1);
     const coverId = 0;
 
-    const [deposit] = await individualClaims.getAssessmentDepositAndReward(coverAmount, coverPeriod, payoutAsset);
+    const [deposit] = await individualClaims.getAssessmentDepositAndReward(coverAmount, coverPeriod, coverAsset);
 
     await expect(
       individualClaims.connect(coverOwner).submitClaim(coverId, 0, coverAmount, '', {
@@ -332,13 +332,13 @@ describe('submitClaim', function () {
     const [coverOwner] = this.accounts.members;
     const coverPeriod = daysToSeconds(30);
     const coverAmount = parseEther('100');
-    const payoutAsset = ASSET.ETH;
+    const coverAsset = ASSET.ETH;
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
       await cover.createMockCover(
         coverOwner.address,
         0, // productId
-        payoutAsset,
+        coverAsset,
         [[coverAmount, timestamp + 1, coverPeriod, 0, false, 0]],
       );
     }
@@ -348,7 +348,7 @@ describe('submitClaim', function () {
     const [expectedDeposit, expectedTotalReward] = await individualClaims.getAssessmentDepositAndReward(
       coverAmount,
       coverPeriod,
-      payoutAsset,
+      coverAsset,
     );
 
     await individualClaims.connect(coverOwner).submitClaim(coverId, 0, coverAmount, '', { value: expectedDeposit });

--- a/test/unit/YieldTokenIncidents/helpers.js
+++ b/test/unit/YieldTokenIncidents/helpers.js
@@ -79,11 +79,11 @@ const getVoteStruct = ({ accepted, denied, start, end }) => [accepted, denied, s
 const getIncidentStruct = ({
   productId,
   date,
-  payoutAsset,
+  coverAsset,
   activeCoverAmount,
   expectedPayoutRatio,
   assessmentDepositRatio,
-}) => [productId, date, payoutAsset, activeCoverAmount, expectedPayoutRatio, assessmentDepositRatio];
+}) => [productId, date, coverAsset, activeCoverAmount, expectedPayoutRatio, assessmentDepositRatio];
 
 module.exports = {
   ASSET,


### PR DESCRIPTION
Description
Fixes Issue: https://github.com/NexusMutual/smart-contracts/issues/355

Rename for less confusion.

Semantically, a payoutAsset is the same as a coverAsset so they should converge on the same name.


Type of change

Chore 

How Has This Been Tested?

All curent tests running again.

```npm run test-unit```

See the added test in the PR.

npm run test-unit