### PR TITLE
chore: replace safeMint() calls with regular mint()

### DIFF
--- a/contracts/interfaces/ICoverNFT.sol
+++ b/contracts/interfaces/ICoverNFT.sol
@@ -6,7 +6,7 @@ import "@openzeppelin/contracts-v4/token/ERC721/IERC721.sol";
 
 interface ICoverNFT is IERC721 {
 
-  function safeMint(address to, uint tokenId) external;
+  function mint(address to, uint tokenId) external;
 
   function isApprovedOrOwner(address spender, uint tokenId) external returns (bool);
 

--- a/contracts/interfaces/IERC721Mock.sol
+++ b/contracts/interfaces/IERC721Mock.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.8.0;
 import "@openzeppelin/contracts-v4/token/ERC721/IERC721.sol";
 
 interface IERC721Mock is IERC721 {
-  function safeMint(address to, uint tokenId) external;
+  function mint(address to, uint tokenId) external;
 
   function isApprovedOrOwner(address spender, uint tokenId) external returns (bool);
 }

--- a/contracts/mocks/Claims/CLMockCover.sol
+++ b/contracts/mocks/Claims/CLMockCover.sol
@@ -104,7 +104,7 @@ contract CLMockCover {
     }
 
     coverId = coverData.length - 1;
-    coverNFT.safeMint(owner, coverId);
+    coverNFT.mint(owner, coverId);
   }
 
   function addProductType(

--- a/contracts/mocks/Claims/CLMockUnknownNFT.sol
+++ b/contracts/mocks/Claims/CLMockUnknownNFT.sol
@@ -9,8 +9,8 @@ contract CLMockUnknownNFT is ERC721 {
   constructor(string memory name_, string memory symbol_) ERC721(name_, symbol_) {
   }
 
-  function safeMint(address to, uint tokenId) external {
-    _safeMint(to, tokenId);
+  function mint(address to, uint tokenId) external {
+    _mint(to, tokenId);
   }
 
 }

--- a/contracts/mocks/Incidents/ICMockCover.sol
+++ b/contracts/mocks/Incidents/ICMockCover.sol
@@ -83,7 +83,7 @@ contract ICMockCover {
     }
 
     coverId = coverData.length - 1;
-    coverNFT.safeMint(owner, coverId);
+    coverNFT.mint(owner, coverId);
   }
 
   function coverSegments(

--- a/contracts/mocks/Incidents/ICMockUnknownNFT.sol
+++ b/contracts/mocks/Incidents/ICMockUnknownNFT.sol
@@ -9,8 +9,8 @@ contract ICMockUnknownNFT is ERC721 {
   constructor(string memory name_, string memory symbol_) ERC721(name_, symbol_) {
   }
 
-  function safeMint(address to, uint tokenId) external {
-    _safeMint(to, tokenId);
+  function mint(address to, uint tokenId) external {
+    _mint(to, tokenId);
   }
 
 }

--- a/contracts/mocks/MemberRoles/MRMockCover.sol
+++ b/contracts/mocks/MemberRoles/MRMockCover.sol
@@ -30,7 +30,7 @@ contract MRMockCover {
   }
 
   function createMockCover(address to, uint tokenId) public {
-    coverNFT.safeMint(to, tokenId);
+    coverNFT.mint(to, tokenId);
   }
 
 }

--- a/contracts/mocks/Tokens/ERC721Mock.sol
+++ b/contracts/mocks/Tokens/ERC721Mock.sol
@@ -10,8 +10,8 @@ contract ERC721Mock is ERC721 {
     /* noop */
   }
 
-  function safeMint(address to, uint tokenId) external {
-    _safeMint(to, tokenId);
+  function mint(address to, uint tokenId) external {
+    _mint(to, tokenId);
   }
 
   function isApprovedOrOwner(address spender, uint256 tokenId) external view returns (bool) {

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -217,7 +217,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
     ));
 
     uint coverId = _coverData.length - 1;
-    ICoverNFT(coverNFT).safeMint(params.owner, coverId);
+    ICoverNFT(coverNFT).mint(params.owner, coverId);
 
     emit CoverBought(coverId, params.productId, 0, msg.sender, params.ipfsData);
     return coverId;

--- a/contracts/modules/cover/CoverNFT.sol
+++ b/contracts/modules/cover/CoverNFT.sol
@@ -19,8 +19,8 @@ contract CoverNFT is ERC721 {
 
   }
 
-  function safeMint(address to, uint tokenId) external onlyOperator {
-    _safeMint(to, tokenId);
+  function mint(address to, uint tokenId) external onlyOperator {
+    _mint(to, tokenId);
   }
 
   function isApprovedOrOwner(address spender, uint tokenId) external view returns (bool) {

--- a/contracts/modules/cover/CoverUtilsLib.sol
+++ b/contracts/modules/cover/CoverUtilsLib.sol
@@ -109,7 +109,7 @@ library CoverUtilsLib {
       )
     );
 
-    params.coverNFT.safeMint(params.toNewOwner, newCoverId);
+    params.coverNFT.mint(params.toNewOwner, newCoverId);
   }
 
   function calculateProxyCodeHash(address coverProxyAddress) external pure returns (bytes32) {

--- a/test/unit/MemberRoles/switchMembershipAndAssets.js
+++ b/test/unit/MemberRoles/switchMembershipAndAssets.js
@@ -126,15 +126,15 @@ describe('switchMembershipAndAssets', function () {
       nonMembers: [nonMember1],
     } = this.accounts;
 
-    await stakingPool0.connect(member1).safeMint(member1.address, 0);
-    await stakingPool0.connect(member1).safeMint(member1.address, 1);
+    await stakingPool0.connect(member1).mint(member1.address, 0);
+    await stakingPool0.connect(member1).mint(member1.address, 1);
 
-    await stakingPool1.connect(member1).safeMint(member1.address, 0);
-    await stakingPool1.connect(member1).safeMint(member1.address, 1);
-    await stakingPool1.connect(member1).safeMint(member1.address, 2);
+    await stakingPool1.connect(member1).mint(member1.address, 0);
+    await stakingPool1.connect(member1).mint(member1.address, 1);
+    await stakingPool1.connect(member1).mint(member1.address, 2);
 
-    await stakingPool2.connect(member1).safeMint(member1.address, 0);
-    await stakingPool2.connect(member1).safeMint(member1.address, 1);
+    await stakingPool2.connect(member1).mint(member1.address, 0);
+    await stakingPool2.connect(member1).mint(member1.address, 1);
     await nxm.connect(member1).approve(memberRoles.address, ethers.constants.MaxUint256);
 
     const newMemberAddress = nonMember1.address;
@@ -188,10 +188,10 @@ describe('switchMembershipAndAssets', function () {
       nonMembers: [nonMember1],
     } = this.accounts;
 
-    await stakingPool0.connect(member1).safeMint(member2.address, 0);
-    await stakingPool0.connect(member1).safeMint(member2.address, 1);
+    await stakingPool0.connect(member1).mint(member2.address, 0);
+    await stakingPool0.connect(member1).mint(member2.address, 1);
 
-    await stakingPool1.connect(member1).safeMint(member1.address, 0);
+    await stakingPool1.connect(member1).mint(member1.address, 0);
 
     await nxm.connect(member1).approve(memberRoles.address, ethers.constants.MaxUint256);
 


### PR DESCRIPTION
Fixes #354
Changed all `safeMint()` function calls to use `mint()` instead. 


### Type of change
-  Chore 


## How Has This Been Tested?

I didn't add any further tests, as I didn't see any yet for the NFTs.
`npm run test`

