### PR TITLE
Feat: Add cover segments view

### DIFF
--- a/contracts/mocks/CoverViewer/CoverViewerMockCover.sol
+++ b/contracts/mocks/CoverViewer/CoverViewerMockCover.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity ^0.8.9;
+
+import "../../interfaces/ICover.sol";
+
+contract CoverViewerMockCover {
+
+
+  mapping(uint => CoverSegment[]) public _coverSegments;
+
+  function addSegments(uint coverId, CoverSegment[] memory segments) public {
+
+    for (uint i = 0; i < segments.length; i++) {
+      _coverSegments[coverId].push(segments[i]);
+    }
+  }
+
+  function coverSegmentsCount(uint coverId) external view returns (uint) {
+    return _coverSegments[coverId].length;
+  }
+
+  function coverSegments(uint coverId, uint segmentId) external view returns (CoverSegment memory) {
+    return _coverSegments[coverId][segmentId];
+  }
+}

--- a/contracts/modules/cover/CoverViewer.sol
+++ b/contracts/modules/cover/CoverViewer.sol
@@ -111,6 +111,17 @@ contract CoverViewer {
     return coverViews;
   }
 
+  function getCoverSegments(uint coverId) external view returns (CoverSegment[] memory segments) {
+
+    ICover _cover = cover();
+    uint count = _cover.coverSegmentsCount(coverId);
+    segments = new CoverSegment[](count);
+
+    for (uint i = 0; i < count; i++) {
+      segments[i] = _cover.coverSegments(coverId, i);
+    }
+  }
+
   /* ========== COVER PRICING VIEWS ========== */
 
   function getPoolAllocationPriceParametersForProduct(

--- a/test/unit/CoverViewer/index.js
+++ b/test/unit/CoverViewer/index.js
@@ -1,0 +1,16 @@
+const { takeSnapshot, revertToSnapshot } = require('../utils').evm;
+const setup = require('./setup');
+
+describe.only('CoverViewer unit tests', function () {
+  before(setup);
+
+  beforeEach(async function () {
+    this.snapshotId = await takeSnapshot();
+  });
+
+  afterEach(async function () {
+    await revertToSnapshot(this.snapshotId);
+  });
+
+  require('./views');
+});

--- a/test/unit/CoverViewer/index.js
+++ b/test/unit/CoverViewer/index.js
@@ -1,7 +1,7 @@
 const { takeSnapshot, revertToSnapshot } = require('../utils').evm;
 const setup = require('./setup');
 
-describe.only('CoverViewer unit tests', function () {
+describe('CoverViewer unit tests', function () {
   before(setup);
 
   beforeEach(async function () {

--- a/test/unit/CoverViewer/setup.js
+++ b/test/unit/CoverViewer/setup.js
@@ -1,0 +1,31 @@
+const { ethers } = require('hardhat');
+const { hex } = require('../utils').helpers;
+
+async function setup () {
+  const MasterMock = await ethers.getContractFactory('MasterMock');
+  const Pool = await ethers.getContractFactory('CoverMockPool');
+  const Cover = await ethers.getContractFactory('CoverViewerMockCover');
+  const CoverViewer = await ethers.getContractFactory('CoverViewer');
+
+  const [owner] = await ethers.getSigners();
+
+  const master = await MasterMock.deploy();
+  await master.deployed();
+
+  const pool = await Pool.deploy();
+
+  const cover = await Cover.deploy();
+
+  const coverViewer = await CoverViewer.deploy(master.address);
+
+  // set contract addresses
+  await master.setLatestAddress(hex('P1'), pool.address);
+  await master.setLatestAddress(hex('CO'), cover.address);
+
+  this.master = master;
+  this.pool = pool;
+  this.cover = cover;
+  this.coverViewer = coverViewer;
+}
+
+module.exports = setup;

--- a/test/unit/CoverViewer/setup.js
+++ b/test/unit/CoverViewer/setup.js
@@ -1,13 +1,11 @@
 const { ethers } = require('hardhat');
 const { hex } = require('../utils').helpers;
 
-async function setup () {
+async function setup() {
   const MasterMock = await ethers.getContractFactory('MasterMock');
   const Pool = await ethers.getContractFactory('CoverMockPool');
   const Cover = await ethers.getContractFactory('CoverViewerMockCover');
   const CoverViewer = await ethers.getContractFactory('CoverViewer');
-
-  const [owner] = await ethers.getSigners();
 
   const master = await MasterMock.deploy();
   await master.deployed();

--- a/test/unit/CoverViewer/views.js
+++ b/test/unit/CoverViewer/views.js
@@ -1,15 +1,10 @@
 const { assert, expect } = require('chai');
 const { ethers } = require('hardhat');
-const { utils: { parseEther } } = ethers;
-
 const {
-  constants: { ZERO_ADDRESS },
-} = require('@openzeppelin/test-helpers');
-const { BigNumber } = require('ethers');
-const { bnEqual } = require('../utils').helpers;
+  utils: { parseEther },
+} = ethers;
 
 describe('views', function () {
-
   it('getCoverSegments returns segments', async function () {
     const { cover, coverViewer } = this;
 

--- a/test/unit/CoverViewer/views.js
+++ b/test/unit/CoverViewer/views.js
@@ -1,0 +1,34 @@
+const { assert, expect } = require('chai');
+const { ethers } = require('hardhat');
+const { utils: { parseEther } } = ethers;
+
+const {
+  constants: { ZERO_ADDRESS },
+} = require('@openzeppelin/test-helpers');
+const { BigNumber } = require('ethers');
+const { bnEqual } = require('../utils').helpers;
+
+describe('views', function () {
+
+  it('getCoverSegments returns segments', async function () {
+    const { cover, coverViewer } = this;
+
+    const coverSegment1 = {
+      amount: parseEther('100'),
+      start: 1000,
+      period: 3600 * 24 * 30, // seconds
+      priceRatio: 3000,
+      expired: false,
+      globalRewardsRatio: 5000,
+    };
+
+    const coverId = 0;
+
+    await cover.addSegments(coverId, [coverSegment1]);
+
+    const segments = await coverViewer.getCoverSegments(coverId);
+
+    assert.equal(segments.length, 1);
+    assert(segments[0].amount.toString(), coverSegment1.amount.toString());
+  });
+});

--- a/test/unit/CoverViewer/views.js
+++ b/test/unit/CoverViewer/views.js
@@ -1,4 +1,4 @@
-const { assert, expect } = require('chai');
+const { assert } = require('chai');
 const { ethers } = require('hardhat');
 const {
   utils: { parseEther },

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -12,4 +12,5 @@ describe('UNIT TESTS', function () {
   require('./YieldTokenIncidents');
   require('./StakingPool');
   require('./PriceFeedOracle');
+  require('./CoverViewer');
 });


### PR DESCRIPTION
## Context

Fixes Issue: https://github.com/NexusMutual/smart-contracts/issues/364

This is needed for displaying all cover segments in the UI.
## Changes proposed in this pull request

 It's easier to add it in the CoverViewer.sol to not bloat Cover.sol size so a function is added there for returning a list of CoverSegment items.


## Test plan

Added test for CoverViewer

```npm run test-unit```