### PR TITLE
Feature/upgrade oz signature

### DIFF
--- a/contracts/interfaces/IMemberRoles.sol
+++ b/contracts/interfaces/IMemberRoles.sol
@@ -7,7 +7,7 @@ interface IMemberRoles {
 
   enum Role {UnAssigned, AdvisoryBoard, Member, Owner}
 
-  function signUp(address _userAddress, bytes calldata data) external payable;
+  function join(address _userAddress, uint nonce, bytes calldata signature) external payable;
 
   function switchMembership(address _newAddress) external;
 

--- a/contracts/interfaces/IMemberRoles.sol
+++ b/contracts/interfaces/IMemberRoles.sol
@@ -44,5 +44,7 @@ interface IMemberRoles {
 
   event MemberRole(uint256 indexed roleId, bytes32 roleName, string roleDescription);
 
+  event MemberJoined(address indexed newMember, uint indexed nonce);
+
   event switchedMembership(address indexed previousMember, address indexed newMember, uint timeStamp);
 }

--- a/contracts/modules/governance/MemberRoles.sol
+++ b/contracts/modules/governance/MemberRoles.sol
@@ -139,10 +139,12 @@ contract MemberRoles is IMemberRoles, Governed, LegacyMasterAware {
   /// the address and a nonce (incremented if a new signature is required for the same address).
   ///
   /// @param _userAddress  The address of the user for whom the joining fee is paid.
-  /// @param data          Encoded data containing the nonce and signature.
-  function signUp(
+  /// @param nonce        Signers nonce. Increments if new signature needed for the same address
+  /// @param  signature   The signed message hash
+  function join(
     address _userAddress,
-    bytes calldata data
+    uint nonce,
+    bytes calldata signature
   ) public override payable {
     require(_userAddress != address(0), "MemberRoles: Address 0 cannot be used");
     require(!ms.isPause(), "MemberRoles: Emergency pause applied");
@@ -151,11 +153,6 @@ contract MemberRoles is IMemberRoles, Governed, LegacyMasterAware {
       msg.value == joiningFee,
       "MemberRoles: The transaction value should equal to the joining fee"
     );
-
-    // Extract the nonce and the compact signature representation.
-    // See: https://eips.ethereum.org/EIPS/eip-2098
-    (uint nonce) = abi.decode(data[:32], (uint));
-    bytes memory signature = data[32:96];
 
     // Reconstruct the original message hash.
     bytes32 messageHash = keccak256(abi.encode(MEMBERSHIP_APPROVAL, nonce, _userAddress, block.chainid));

--- a/contracts/modules/governance/MemberRoles.sol
+++ b/contracts/modules/governance/MemberRoles.sol
@@ -184,6 +184,8 @@ contract MemberRoles is IMemberRoles, Governed, LegacyMasterAware {
     // Transfer the joining fee to the pool.
     (bool ok, /* data */) = poolAddress.call{value: joiningFee}("");
     require(ok, "MemberRoles: The joining fee transfer to the pool failed");
+
+    emit MemberJoined(_userAddress, nonce);
   }
 
   /// Withdraws membership

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0",
       "dependencies": {
         "@openzeppelin/contracts": "^2.5.1",
-        "@openzeppelin/contracts-v4": "npm:@openzeppelin/contracts@^4.0.0",
+        "@openzeppelin/contracts-v4": "npm:@openzeppelin/contracts@^4.7.3",
         "@openzeppelin/test-helpers": "^0.5.16",
         "dotenv": "^8.2.0",
         "ethereum-cryptography": "^1.0.1",
@@ -2717,9 +2717,9 @@
     },
     "node_modules/@openzeppelin/contracts-v4": {
       "name": "@openzeppelin/contracts",
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.3.1.tgz",
-      "integrity": "sha512-QjgbPPlmDK2clK1hzjw2ROfY8KA5q+PfhDUUxZFEBCZP9fi6d5FuNoh/Uq0oCTMEKPmue69vhX2jcl0N/tFKGw=="
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.7.3.tgz",
+      "integrity": "sha512-dGRS0agJzu8ybo44pCIf3xBaPQN/65AIXNgK8+4gzKd5kbvlqyxryUYVLJv7fK98Seyd2hDZzVEHSWAh0Bt1Yw=="
     },
     "node_modules/@openzeppelin/test-helpers": {
       "version": "0.5.16",
@@ -28276,9 +28276,9 @@
       "integrity": "sha512-qIy6tLx8rtybEsIOAlrM4J/85s2q2nPkDqj/Rx46VakBZ0LwtFhXIVub96LXHczQX0vaqmAueDqNPXtbSXSaYQ=="
     },
     "@openzeppelin/contracts-v4": {
-      "version": "npm:@openzeppelin/contracts@4.3.1",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.3.1.tgz",
-      "integrity": "sha512-QjgbPPlmDK2clK1hzjw2ROfY8KA5q+PfhDUUxZFEBCZP9fi6d5FuNoh/Uq0oCTMEKPmue69vhX2jcl0N/tFKGw=="
+      "version": "npm:@openzeppelin/contracts@4.7.3",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.7.3.tgz",
+      "integrity": "sha512-dGRS0agJzu8ybo44pCIf3xBaPQN/65AIXNgK8+4gzKd5kbvlqyxryUYVLJv7fK98Seyd2hDZzVEHSWAh0Bt1Yw=="
     },
     "@openzeppelin/test-helpers": {
       "version": "0.5.16",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/NexusMutual/smart-contracts",
   "dependencies": {
     "@openzeppelin/contracts": "^2.5.1",
-    "@openzeppelin/contracts-v4": "npm:@openzeppelin/contracts@^4.0.0",
+    "@openzeppelin/contracts-v4": "npm:@openzeppelin/contracts@^4.7.3",
     "@openzeppelin/test-helpers": "^0.5.16",
     "dotenv": "^8.2.0",
     "ethereum-cryptography": "^1.0.1",

--- a/test/integration/utils/enroll.js
+++ b/test/integration/utils/enroll.js
@@ -1,38 +1,24 @@
-const { web3, ethers, network } = require('hardhat');
+const { web3, network } = require('hardhat');
 const { ether } = require('@openzeppelin/test-helpers');
 const { MAX_UINT256 } = require('@openzeppelin/test-helpers').constants;
 const { toBN } = web3.utils;
 const { parseUnits } = require('ethers/lib/utils');
-const { formatBytes32String, defaultAbiCoder, arrayify, hexConcat, hexZeroPad, splitSignature, keccak256 } =
-  ethers.utils;
+const { signMembershipApproval } = require('../utils').membership;
 
 const JOINING_FEE = parseUnits('0.002');
-const MEMBERSHIP_APPROVAL = formatBytes32String('MEMBERSHIP_APPROVAL');
-
-const approveMembership = async ({ nonce, address, chainId, kycAuthSigner }) => {
-  const message = defaultAbiCoder.encode(
-    ['bytes32', 'uint256', 'address', 'uint256'],
-    [MEMBERSHIP_APPROVAL, nonce, address, chainId || network.config.chainId],
-  );
-  const hash = keccak256(message);
-  const signature = await kycAuthSigner.signMessage(arrayify(hash));
-  const { compact: compactSignature } = splitSignature(signature);
-
-  return hexConcat([hexZeroPad(nonce, 32), compactSignature]);
-};
 
 async function enrollMember({ mr, tk, tc }, members, kycAuthSigner, options = {}) {
   const { initialTokens = ether('2500') } = options;
 
   for (const member of members) {
-    const membershipApprovalData0 = await approveMembership({
+    const membershipApprovalData0 = await signMembershipApproval({
       nonce: 0,
       address: member.address,
       kycAuthSigner,
       chainId: network.config.chainId,
     });
 
-    await mr.signUp(member.address, membershipApprovalData0, {
+    await mr.join(member.address, 0, membershipApprovalData0, {
       value: JOINING_FEE,
     });
 

--- a/test/unit/MemberRoles/index.js
+++ b/test/unit/MemberRoles/index.js
@@ -12,7 +12,7 @@ describe('MemberRoles unit tests', function () {
     await revertToSnapshot(this.snapshotId);
   });
 
-  require('./signUp');
+  require('./join');
   require('./switchMembership');
   require('./withdrawMembership');
   require('./switchMembershipAndAssets');

--- a/test/unit/MemberRoles/join.js
+++ b/test/unit/MemberRoles/join.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 const { ethers, network } = require('hardhat');
-const { expectRevert, expectEvent } = require('@openzeppelin/test-helpers');
+const { expectRevert } = require('@openzeppelin/test-helpers');
 const { parseUnits } = require('ethers/lib/utils');
 const { arrayify, splitSignature } = ethers.utils;
 const { signMembershipApproval } = require('../utils').membership;
@@ -302,6 +302,5 @@ describe('join', function () {
 
     const isMemberAfter = await memberRoles.isMember(nonMembers[0].address);
     expect(isMemberAfter).to.be.equal(true);
-
   });
 });

--- a/test/unit/MemberRoles/join.js
+++ b/test/unit/MemberRoles/join.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 const { ethers, network } = require('hardhat');
-const { expectRevert } = require('@openzeppelin/test-helpers');
+const { expectRevert, expectEvent } = require('@openzeppelin/test-helpers');
 const { parseUnits } = require('ethers/lib/utils');
 const { arrayify, splitSignature } = ethers.utils;
 const { signMembershipApproval } = require('../utils').membership;
@@ -280,7 +280,7 @@ describe('join', function () {
     expect(addToWhitelistLastCalledWtihAfter).to.be.equal(nonMembers[0].address);
   });
 
-  it('assigns the member role to the address', async function () {
+  it('assigns the member role to the address and emits MemberJoined event', async function () {
     const { memberRoles } = this.contracts;
     const { nonMembers, defaultSender: kycAuthSigner } = this.accounts;
 
@@ -292,11 +292,16 @@ describe('join', function () {
     const isMemberBefore = await memberRoles.isMember(nonMembers[0].address);
     expect(isMemberBefore).to.be.equal(false);
 
-    await memberRoles.join(nonMembers[0].address, 0, arrayify(membershipApprovalData0), {
-      value: JOINING_FEE,
-    });
+    await expect(
+      memberRoles.join(nonMembers[0].address, 0, arrayify(membershipApprovalData0), {
+        value: JOINING_FEE,
+      }),
+    )
+      .to.emit(memberRoles, 'MemberJoined')
+      .withArgs(nonMembers[0].address, 0);
 
     const isMemberAfter = await memberRoles.isMember(nonMembers[0].address);
     expect(isMemberAfter).to.be.equal(true);
+
   });
 });

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -7,6 +7,7 @@ const tokenPrice = require('./token-price');
 const buyCover = require('./buyCover');
 const getQuote = require('./getQuote');
 const governance = require('./governance');
+const membership = require('./membership');
 
 module.exports = {
   accounts,
@@ -18,4 +19,5 @@ module.exports = {
   buyCover,
   getQuote,
   governance,
+  membership,
 };

--- a/test/utils/membership.js
+++ b/test/utils/membership.js
@@ -1,0 +1,16 @@
+const { ethers, network } = require('hardhat');
+const { arrayify, formatBytes32String, defaultAbiCoder, keccak256 } = ethers.utils;
+
+const MEMBERSHIP_APPROVAL = formatBytes32String('MEMBERSHIP_APPROVAL');
+
+const signMembershipApproval = async ({ address, nonce, chainId, kycAuthSigner }) => {
+  const message = defaultAbiCoder.encode(
+    ['bytes32', 'uint256', 'address', 'uint256'],
+    [MEMBERSHIP_APPROVAL, nonce, address, chainId || network.config.chainId],
+  );
+  const hash = keccak256(message);
+  const signature = await kycAuthSigner.signMessage(arrayify(hash));
+  return signature;
+};
+
+module.exports = { signMembershipApproval };


### PR DESCRIPTION
## Context
OZ updated their contracts to remove support for compact signatures. This PR updates the tests/contracts to use standard signatures with `memberRoles.signUp()`

closes #284 

## Changes proposed in this pull request

- Changed `MemberRoles.signUp()`:
        - Take standard v,r,s signature
        - Accept the nonce as a seperate parameter
        - Changed function name to `join()`

- Updated tests to refect the changes
- Moved `approveMembership` fn to utils folder and renamed it to `signMembershipApproval`  (open to other names)
 

## Test plan
No tests were added. Relevant tests are in `unit/MemberRoles/join.js`


## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [x] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


