### PR TITLE
chore: silence unused variable warnings and function visibility.

### DIFF
--- a/contracts/modules/cover/CoverUtilsLib.sol
+++ b/contracts/modules/cover/CoverUtilsLib.sol
@@ -112,7 +112,7 @@ library CoverUtilsLib {
     params.coverNFT.safeMint(params.toNewOwner, newCoverId);
   }
 
-  function calculateProxyCodeHash(address coverProxyAddress) external view returns (bytes32) {
+  function calculateProxyCodeHash(address coverProxyAddress) external pure returns (bytes32) {
     return keccak256(
       abi.encodePacked(
       type(MinimalBeaconProxy).creationCode,

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -191,6 +191,7 @@ contract StakingPool is IStakingPool, SolmateERC721 {
   }
 
   function tokenURI(uint256 id) public pure override returns (string memory) {
+    id;  // To silence unused param warning. Remove once fn is implemented
     return "";
   }
 
@@ -1224,10 +1225,12 @@ contract StakingPool is IStakingPool, SolmateERC721 {
   /* management */
 
   function addProducts(ProductParams[] memory params) external onlyManager {
+    totalSupply = totalSupply;  // To silence view fn warning. Remove once implemented
     params;
   }
 
   function removeProducts(uint[] memory productIds) external onlyManager {
+    totalSupply = totalSupply;  // To silence view fn warning. Remove once implemented
     productIds;
   }
 


### PR DESCRIPTION
Made some code changes to silence 4 warnings. 3 of which are only temporariy until StakingPool functions are finished.
- Changed calculateProxyCodeHash() from view to pure. 
- Added placeholder code to silence unused parameter in StakingPool.tokenURI()
- Added sstore to StakingPool.removeProduct() & addProduct() to avoid warning that function should be `view`

Fixes #271 

### Type of change
- Chore


## How Has This Been Tested?
- `npx hardhat clean && npm run compile` 
