### PR TITLE
Check that when an asset is added to the pool it has an oracle

### DIFF
--- a/contracts/interfaces/IPriceFeedOracle.sol
+++ b/contracts/interfaces/IPriceFeedOracle.sol
@@ -2,9 +2,19 @@
 
 pragma solidity >=0.5.0;
 
+interface Aggregator {
+  function latestAnswer() external view returns (int);
+}
+
 interface IPriceFeedOracle {
 
+  struct OracleAsset {
+    Aggregator aggregator;
+    uint8 decimals;
+  }
+
   function ETH() external view returns (address);
+  function assets(address) external view returns (address, uint8);
 
   function getAssetToEthRate(address asset) external view returns (uint);
   function getAssetForEth(address asset, uint ethIn) external view returns (uint);

--- a/contracts/modules/capital/Pool.sol
+++ b/contracts/modules/capital/Pool.sol
@@ -218,6 +218,9 @@ contract Pool is IPool, MasterAware, ReentrancyGuard {
     require(_max >= _min, "Pool: max < min");
     require(_maxSlippageRatio <= MAX_SLIPPAGE_DENOMINATOR, "Pool: Max slippage ratio > 1");
 
+    (address aggregator, ) = priceFeedOracle.assets(assetAddress);
+    require(aggregator != address(0), "Pool: Asset lacks oracle");
+
     // Check whether the new asset already exists as a cover asset
     uint coverAssetsCount = coverAssets.length;
     for (uint i = 0; i < coverAssetsCount; i++) {

--- a/contracts/modules/capital/Pool.sol
+++ b/contracts/modules/capital/Pool.sol
@@ -2,7 +2,6 @@
 
 pragma solidity ^0.8.16;
 
-import "@openzeppelin/contracts-v4/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts-v4/utils/Address.sol";
 import "@openzeppelin/contracts-v4/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts-v4/security/ReentrancyGuard.sol";
@@ -741,14 +740,10 @@ contract Pool is IPool, MasterAware, ReentrancyGuard {
       for (uint i = 0; i < coverAssetsCount; i++) {
         Asset memory asset = coverAssets[i];
 
-        (address aggregator, ) = priceFeedOracle.assets(asset.assetAddress);
-
-        IERC20Detailed erc20 = IERC20Detailed(asset.assetAddress);
-
         if (asset.assetAddress != ETH) {
-          require(aggregator != address(0), "Pool: Asset lacks oracle");
+          (address aggregator, ) = priceFeedOracle.assets(asset.assetAddress);
+          require(aggregator != address(0), "Pool: Oracle lacks asset");
         }
-
       }
 
       priceFeedOracle = IPriceFeedOracle(value);

--- a/contracts/modules/capital/Pool.sol
+++ b/contracts/modules/capital/Pool.sol
@@ -13,6 +13,7 @@ import "../../interfaces/INXMToken.sol";
 import "../../interfaces/IPool.sol";
 import "../../interfaces/IPriceFeedOracle.sol";
 import "../../interfaces/ITokenController.sol";
+import "../../interfaces/IERC20Detailed.sol";
 import "../../libraries/SafeUintCast.sol";
 
 contract Pool is IPool, MasterAware, ReentrancyGuard {
@@ -741,7 +742,13 @@ contract Pool is IPool, MasterAware, ReentrancyGuard {
         Asset memory asset = coverAssets[i];
 
         (address aggregator, ) = priceFeedOracle.assets(asset.assetAddress);
-        require(aggregator != address(0), "Pool: Asset lacks oracle");
+
+        IERC20Detailed erc20 = IERC20Detailed(asset.assetAddress);
+
+        if (asset.assetAddress != ETH) {
+          require(aggregator != address(0), "Pool: Asset lacks oracle");
+        }
+
       }
 
       priceFeedOracle = IPriceFeedOracle(value);

--- a/contracts/modules/capital/Pool.sol
+++ b/contracts/modules/capital/Pool.sol
@@ -14,6 +14,7 @@ import "../../interfaces/IPriceFeedOracle.sol";
 import "../../interfaces/ITokenController.sol";
 import "../../interfaces/IERC20Detailed.sol";
 import "../../libraries/SafeUintCast.sol";
+import "hardhat/console.sol";
 
 contract Pool is IPool, MasterAware, ReentrancyGuard {
   using SafeERC20 for IERC20;
@@ -736,12 +737,20 @@ contract Pool is IPool, MasterAware, ReentrancyGuard {
     if (code == "PRC_FEED") {
 
       uint coverAssetsCount = coverAssets.length;
-
       for (uint i = 0; i < coverAssetsCount; i++) {
         Asset memory asset = coverAssets[i];
-
         if (asset.assetAddress != ETH) {
-          (address aggregator, ) = priceFeedOracle.assets(asset.assetAddress);
+          (address aggregator, ) = IPriceFeedOracle(value).assets(asset.assetAddress);
+
+          require(aggregator != address(0), "Pool: Oracle lacks asset");
+        }
+      }
+
+      uint investmentAssetsCount = investmentAssets.length;
+      for (uint i = 0; i < investmentAssetsCount; i++) {
+        Asset memory asset = investmentAssets[i];
+        if (asset.assetAddress != ETH) {
+          (address aggregator, ) = IPriceFeedOracle(value).assets(asset.assetAddress);
           require(aggregator != address(0), "Pool: Oracle lacks asset");
         }
       }

--- a/contracts/modules/capital/Pool.sol
+++ b/contracts/modules/capital/Pool.sol
@@ -14,7 +14,6 @@ import "../../interfaces/IPriceFeedOracle.sol";
 import "../../interfaces/ITokenController.sol";
 import "../../interfaces/IERC20Detailed.sol";
 import "../../libraries/SafeUintCast.sol";
-import "hardhat/console.sol";
 
 contract Pool is IPool, MasterAware, ReentrancyGuard {
   using SafeERC20 for IERC20;

--- a/contracts/modules/capital/Pool.sol
+++ b/contracts/modules/capital/Pool.sol
@@ -734,6 +734,16 @@ contract Pool is IPool, MasterAware, ReentrancyGuard {
     }
 
     if (code == "PRC_FEED") {
+
+      uint coverAssetsCount = coverAssets.length;
+
+      for (uint i = 0; i < coverAssetsCount; i++) {
+        Asset memory asset = coverAssets[i];
+
+        (address aggregator, ) = priceFeedOracle.assets(asset.assetAddress);
+        require(aggregator != address(0), "Pool: Asset lacks oracle");
+      }
+
       priceFeedOracle = IPriceFeedOracle(value);
       return;
     }

--- a/contracts/modules/capital/PriceFeedOracle.sol
+++ b/contracts/modules/capital/PriceFeedOracle.sol
@@ -5,17 +5,9 @@ pragma solidity ^0.5.0;
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "../../interfaces/IPriceFeedOracle.sol";
 
-interface Aggregator {
-  function latestAnswer() external view returns (int);
-}
 
 contract PriceFeedOracle is IPriceFeedOracle {
   using SafeMath for uint;
-
-  struct OracleAsset {
-    Aggregator aggregator;
-    uint8 decimals;
-  }
 
   mapping(address => OracleAsset) public assets;
 

--- a/test/unit/CowOperator/setup.js
+++ b/test/unit/CowOperator/setup.js
@@ -53,7 +53,7 @@ async function setup() {
   const priceFeedOracle = await PriceFeedOracle.deploy(
     [dai.address, stEth.address, usdc.address],
     [daiAggregator.address, stethAggregator.address, usdcAggregator.address],
-    [18, 18, 18],
+    [18, 18, 6],
   );
 
   // Deploy Pool

--- a/test/unit/CowOperator/setup.js
+++ b/test/unit/CowOperator/setup.js
@@ -107,7 +107,7 @@ async function setup() {
 const makeWrongValue = value => {
   if (isHexString(value)) {
     return hexlify(randomBytes(hexDataLength(value)));
-  } else if (value instanceof BigNumber) {
+  } else if (BigNumber.isBigNumber(value)) {
     return value.add(1);
   } else if (typeof value === 'number') {
     return value + 1;

--- a/test/unit/CowOperator/setup.js
+++ b/test/unit/CowOperator/setup.js
@@ -46,12 +46,14 @@ async function setup() {
   await daiAggregator.setLatestAnswer(0.0002 * 1e18); // 1 dai = 0.0002 eth, 1 eth = 5000 dai
   const stethAggregator = await ChainlinkAggregatorMock.deploy();
   await stethAggregator.setLatestAnswer(parseEther('1')); // 1 steth = 1 eth
+  const usdcAggregator = await ChainlinkAggregatorMock.deploy();
+  await usdcAggregator.setLatestAnswer(0.0002 * 1e18); // 1 usdc = 0.0002 eth, 1 eth = 5000 dai
 
   // Deploy PriceFeedOracle
   const priceFeedOracle = await PriceFeedOracle.deploy(
-    [dai.address, stEth.address],
-    [daiAggregator.address, stethAggregator.address],
-    [18, 18],
+    [dai.address, stEth.address, usdc.address],
+    [daiAggregator.address, stethAggregator.address, usdcAggregator.address],
+    [18, 18, 18],
   );
 
   // Deploy Pool

--- a/test/unit/Pool/addAsset.js
+++ b/test/unit/Pool/addAsset.js
@@ -1,7 +1,4 @@
-const {
-  artifacts,
-  web3,
-} = require('hardhat');
+const { artifacts, web3 } = require('hardhat');
 const {
   constants: { ZERO_ADDRESS },
   ether,
@@ -20,7 +17,6 @@ const ChainlinkAggregatorMock = artifacts.require('ChainlinkAggregatorMock');
 const assetAddress = '0xC0FfEec0ffeeC0FfEec0fFEec0FfeEc0fFEe0000';
 
 describe('addAsset', function () {
-
   before(async function () {
     const { pool, dai, stETH, chainlinkDAI, chainlinkSteth } = this;
 

--- a/test/unit/Pool/addAsset.js
+++ b/test/unit/Pool/addAsset.js
@@ -40,7 +40,7 @@ describe('addAsset', function () {
     await expectRevert(pool.addAsset(assetAddress, 18, '1', '0', '0', false, { from: governance }), 'Pool: max < min');
   });
 
-  it('reverts when max slippage ratio > 1', async function () {
+  it.only('reverts when max slippage ratio > 1', async function () {
     const { pool } = this;
 
     await expectRevert(

--- a/test/unit/Pool/addAsset.js
+++ b/test/unit/Pool/addAsset.js
@@ -77,6 +77,17 @@ describe('addAsset', function () {
     await expectRevert(pool.addAsset(dai.address, 18, '0', '1', '0', true, { from: governance }), 'Pool: Asset exists');
   });
 
+  it('reverts when asset lacks an oracle', async function () {
+    const { pool } = this;
+
+    const arbitraryAddress = '0x47ec31abc6b86e49933dC7B2969EBEbE3De662cA';
+
+    await expectRevert(
+      pool.addAsset(arbitraryAddress, 18, '0', '1', '0', true, { from: governance }),
+      'Pool: Asset lacks oracle',
+    );
+  });
+
   it('should correctly add the asset with its min, max, and slippage ratio', async function () {
     const { pool, dai, stETH, chainlinkDAI, chainlinkSteth } = this;
 

--- a/test/unit/Pool/index.js
+++ b/test/unit/Pool/index.js
@@ -1,7 +1,7 @@
 const { takeSnapshot, revertToSnapshot } = require('../utils').evm;
 const setup = require('./setup');
 
-describe('Pool unit tests', function () {
+describe.only('Pool unit tests', function () {
   before(setup);
 
   beforeEach(async function () {

--- a/test/unit/Pool/index.js
+++ b/test/unit/Pool/index.js
@@ -1,7 +1,7 @@
 const { takeSnapshot, revertToSnapshot } = require('../utils').evm;
 const setup = require('./setup');
 
-describe.only('Pool unit tests', function () {
+describe('Pool unit tests', function () {
   before(setup);
 
   beforeEach(async function () {

--- a/test/unit/Pool/removeAsset.js
+++ b/test/unit/Pool/removeAsset.js
@@ -1,9 +1,5 @@
 const { artifacts, web3 } = require('hardhat');
-const {
-  constants: { ZERO_ADDRESS },
-  ether,
-  expectRevert,
-} = require('@openzeppelin/test-helpers');
+const { ether, expectRevert } = require('@openzeppelin/test-helpers');
 const { assert } = require('chai');
 const { hex } = require('../utils').helpers;
 const {
@@ -12,6 +8,10 @@ const {
 const { BN } = web3.utils;
 
 const ETH = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
+
+const ERC20Mock = artifacts.require('ERC20Mock');
+const ChainlinkAggregatorMock = artifacts.require('ChainlinkAggregatorMock');
+const PriceFeedOracle = artifacts.require('PriceFeedOracle');
 
 describe('removeAsset', function () {
   it('reverts when not called by goverance', async function () {
@@ -37,10 +37,6 @@ describe('removeAsset', function () {
 
   it('should correctly remove the asset with its minAmount, maxAmount, and slippage ratio', async function () {
     const { pool, dai, stETH, chainlinkDAI, chainlinkSteth } = this;
-
-    const ERC20Mock = artifacts.require('ERC20Mock');
-    const ChainlinkAggregatorMock = artifacts.require('ChainlinkAggregatorMock');
-    const PriceFeedOracle = artifacts.require('PriceFeedOracle');
 
     const coverToken = await ERC20Mock.new();
     const investmentToken = await ERC20Mock.new();

--- a/test/unit/Pool/setSwapDetailsLastSwapTime.js
+++ b/test/unit/Pool/setSwapDetailsLastSwapTime.js
@@ -1,20 +1,47 @@
 const { ether } = require('@openzeppelin/test-helpers');
 const { expectRevert } = require('@openzeppelin/test-helpers');
 const { assert } = require('chai');
+const {
+  web3,
+  artifacts,
+} = require('hardhat');
 
 const {
   governanceContracts: [governance],
   generalPurpose: [arbitraryCaller],
 } = require('../utils').accounts;
+const { hex } = require('../utils').helpers;
+const { BN } = web3.utils;
 
+const PriceFeedOracle = artifacts.require('PriceFeedOracle');
+const ChainlinkAggregatorMock = artifacts.require('ChainlinkAggregatorMock');
 const ERC20Mock = artifacts.require('ERC20Mock');
 
 describe('setSwapDetailsLastSwapTime', function () {
+
+  before(async function () {
+    const { pool, dai, stETH, chainlinkDAI, chainlinkSteth } = this;
+
+    const otherToken = await ERC20Mock.new();
+
+    const chainlinkNewAsset = await ChainlinkAggregatorMock.new();
+    await chainlinkNewAsset.setLatestAnswer(new BN((1e18).toString()));
+
+    const priceFeedOracle = await PriceFeedOracle.new(
+      [dai.address, stETH.address, otherToken.address],
+      [chainlinkDAI.address, chainlinkSteth.address, chainlinkNewAsset.address],
+      [18, 18, 18],
+    );
+
+    await pool.updateAddressParameters(hex('PRC_FEED'), priceFeedOracle.address, { from: governance });
+
+    this.otherToken = otherToken;
+  });
+
   it('set last swap time for asset', async function () {
-    const { pool, swapOperator } = this;
+    const { pool, swapOperator, otherToken } = this;
 
     const tokenAmount = ether('100000');
-    const otherToken = await ERC20Mock.new();
     await pool.addAsset(otherToken.address, 18, '0', '0', 100, true, {
       from: governance,
     });
@@ -29,10 +56,9 @@ describe('setSwapDetailsLastSwapTime', function () {
   });
 
   it('revers if not called by swap operator', async function () {
-    const { pool } = this;
+    const { pool, otherToken } = this;
 
     const tokenAmount = ether('100000');
-    const otherToken = await ERC20Mock.new();
     await pool.addAsset(otherToken.address, 18, '0', '0', 100, true, {
       from: governance,
     });

--- a/test/unit/Pool/setSwapDetailsLastSwapTime.js
+++ b/test/unit/Pool/setSwapDetailsLastSwapTime.js
@@ -1,10 +1,7 @@
 const { ether } = require('@openzeppelin/test-helpers');
 const { expectRevert } = require('@openzeppelin/test-helpers');
 const { assert } = require('chai');
-const {
-  web3,
-  artifacts,
-} = require('hardhat');
+const { web3, artifacts } = require('hardhat');
 
 const {
   governanceContracts: [governance],
@@ -18,7 +15,6 @@ const ChainlinkAggregatorMock = artifacts.require('ChainlinkAggregatorMock');
 const ERC20Mock = artifacts.require('ERC20Mock');
 
 describe('setSwapDetailsLastSwapTime', function () {
-
   before(async function () {
     const { pool, dai, stETH, chainlinkDAI, chainlinkSteth } = this;
 

--- a/test/unit/Pool/setup.js
+++ b/test/unit/Pool/setup.js
@@ -96,6 +96,7 @@ async function setup() {
   this.tokenController = tokenController;
   this.dai = dai;
   this.chainlinkDAI = chainlinkDAI;
+  this.chainlinkSteth = chainlinkSteth;
   this.swapOperator = swapOperator;
   this.stETH = stETH;
 }

--- a/test/unit/Pool/setup.js
+++ b/test/unit/Pool/setup.js
@@ -21,6 +21,7 @@ async function setup() {
   const master = await MasterMock.new();
   const dai = await ERC20Mock.new();
   const stETH = await ERC20BlacklistableMock.new();
+  const otherAsset = await ERC20Mock.new();
 
   const ethToDaiRate = new BN((394.59 * 1e18).toString());
   const daiToEthRate = new BN(10).pow(new BN(36)).div(ethToDaiRate);
@@ -29,11 +30,13 @@ async function setup() {
   await chainlinkDAI.setLatestAnswer(daiToEthRate);
   const chainlinkSteth = await ChainlinkAggregatorMock.new();
   await chainlinkSteth.setLatestAnswer(new BN((1e18).toString()));
+  const chainlinkNewAsset = await ChainlinkAggregatorMock.new();
+  await chainlinkNewAsset.setLatestAnswer(new BN((1e18).toString()));
 
   const priceFeedOracle = await PriceFeedOracle.new(
-    [dai.address, stETH.address],
-    [chainlinkDAI.address, chainlinkSteth.address],
-    [18, 18],
+    [dai.address, stETH.address, otherAsset.address],
+    [chainlinkDAI.address, chainlinkSteth.address, chainlinkNewAsset.address],
+    [18, 18, 18],
   );
 
   const swapOperator = accounts.generalPurpose[10];
@@ -99,6 +102,7 @@ async function setup() {
   this.chainlinkSteth = chainlinkSteth;
   this.swapOperator = swapOperator;
   this.stETH = stETH;
+  this.otherAsset = otherAsset;
 }
 
 module.exports = setup;

--- a/test/unit/Pool/transferAssetToSwapOperator.js
+++ b/test/unit/Pool/transferAssetToSwapOperator.js
@@ -1,20 +1,47 @@
 const { ether } = require('@openzeppelin/test-helpers');
 const { expectRevert } = require('@openzeppelin/test-helpers');
 const { assert } = require('chai');
+const {
+  web3,
+  artifacts,
+} = require('hardhat');
 
 const {
   governanceContracts: [governance],
   generalPurpose: [arbitraryCaller],
 } = require('../utils').accounts;
+const { hex } = require('../utils').helpers;
+const { BN } = web3.utils;
 
+const PriceFeedOracle = artifacts.require('PriceFeedOracle');
+const ChainlinkAggregatorMock = artifacts.require('ChainlinkAggregatorMock');
 const ERC20Mock = artifacts.require('ERC20Mock');
 
 describe('transferAssetToSwapOperator', function () {
+
+  before(async function () {
+    const { pool, dai, stETH, chainlinkDAI, chainlinkSteth } = this;
+
+    const otherToken = await ERC20Mock.new();
+
+    const chainlinkNewAsset = await ChainlinkAggregatorMock.new();
+    await chainlinkNewAsset.setLatestAnswer(new BN((1e18).toString()));
+
+    const priceFeedOracle = await PriceFeedOracle.new(
+      [dai.address, stETH.address, otherToken.address],
+      [chainlinkDAI.address, chainlinkSteth.address, chainlinkNewAsset.address],
+      [18, 18, 18],
+    );
+
+    await pool.updateAddressParameters(hex('PRC_FEED'), priceFeedOracle.address, { from: governance });
+
+    this.otherToken = otherToken;
+  });
+
   it('transfers added ERC20 asset to swap operator', async function () {
-    const { pool, swapOperator } = this;
+    const { pool, swapOperator, otherToken } = this;
 
     const tokenAmount = ether('100000');
-    const otherToken = await ERC20Mock.new();
     await pool.addAsset(otherToken.address, 18, '0', '0', 100 /* 1% */, true, {
       from: governance,
     });
@@ -31,10 +58,9 @@ describe('transferAssetToSwapOperator', function () {
   });
 
   it('revers if not called by swap operator', async function () {
-    const { pool } = this;
+    const { pool, otherToken } = this;
 
     const tokenAmount = ether('100000');
-    const otherToken = await ERC20Mock.new();
     await pool.addAsset(otherToken.address, 18, '0', '0', 100 /* 1% */, true, {
       from: governance,
     });

--- a/test/unit/Pool/transferAssetToSwapOperator.js
+++ b/test/unit/Pool/transferAssetToSwapOperator.js
@@ -1,10 +1,7 @@
 const { ether } = require('@openzeppelin/test-helpers');
 const { expectRevert } = require('@openzeppelin/test-helpers');
 const { assert } = require('chai');
-const {
-  web3,
-  artifacts,
-} = require('hardhat');
+const { web3, artifacts } = require('hardhat');
 
 const {
   governanceContracts: [governance],
@@ -18,7 +15,6 @@ const ChainlinkAggregatorMock = artifacts.require('ChainlinkAggregatorMock');
 const ERC20Mock = artifacts.require('ERC20Mock');
 
 describe('transferAssetToSwapOperator', function () {
-
   before(async function () {
     const { pool, dai, stETH, chainlinkDAI, chainlinkSteth } = this;
 

--- a/test/unit/Pool/updateParameters.js
+++ b/test/unit/Pool/updateParameters.js
@@ -28,7 +28,7 @@ describe('updateUintParameters', function () {
     }
   });
 
-  it('should revert when updateAddressParameters is called with a PRC_FEED oracle parameter that lacks an investment asset', async function () {
+  it('should revert when called with a PRC_FEED oracle parameter that lacks an investment asset', async function () {
     const { pool, dai, chainlinkDAI } = this;
 
     const priceFeedOracle = await PriceFeedOracle.new([dai.address], [chainlinkDAI.address], [18]);
@@ -39,7 +39,7 @@ describe('updateUintParameters', function () {
     );
   });
 
-  it('should revert when updateAddressParameters is called with a PRC_FEED oracle parameter that lacks a cover asset', async function () {
+  it('should revert when called with a PRC_FEED oracle parameter that lacks a cover asset', async function () {
     const { pool, chainlinkSteth, stETH } = this;
 
     const priceFeedOracle = await PriceFeedOracle.new([stETH.address], [chainlinkSteth.address], [18]);

--- a/test/unit/Pool/updateParameters.js
+++ b/test/unit/Pool/updateParameters.js
@@ -28,28 +28,6 @@ describe('updateUintParameters', function () {
     }
   });
 
-  it('should revert when called with a PRC_FEED oracle parameter that lacks an investment asset', async function () {
-    const { pool, dai, chainlinkDAI } = this;
-
-    const priceFeedOracle = await PriceFeedOracle.new([dai.address], [chainlinkDAI.address], [18]);
-
-    await expectRevert(
-      pool.updateAddressParameters(hex('PRC_FEED'), priceFeedOracle.address, { from: governanceContract }),
-      'Pool: Oracle lacks asset',
-    );
-  });
-
-  it('should revert when called with a PRC_FEED oracle parameter that lacks a cover asset', async function () {
-    const { pool, chainlinkSteth, stETH } = this;
-
-    const priceFeedOracle = await PriceFeedOracle.new([stETH.address], [chainlinkSteth.address], [18]);
-
-    await expectRevert(
-      pool.updateAddressParameters(hex('PRC_FEED'), priceFeedOracle.address, { from: governanceContract }),
-      'Pool: Oracle lacks asset',
-    );
-  });
-
   it('should correctly update the uint parameters', async function () {
     const { pool } = this;
     const params = Object.keys(PoolUintParamType);
@@ -83,9 +61,31 @@ describe('updateAddressParameters', function () {
     }
   });
 
+  it('should revert when called with a PRC_FEED oracle parameter that lacks an investment asset', async function () {
+    const { pool, dai, chainlinkDAI } = this;
+
+    const priceFeedOracle = await PriceFeedOracle.new([dai.address], [chainlinkDAI.address], [18]);
+
+    await expectRevert(
+      pool.updateAddressParameters(hex('PRC_FEED'), priceFeedOracle.address, { from: governanceContract }),
+      'Pool: Oracle lacks asset',
+    );
+  });
+
+  it('should revert when called with a PRC_FEED oracle parameter that lacks a cover asset', async function () {
+    const { pool, chainlinkSteth, stETH } = this;
+
+    const priceFeedOracle = await PriceFeedOracle.new([stETH.address], [chainlinkSteth.address], [18]);
+
+    await expectRevert(
+      pool.updateAddressParameters(hex('PRC_FEED'), priceFeedOracle.address, { from: governanceContract }),
+      'Pool: Oracle lacks asset',
+    );
+  });
+
   it('should correctly update the address parameters', async function () {
     const { pool } = this;
-    const params = Object.keys(PoolAddressParamType);
+    const params = Object.keys(PoolAddressParamType).filter(param => param !== 'priceFeedOracle');
 
     for (const paramName of params) {
       const before = await pool[paramName]();
@@ -97,5 +97,23 @@ describe('updateAddressParameters', function () {
       const actual = await pool[paramName]();
       assert.strictEqual(actual.toString(), generalPurpose);
     }
+  });
+
+  it('should correctly update the PRC_FEED parameter', async function () {
+    const { pool, dai, stETH, chainlinkDAI, chainlinkSteth } = this;
+
+    const newPriceFeedOracle = await PriceFeedOracle.new(
+      [dai.address, stETH.address],
+      [chainlinkDAI.address, chainlinkSteth.address],
+      [18, 18],
+    );
+
+    await pool.updateAddressParameters(PoolAddressParamType.priceFeedOracle, newPriceFeedOracle.address, {
+      from: governanceContract,
+    });
+
+    const storedAddress = await pool.priceFeedOracle();
+
+    assert.equal(storedAddress, newPriceFeedOracle.address);
   });
 });

--- a/test/unit/Pool/upgradeCapitalPool.js
+++ b/test/unit/Pool/upgradeCapitalPool.js
@@ -1,9 +1,6 @@
 const { ether } = require('@openzeppelin/test-helpers');
 const { ZERO_ADDRESS } = require('@openzeppelin/test-helpers').constants;
-const {
-  web3,
-  artifacts,
-} = require('hardhat');
+const { web3, artifacts } = require('hardhat');
 const { assert } = require('chai');
 const { expectRevert } = require('@openzeppelin/test-helpers');
 const { hex } = require('../utils').helpers;


### PR DESCRIPTION
## Context

Fixes issue: https://github.com/NexusMutual/smart-contracts/issues/314

We want to prevent addition of assets don't have a registered oracle.

This prevents any issue with pool value calculations that may lock the system.

## Changes proposed in this pull request

Add a require to the addAsset function in Pool.sol


## Test plan

Upgrade all tests that interact with addAsset to now have a oracle available.

`npm run test-unit`

## Checklist
- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [x] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works