### PR TITLE
Feat: Add initialize function to Cover.sol

### DIFF
--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -104,6 +104,19 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
     stakingPoolImplementation = _stakingPoolImplementation;
   }
 
+  function initialize(
+    uint24 _globalCapacityRatio,
+    uint24 _globalRewardsRatio,
+    uint32 coverAssetsFallback
+  ) external {
+
+    require(globalCapacityRatio == 0, "Cover: already initialized");
+
+    globalCapacityRatio = 20000; // x2
+    globalRewardsRatio = 5000; // 50%
+    coverAssetsFallback = 3; // 0x11 - DAI and ETH
+  }
+
   /* === MUTATIVE FUNCTIONS ==== */
 
   /// @dev Migrates covers from V1. Meant to be used by EOA Nexus Mutual members

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -105,9 +105,6 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
   }
 
   function initialize(
-    uint24 _globalCapacityRatio,
-    uint24 _globalRewardsRatio,
-    uint32 coverAssetsFallback
   ) external {
 
     require(globalCapacityRatio == 0, "Cover: already initialized");

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -107,7 +107,7 @@ contract StakingPool is IStakingPool, ERC721 {
   uint public constant REWARD_BONUS_PER_TRANCHE_DENOMINATOR = 100_00;
   uint public constant PRODUCT_WEIGHT_DENOMINATOR = 100_00;
   uint public constant WEIGHT_DENOMINATOR = 100;
-  uint public constant REWARDS_DENOMINATOR = 100;
+  uint public constant REWARDS_DENOMINATOR = 100_00;
   uint public constant FEE_DENOMINATOR = 100;
 
   // denominators for cover contract parameters

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -355,7 +355,7 @@ async function setup() {
 
   await cover.updateUintParameters(
     [0, 1], // CoverUintParams.globalCapacityRatio, CoverUintParams.globalRewardsRatio
-    [10000, 50],
+    [10000, 5000],
   );
 
   await gv.changeMasterAddress(master.address);

--- a/test/unit/Cover/index.js
+++ b/test/unit/Cover/index.js
@@ -19,4 +19,5 @@ describe('Cover unit tests', function () {
   require('./performStakeBurn');
   require('./expireCover');
   require('./coverNFT');
+  require('./initialize');
 });

--- a/test/unit/Cover/initialize.js
+++ b/test/unit/Cover/initialize.js
@@ -1,6 +1,4 @@
-const { expectRevert } = require('@openzeppelin/test-helpers');
-
-const { bnEqual } = require('../utils').helpers;
+const { assert, expect } = require('chai');
 
 describe('initialize', function () {
   it('should edit purchased cover and increase amount', async function () {
@@ -15,9 +13,9 @@ describe('initialize', function () {
     const globalRewardsRatio = await cover.globalRewardsRatio();
     const coverAssetsFallback = await cover.coverAssetsFallback();
 
-    bnEqual(globalCapacityRatio, 20000);
-    bnEqual(globalRewardsRatio, 5000);
-    bnEqual(coverAssetsFallback, 3); // 3 = 0x11 - DAI and ETH
+    assert.equal(globalCapacityRatio, 20000);
+    assert.equal(globalRewardsRatio, 5000);
+    assert.equal(coverAssetsFallback, 3); // 3 = 0x11 - DAI and ETH
   });
 
   it('should revert if globalCapacityRatio already set to a non-zero value', async function () {
@@ -25,6 +23,6 @@ describe('initialize', function () {
 
     await cover.connect(accounts.governanceContracts[0]).updateUintParameters([0], ['10000']);
 
-    await expectRevert(cover.initialize(), 'Cover: already initialized');
+    await expect(cover.initialize()).to.be.revertedWith('Cover: already initialized');
   });
 });

--- a/test/unit/Cover/initialize.js
+++ b/test/unit/Cover/initialize.js
@@ -1,4 +1,4 @@
-const { assert, expect } = require('chai');
+const { expect } = require('chai');
 
 describe('initialize', function () {
   it('should edit purchased cover and increase amount', async function () {
@@ -13,9 +13,9 @@ describe('initialize', function () {
     const globalRewardsRatio = await cover.globalRewardsRatio();
     const coverAssetsFallback = await cover.coverAssetsFallback();
 
-    assert.equal(globalCapacityRatio, 20000);
-    assert.equal(globalRewardsRatio, 5000);
-    assert.equal(coverAssetsFallback, 3); // 3 = 0x11 - DAI and ETH
+    expect(globalCapacityRatio).to.be.equal(20000);
+    expect(globalRewardsRatio).to.be.equal(5000);
+    expect(coverAssetsFallback).to.be.equal(3); // 3 = 0x11 - DAI and ETH
   });
 
   it('should revert if globalCapacityRatio already set to a non-zero value', async function () {

--- a/test/unit/Cover/initialize.js
+++ b/test/unit/Cover/initialize.js
@@ -1,0 +1,34 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+const { expectRevert } = require('@openzeppelin/test-helpers');
+
+const { bnEqual } = require('../utils').helpers;
+
+describe('initialize', function () {
+  it('should edit purchased cover and increase amount', async function () {
+    const { cover, accounts } = this;
+
+    const [coverBuyer] = this.accounts.members;
+
+    // reset initialization
+    await cover.connect(accounts.governanceContracts[0]).updateUintParameters([0], ['0']);
+
+    await cover.initialize();
+
+    const globalCapacityRatio = await cover.globalCapacityRatio();
+    const globalRewardsRatio = await cover.globalRewardsRatio();
+    const coverAssetsFallback = await cover.coverAssetsFallback();
+
+    bnEqual(globalCapacityRatio, 20000);
+    bnEqual(globalRewardsRatio, 5000);
+    bnEqual(coverAssetsFallback, 3); // 3 = 0x11 - DAI and ETH
+  });
+
+  it('should revert if globalCapacityRatio already set to a non-zero value', async function () {
+    const { cover, accounts } = this;
+
+    await cover.connect(accounts.governanceContracts[0]).updateUintParameters([0], ['10000']);
+
+    await expectRevert(cover.initialize(), 'Cover: already initialized');
+  });
+});

--- a/test/unit/Cover/initialize.js
+++ b/test/unit/Cover/initialize.js
@@ -1,5 +1,3 @@
-const { expect } = require('chai');
-const { ethers } = require('hardhat');
 const { expectRevert } = require('@openzeppelin/test-helpers');
 
 const { bnEqual } = require('../utils').helpers;
@@ -7,8 +5,6 @@ const { bnEqual } = require('../utils').helpers;
 describe('initialize', function () {
   it('should edit purchased cover and increase amount', async function () {
     const { cover, accounts } = this;
-
-    const [coverBuyer] = this.accounts.members;
 
     // reset initialization
     await cover.connect(accounts.governanceContracts[0]).updateUintParameters([0], ['0']);


### PR DESCRIPTION
## Context

Fixes issue: https://github.com/NexusMutual/smart-contracts/issues/350

Add an initialize() function with hardcoded parameters for StakingPool.sol since it's a proxy.

## Changes proposed in this pull request

Add the initialize() function.

Change decimals for globalRewardsRatio to 4 therefore denominator is 10000. 

There was a discrepancy between Cover.sol and StakingPool.sol (had 2 decimals).

## Test plan

Added unit test.

`npm run test-unit`

## Checklist
- [ ] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [x] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works