### PR TITLE
Replace OZ base NFT with solmate in CoverNFT

### DIFF
--- a/contracts/mocks/Claims/CLMockUnknownNFT.sol
+++ b/contracts/mocks/Claims/CLMockUnknownNFT.sol
@@ -13,8 +13,7 @@ contract CLMockUnknownNFT is ERC721 {
     _mint(to, tokenId);
   }
 
-  function tokenURI(uint id) public view override returns (string memory) {
-    id; 
+  function tokenURI(uint) public view override returns (string memory) {
     return "";
   }
 

--- a/contracts/mocks/Claims/CLMockUnknownNFT.sol
+++ b/contracts/mocks/Claims/CLMockUnknownNFT.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.9;
 
-import "@openzeppelin/contracts-v4/token/ERC721/ERC721.sol";
+import "solmate/src/tokens/ERC721.sol";
 
 
 contract CLMockUnknownNFT is ERC721 {
@@ -11,6 +11,11 @@ contract CLMockUnknownNFT is ERC721 {
 
   function mint(address to, uint tokenId) external {
     _mint(to, tokenId);
+  }
+
+  function tokenURI(uint id) public view override returns (string memory) {
+    id; 
+    return "";
   }
 
 }

--- a/contracts/mocks/Cover/CoverMockNFT.sol
+++ b/contracts/mocks/Cover/CoverMockNFT.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity >=0.8.4;
+
+//import "solmate/src/tokens/ERC721.sol";
+import "../../modules/cover/CoverNFT.sol";
+
+contract CoverMockNFT is CoverNFT {
+
+  constructor(string memory name_, string memory symbol_, address operator) CoverNFT(name_, symbol_, operator) {}
+
+  function setMockOperator(address operator_) public {
+    operator = operator_;
+  }
+}

--- a/contracts/mocks/Cover/CoverMockStakingPool.sol
+++ b/contracts/mocks/Cover/CoverMockStakingPool.sol
@@ -46,10 +46,6 @@ contract CoverMockStakingPool is IStakingPool, ERC721Mock {
     memberRoles = _memberRoles;
   }
 
-  function nameWithPoolId() public view returns (string memory) {
-    return string(abi.encodePacked(name, " ", Strings.toString(poolId)));
-  }
-
   function initialize(
     address _manager,
     bool _isPrivatePool,

--- a/contracts/mocks/Cover/CoverMockStakingPool.sol
+++ b/contracts/mocks/Cover/CoverMockStakingPool.sol
@@ -2,15 +2,13 @@
 
 pragma solidity ^0.8.9;
 
+import "../Tokens/ERC721Mock.sol";
 import "@openzeppelin/contracts-v4/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts-v4/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts-v4/utils/Strings.sol";
-import "@openzeppelin/contracts-v4/token/ERC721/ERC721.sol";
-
 import "../../modules/staking/StakingPool.sol";
 
 
-contract CoverMockStakingPool is IStakingPool, ERC721 {
+contract CoverMockStakingPool is IStakingPool, ERC721Mock {
 
   struct BurnStakeCalledWith {
     uint productId;
@@ -43,13 +41,13 @@ contract CoverMockStakingPool is IStakingPool, ERC721 {
     address /* _coverContract */,
     ITokenController /* _tokenController */,
     address _memberRoles
-  ) ERC721("Nexus Mutual Staking Pool", "NMSPT")
+  ) ERC721Mock("Nexus Mutual Staking Pool", "NMSPT")
   {
     memberRoles = _memberRoles;
   }
 
-  function name() public view override returns (string memory) {
-    return string(abi.encodePacked(super.name(), " ", Strings.toString(poolId)));
+  function nameWithPoolId() public view returns (string memory) {
+    return string(abi.encodePacked(name, " ", Strings.toString(poolId)));
   }
 
   function initialize(
@@ -72,7 +70,7 @@ contract CoverMockStakingPool is IStakingPool, ERC721 {
 
   function operatorTransferFrom(address from, address to, uint256 amount) external /*override*/ {
     require(msg.sender == memberRoles, "StakingPool: Caller is not MemberRoles");
-    _transfer(from, to, amount);
+    transferFrom(from, to, amount);
   }
 
 
@@ -114,7 +112,7 @@ contract CoverMockStakingPool is IStakingPool, ERC721 {
   ) external {
     uint length = tokenIds.length;
     for (uint i = 0; i < length; i++) {
-      _safeTransfer(from, to, tokenIds[i], "");
+      safeTransferFrom(from, to, tokenIds[i]);
     }
   }
 

--- a/contracts/mocks/Cover/CoverMockStakingPool.sol
+++ b/contracts/mocks/Cover/CoverMockStakingPool.sol
@@ -70,7 +70,7 @@ contract CoverMockStakingPool is IStakingPool, ERC721Mock {
 
   function operatorTransferFrom(address from, address to, uint256 amount) external /*override*/ {
     require(msg.sender == memberRoles, "StakingPool: Caller is not MemberRoles");
-    transferFrom(from, to, amount);
+    _operatorTransferFrom(from, to, amount);
   }
 
 

--- a/contracts/mocks/Incidents/ICMockUnknownNFT.sol
+++ b/contracts/mocks/Incidents/ICMockUnknownNFT.sol
@@ -13,8 +13,7 @@ contract ICMockUnknownNFT is ERC721 {
     _mint(to, tokenId);
   }
 
-  function tokenURI(uint id) public view override returns (string memory) {
-    id; 
+  function tokenURI(uint) public view override returns (string memory) {
     return "";
   }
 

--- a/contracts/mocks/Incidents/ICMockUnknownNFT.sol
+++ b/contracts/mocks/Incidents/ICMockUnknownNFT.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.9;
 
-import "@openzeppelin/contracts-v4/token/ERC721/ERC721.sol";
+import "solmate/src/tokens/ERC721.sol";
 
 
 contract ICMockUnknownNFT is ERC721 {
@@ -11,6 +11,11 @@ contract ICMockUnknownNFT is ERC721 {
 
   function mint(address to, uint tokenId) external {
     _mint(to, tokenId);
+  }
+
+  function tokenURI(uint id) public view override returns (string memory) {
+    id; 
+    return "";
   }
 
 }

--- a/contracts/mocks/MemberRoles/MRMockCoverNFT.sol
+++ b/contracts/mocks/MemberRoles/MRMockCoverNFT.sol
@@ -11,7 +11,6 @@ contract MRMockCoverNFT is ERC721Mock {
   }
 
   function operatorTransferFrom(address from, address to, uint256 tokenId) external {
-    super.transferFrom(from, to, tokenId);
+      _operatorTransferFrom(from, to, tokenId);
   }
-
 }

--- a/contracts/mocks/MemberRoles/MRMockCoverNFT.sol
+++ b/contracts/mocks/MemberRoles/MRMockCoverNFT.sol
@@ -11,7 +11,7 @@ contract MRMockCoverNFT is ERC721Mock {
   }
 
   function operatorTransferFrom(address from, address to, uint256 tokenId) external {
-    _transfer(from, to, tokenId);
+    super.transferFrom(from, to, tokenId);
   }
 
 }

--- a/contracts/mocks/MemberRoles/MRMockStkaingPool.sol
+++ b/contracts/mocks/MemberRoles/MRMockStkaingPool.sol
@@ -17,7 +17,7 @@ contract MRMockStakingPool is ERC721Mock {
   ) external {
     uint length = tokenIds.length;
     for (uint i = 0; i < length; i++) {
-      super.safeTransferFrom(from, to, tokenIds[i]);
+      _operatorTransferFrom(from, to, tokenIds[i]);
     }
   }
 

--- a/contracts/mocks/MemberRoles/MRMockStkaingPool.sol
+++ b/contracts/mocks/MemberRoles/MRMockStkaingPool.sol
@@ -17,7 +17,7 @@ contract MRMockStakingPool is ERC721Mock {
   ) external {
     uint length = tokenIds.length;
     for (uint i = 0; i < length; i++) {
-      _safeTransfer(from, to, tokenIds[i], "");
+      super.safeTransferFrom(from, to, tokenIds[i]);
     }
   }
 

--- a/contracts/mocks/Tokens/ERC721Mock.sol
+++ b/contracts/mocks/Tokens/ERC721Mock.sol
@@ -19,8 +19,7 @@ contract ERC721Mock is ERC721 {
     return spender == owner || isApprovedForAll[owner][spender] || spender == getApproved[tokenId];
   }
 
-  function tokenURI(uint id) public view override returns (string memory) {
-    id; 
+  function tokenURI(uint) public view override returns (string memory) {
     return "";
   }
 

--- a/contracts/mocks/Tokens/ERC721Mock.sol
+++ b/contracts/mocks/Tokens/ERC721Mock.sol
@@ -24,5 +24,24 @@ contract ERC721Mock is ERC721 {
     return "";
   }
 
+  function _operatorTransferFrom(address from, address to, uint256 tokenId) internal {
+        require(from == _ownerOf[tokenId], "WRONG_FROM");
+
+        require(to != address(0), "INVALID_RECIPIENT");
+
+        // Underflow of the sender's balance is impossible because we check for
+        // ownership above and the recipient's balance can't realistically overflow.
+        unchecked {
+            _balanceOf[from]--;
+
+            _balanceOf[to]++;
+        }
+
+        _ownerOf[tokenId] = to;
+
+        delete getApproved[tokenId];
+
+        emit Transfer(from, to, tokenId);
+  }
 
 }

--- a/contracts/mocks/Tokens/ERC721Mock.sol
+++ b/contracts/mocks/Tokens/ERC721Mock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity >=0.8.4;
 
-import "@openzeppelin/contracts-v4/token/ERC721/ERC721.sol";
+import "solmate/src/tokens/ERC721.sol";
 
 contract ERC721Mock is ERC721 {
 
@@ -15,7 +15,14 @@ contract ERC721Mock is ERC721 {
   }
 
   function isApprovedOrOwner(address spender, uint256 tokenId) external view returns (bool) {
-    return _isApprovedOrOwner(spender, tokenId);
+    address owner = ownerOf(tokenId);
+    return spender == owner || isApprovedForAll[owner][spender] || spender == getApproved[tokenId];
   }
+
+  function tokenURI(uint id) public view override returns (string memory) {
+    id; 
+    return "";
+  }
+
 
 }

--- a/contracts/mocks/integration/IntegrationMockStakingPool.sol
+++ b/contracts/mocks/integration/IntegrationMockStakingPool.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.9;
 
 import "@openzeppelin/contracts-v4/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts-v4/token/ERC721/ERC721.sol";
+import "solmate/src/tokens/ERC721.sol";
 import "@openzeppelin/contracts-v4/utils/Strings.sol";
 
 import "../../modules/staking/StakingPool.sol";

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -2,7 +2,6 @@
 
 pragma solidity ^0.8.9;
 
-import "solmate/src/tokens/ERC721.sol";
 import "@openzeppelin/contracts-v4/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts-v4/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts-v4/proxy/beacon/UpgradeableBeacon.sol";

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.9;
 
-import "@openzeppelin/contracts-v4/token/ERC721/ERC721.sol";
+import "solmate/src/tokens/ERC721.sol";
 import "@openzeppelin/contracts-v4/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts-v4/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts-v4/proxy/beacon/UpgradeableBeacon.sol";

--- a/contracts/modules/cover/CoverNFT.sol
+++ b/contracts/modules/cover/CoverNFT.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.9;
 
-import "@openzeppelin/contracts-v4/token/ERC721/ERC721.sol";
+import "@rari-capital/solmate/src/tokens/ERC721.sol";
 import "../../interfaces/ICover.sol";
 
 contract CoverNFT is ERC721 {
@@ -19,12 +19,18 @@ contract CoverNFT is ERC721 {
 
   }
 
+  function tokenURI(uint256 id) public pure override returns (string memory) {
+    id;  // To silence unused param warning. Remove once fn is implemented
+    return "";
+  }
+
   function mint(address to, uint tokenId) external onlyOperator {
     _mint(to, tokenId);
   }
 
   function isApprovedOrOwner(address spender, uint tokenId) external view returns (bool) {
-    return _isApprovedOrOwner(spender, tokenId);
+    address owner = ownerOf(tokenId);
+    return spender == owner || isApprovedForAll[owner][spender] || spender == getApproved[tokenId];
   }
 
   function burn(uint tokenId) external onlyOperator {
@@ -32,7 +38,7 @@ contract CoverNFT is ERC721 {
   }
 
   function operatorTransferFrom(address from, address to, uint256 tokenId) external onlyOperator {
-    _transfer(from, to, tokenId);
+    super.transferFrom(from, to, tokenId);
   }
 
 

--- a/contracts/modules/cover/CoverNFT.sol
+++ b/contracts/modules/cover/CoverNFT.sol
@@ -38,7 +38,23 @@ contract CoverNFT is ERC721 {
   }
 
   function operatorTransferFrom(address from, address to, uint256 tokenId) external onlyOperator {
-    super.transferFrom(from, to, tokenId);
+        require(from == _ownerOf[tokenId], "WRONG_FROM");
+
+        require(to != address(0), "INVALID_RECIPIENT");
+
+        // Underflow of the sender's balance is impossible because we check for
+        // ownership above and the recipient's balance can't realistically overflow.
+        unchecked {
+            _balanceOf[from]--;
+
+            _balanceOf[to]++;
+        }
+
+        _ownerOf[tokenId] = to;
+
+        delete getApproved[tokenId];
+
+        emit Transfer(from, to, tokenId);
   }
 
 

--- a/contracts/modules/cover/CoverNFT.sol
+++ b/contracts/modules/cover/CoverNFT.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.9;
 
-import "@rari-capital/solmate/src/tokens/ERC721.sol";
+import "solmate/src/tokens/ERC721.sol";
 import "../../interfaces/ICover.sol";
 
 contract CoverNFT is ERC721 {

--- a/contracts/modules/cover/CoverNFT.sol
+++ b/contracts/modules/cover/CoverNFT.sol
@@ -19,8 +19,7 @@ contract CoverNFT is ERC721 {
 
   }
 
-  function tokenURI(uint256 id) public pure override returns (string memory) {
-    id;  // To silence unused param warning. Remove once fn is implemented
+  function tokenURI(uint256) public pure override returns (string memory) {
     return "";
   }
 
@@ -39,19 +38,16 @@ contract CoverNFT is ERC721 {
 
   function operatorTransferFrom(address from, address to, uint256 tokenId) external onlyOperator {
         require(from == _ownerOf[tokenId], "WRONG_FROM");
-
         require(to != address(0), "INVALID_RECIPIENT");
 
         // Underflow of the sender's balance is impossible because we check for
         // ownership above and the recipient's balance can't realistically overflow.
         unchecked {
             _balanceOf[from]--;
-
             _balanceOf[to]++;
         }
 
         _ownerOf[tokenId] = to;
-
         delete getApproved[tokenId];
 
         emit Transfer(from, to, tokenId);

--- a/contracts/modules/cover/CoverViewer.sol
+++ b/contracts/modules/cover/CoverViewer.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.9;
 
-import "@openzeppelin/contracts-v4/token/ERC721/ERC721.sol";
+import "solmate/src/tokens/ERC721.sol";
 import "@openzeppelin/contracts-v4/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts-v4/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts-v4/proxy/beacon/UpgradeableBeacon.sol";

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -192,8 +192,7 @@ contract StakingPool is IStakingPool, SolmateERC721 {
     _mint(_manager, 0);
   }
 
-  function tokenURI(uint256 id) public pure override returns (string memory) {
-    id;  // To silence unused param warning. Remove once fn is implemented
+  function tokenURI(uint256) public pure override returns (string memory) {
     return "";
   }
 

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.9;
 
 import "@openzeppelin/contracts-v4/token/ERC20/IERC20.sol";
 // TODO: consider using solmate ERC721 implementation
-//import "@openzeppelin/contracts-v4/token/ERC721/ERC721.sol";
-import { ERC721 as SolmateERC721 } from "@rari-capital/solmate/src/tokens/ERC721.sol";
+//import "solmate/src/tokens/ERC721.sol";
+import { ERC721 as SolmateERC721 } from "solmate/src/tokens/ERC721.sol";
 import "@openzeppelin/contracts-v4/utils/Strings.sol";
 
 //import "../../interfaces/ISolmateERC721.sol";

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "keccak256": "^1.0.3",
         "merkletreejs": "^0.2.24",
         "node-fetch": "^2.6.7",
+        "solmate": "^6.6.1",
         "workerpool": "^6.2.0"
       },
       "devDependencies": {
@@ -29,7 +30,6 @@
         "@nomiclabs/hardhat-truffle5": "^2.0.4",
         "@nomiclabs/hardhat-waffle": "^2.0.2",
         "@nomiclabs/hardhat-web3": "^2.0.0",
-        "@rari-capital/solmate": "^6.4.0",
         "@tenderly/hardhat-tenderly": "^1.1.4",
         "@typechain/truffle-v5": "^3.0.0",
         "chai": "^4.3.6",
@@ -2740,12 +2740,6 @@
       "dev": true,
       "optional": true,
       "peer": true
-    },
-    "node_modules/@rari-capital/solmate": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@rari-capital/solmate/-/solmate-6.4.0.tgz",
-      "integrity": "sha512-BXWIHHbG5Zbgrxi0qVYe0Zs+bfx+XgOciVUACjuIApV0KzC0kY8XdO1higusIei/ZKCC+GUKdcdQZflxYPUTKQ==",
-      "dev": true
     },
     "node_modules/@redux-saga/core": {
       "version": "1.1.3",
@@ -34045,6 +34039,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/solmate": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/solmate/-/solmate-6.6.1.tgz",
+      "integrity": "sha512-WHvRXQvGtgR6R9nmkDTz/d+oULMqf/D33rlzQyadTX2SbuTmaW7ToEjGjGtWUVCQwZsZ/JP3vbOEVv7fB50btg=="
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -40571,12 +40570,6 @@
       "dev": true,
       "optional": true,
       "peer": true
-    },
-    "@rari-capital/solmate": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@rari-capital/solmate/-/solmate-6.4.0.tgz",
-      "integrity": "sha512-BXWIHHbG5Zbgrxi0qVYe0Zs+bfx+XgOciVUACjuIApV0KzC0kY8XdO1higusIei/ZKCC+GUKdcdQZflxYPUTKQ==",
-      "dev": true
     },
     "@redux-saga/core": {
       "version": "1.1.3",
@@ -65659,6 +65652,11 @@
           }
         }
       }
+    },
+    "solmate": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/solmate/-/solmate-6.6.1.tgz",
+      "integrity": "sha512-WHvRXQvGtgR6R9nmkDTz/d+oULMqf/D33rlzQyadTX2SbuTmaW7ToEjGjGtWUVCQwZsZ/JP3vbOEVv7fB50btg=="
     },
     "source-map": {
       "version": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "keccak256": "^1.0.3",
     "merkletreejs": "^0.2.24",
     "node-fetch": "^2.6.7",
+    "solmate": "^6.6.1",
     "workerpool": "^6.2.0"
   },
   "devDependencies": {
@@ -40,7 +41,6 @@
     "@nomiclabs/hardhat-truffle5": "^2.0.4",
     "@nomiclabs/hardhat-waffle": "^2.0.2",
     "@nomiclabs/hardhat-web3": "^2.0.0",
-    "@rari-capital/solmate": "^6.4.0",
     "@tenderly/hardhat-tenderly": "^1.1.4",
     "@typechain/truffle-v5": "^3.0.0",
     "chai": "^4.3.6",

--- a/test/unit/Cover/coverNFT.js
+++ b/test/unit/Cover/coverNFT.js
@@ -1,0 +1,106 @@
+const { ethers } = require('ethers');
+const { expect } = require('chai');
+const { expectRevert } = require('@openzeppelin/test-helpers');
+const { AddressZero } = ethers.constants;
+
+describe('CoverNFT', function () {
+  it('should verify that constructor variables were set correctly', async function () {
+    const { coverNFT } = this;
+    expect(await coverNFT.name()).to.be.eq('NexusMutual Cover');
+    expect(await coverNFT.symbol()).to.be.eq('NXMC');
+  });
+  it('should return tokenURI', async function () {
+    const { coverNFT } = this;
+    expect(await coverNFT.tokenURI(0)).to.be.eq('');
+  });
+  it('should fail to mint - onlyOperator()', async function () {
+    const { coverNFT } = this;
+    await expectRevert(coverNFT.mint(coverNFT.address, 10), 'CoverNFT: Not operator');
+  });
+  it('should successfully mint', async function () {
+    const { coverNFT } = this;
+    const { members } = this.accounts;
+    await coverNFT.setMockOperator(members[0].address);
+    await coverNFT.connect(members[0]).mint(members[1].address, 0);
+    expect(await coverNFT.ownerOf(0)).to.be.equal(members[1].address);
+  });
+  it('should fail to burn - onlyOperator()', async function () {
+    const { coverNFT } = this;
+    await expectRevert(coverNFT.burn(0), 'CoverNFT: Not operator');
+  });
+  it('should successfully burn', async function () {
+    const { coverNFT } = this;
+    const { members } = this.accounts;
+    await coverNFT.setMockOperator(members[0].address);
+    await coverNFT.connect(members[0]).mint(members[1].address, 0);
+    await coverNFT.connect(members[0]).burn(0);
+    await expectRevert(coverNFT.ownerOf(0), 'NOT_MINTED');
+  });
+  it('should return success for isApproveOrOwner() - owner == sender', async function () {
+    const { coverNFT } = this;
+    const { members } = this.accounts;
+    await coverNFT.setMockOperator(members[0].address);
+    await coverNFT.connect(members[0]).mint(members[1].address, 0);
+    expect(await coverNFT.isApprovedOrOwner(members[1].address, 0)).to.be.equal(true);
+    expect(await coverNFT.isApprovedOrOwner(members[0].address, 0)).to.be.equal(false);
+  });
+  it('should return success for isApproveOrOwner() - isApprovedForAll', async function () {
+    const { coverNFT } = this;
+    const { members } = this.accounts;
+    await coverNFT.setMockOperator(members[0].address);
+    await coverNFT.connect(members[0]).mint(members[1].address, 0);
+    await coverNFT.connect(members[1]).setApprovalForAll(members[0].address, true);
+    expect(await coverNFT.isApprovedOrOwner(members[0].address, 0)).to.be.equal(true);
+    expect(await coverNFT.isApprovedOrOwner(members[1].address, 0)).to.be.equal(true);
+  });
+  it('should return success for isApproveOrOwner() - isApproved', async function () {
+    const { coverNFT } = this;
+    const { members } = this.accounts;
+    await coverNFT.setMockOperator(members[0].address);
+    await coverNFT.connect(members[0]).mint(members[1].address, 0);
+    await coverNFT.connect(members[1]).approve(members[0].address, 0);
+    expect(await coverNFT.isApprovedOrOwner(members[0].address, 0)).to.be.equal(true);
+    expect(await coverNFT.isApprovedOrOwner(members[1].address, 0)).to.be.equal(true);
+  });
+  it('should revert when calling isApproveOrOwner() for non-existing tokenId', async function () {
+    const { coverNFT } = this;
+    const { members } = this.accounts;
+    await expectRevert(coverNFT.isApprovedOrOwner(members[0].address, 0), 'NOT_MINTED');
+  });
+  it('should fail to transfer from operator - onlyOperator()', async function () {
+    const { coverNFT } = this;
+    const { members } = this.accounts;
+    await expectRevert(
+      coverNFT.operatorTransferFrom(coverNFT.address, members[0].address, 0),
+      'CoverNFT: Not operator',
+    );
+  });
+  it('should fail to transfer from operator - wrong from address', async function () {
+    const { coverNFT } = this;
+    const { members } = this.accounts;
+    await coverNFT.setMockOperator(members[0].address);
+    await coverNFT.connect(members[0]).mint(members[1].address, 0);
+    await expectRevert(
+      coverNFT.connect(members[0]).operatorTransferFrom(members[2].address, members[0].address, 0),
+      'WRONG_FROM',
+    );
+  });
+  it('should fail to transfer from operator - send to 0 address', async function () {
+    const { coverNFT } = this;
+    const { members } = this.accounts;
+    await coverNFT.setMockOperator(members[0].address);
+    await coverNFT.connect(members[0]).mint(members[1].address, 0);
+    await expectRevert(
+      coverNFT.connect(members[0]).operatorTransferFrom(members[1].address, AddressZero, 0),
+      'INVALID_RECIPIENT',
+    );
+  });
+  it('should successfully transfer from the operator', async function () {
+    const { coverNFT } = this;
+    const { members } = this.accounts;
+    await coverNFT.setMockOperator(members[0].address);
+    await coverNFT.connect(members[0]).mint(members[1].address, 0);
+    await coverNFT.connect(members[0]).operatorTransferFrom(members[1].address, members[0].address, 0);
+    expect(await coverNFT.ownerOf(0)).to.be.equal(members[0].address);
+  });
+});

--- a/test/unit/Cover/index.js
+++ b/test/unit/Cover/index.js
@@ -18,4 +18,5 @@ describe('Cover unit tests', function () {
   require('./totalActiveCoverInAsset');
   require('./performStakeBurn');
   require('./expireCover');
+  require('./coverNFT');
 });

--- a/test/unit/Cover/setup.js
+++ b/test/unit/Cover/setup.js
@@ -25,7 +25,7 @@ async function setup() {
   const ChainlinkAggregatorMock = await ethers.getContractFactory('ChainlinkAggregatorMock');
   const QuotationData = await ethers.getContractFactory('CoverMockQuotationData');
   const MemberRolesMock = await ethers.getContractFactory('MemberRolesMock');
-  const CoverNFT = await ethers.getContractFactory('CoverNFT');
+  const CoverNFT = await ethers.getContractFactory('CoverMockNFT');
   const TokenController = await ethers.getContractFactory('TokenControllerMock');
   const NXMToken = await ethers.getContractFactory('NXMTokenMock');
   const MCR = await ethers.getContractFactory('CoverMockMCR');
@@ -204,6 +204,7 @@ async function setup() {
   this.memberRoles = memberRoles;
   this.chainlinkDAI = chainlinkDAI;
   this.cover = cover;
+  this.coverNFT = coverNFT;
   this.accounts = accounts;
   this.capacityFactor = capacityFactor;
 }

--- a/test/unit/MemberRoles/switchMembershipAndAssets.js
+++ b/test/unit/MemberRoles/switchMembershipAndAssets.js
@@ -108,6 +108,7 @@ describe('switchMembershipAndAssets', function () {
       expect(ownershipArr[1]).to.be.equal(member1.address);
       expect(ownershipArr[2]).to.be.equal(member1.address);
     }
+    await coverNFT.connect(member1).setApprovalForAll(cover.address, true);
 
     const newMemberAddress = nonMember1.address;
     await memberRoles.connect(member1).switchMembershipAndAssets(newMemberAddress, [0, 2], [], []);
@@ -137,6 +138,8 @@ describe('switchMembershipAndAssets', function () {
     await stakingPool2.connect(member1).mint(member1.address, 1);
     await nxm.connect(member1).approve(memberRoles.address, ethers.constants.MaxUint256);
 
+    await stakingPool1.connect(member1).setApprovalForAll(memberRoles.address, true);
+    await stakingPool2.connect(member1).setApprovalForAll(memberRoles.address, true);
     const newMemberAddress = nonMember1.address;
     await memberRoles.connect(member1).switchMembershipAndAssets(
       newMemberAddress,
@@ -206,7 +209,7 @@ describe('switchMembershipAndAssets', function () {
           [0], // NFTs from pool 2
         ],
       ),
-    ).to.be.revertedWith('ERC721: transfer of token that is not own');
+    ).to.be.revertedWith('WRONG_FROM');
   });
 
   it('reverts when trying to transfer cover nfts of another member', async function () {
@@ -224,6 +227,6 @@ describe('switchMembershipAndAssets', function () {
     await nxm.connect(member1).approve(memberRoles.address, ethers.constants.MaxUint256);
     await expect(
       memberRoles.connect(member1).switchMembershipAndAssets(newMemberAddress, [0, 2], [], []),
-    ).to.be.revertedWith('ERC721: transfer of token that is not own');
+    ).to.be.revertedWith('WRONG_FROM');
   });
 });

--- a/test/unit/MemberRoles/switchMembershipAndAssets.js
+++ b/test/unit/MemberRoles/switchMembershipAndAssets.js
@@ -108,7 +108,6 @@ describe('switchMembershipAndAssets', function () {
       expect(ownershipArr[1]).to.be.equal(member1.address);
       expect(ownershipArr[2]).to.be.equal(member1.address);
     }
-    await coverNFT.connect(member1).setApprovalForAll(cover.address, true);
 
     const newMemberAddress = nonMember1.address;
     await memberRoles.connect(member1).switchMembershipAndAssets(newMemberAddress, [0, 2], [], []);
@@ -138,8 +137,6 @@ describe('switchMembershipAndAssets', function () {
     await stakingPool2.connect(member1).mint(member1.address, 1);
     await nxm.connect(member1).approve(memberRoles.address, ethers.constants.MaxUint256);
 
-    await stakingPool1.connect(member1).setApprovalForAll(memberRoles.address, true);
-    await stakingPool2.connect(member1).setApprovalForAll(memberRoles.address, true);
     const newMemberAddress = nonMember1.address;
     await memberRoles.connect(member1).switchMembershipAndAssets(
       newMemberAddress,


### PR DESCRIPTION
## Context
resolves #295 


## Changes proposed in this pull request
This PR replaces the OZ 721 implementation with solmates 721 implementation. 

## Test plan
No further tests were added.
