### PR TITLE
Chore/Rename bucketStartTime to bucketEndTime

### DIFF
--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -269,14 +269,14 @@ contract StakingPool is IStakingPool, ERC721 {
         // each bucket contains a reward reduction - we subtract it when the bucket *starts*!
 
         ++_firstActiveBucketId;
-        uint bucketStartTime = _firstActiveBucketId * BUCKET_DURATION;
-        uint elapsed = bucketStartTime - _lastAccNxmUpdate;
+        uint bucketEndTime = _firstActiveBucketId * BUCKET_DURATION;
+        uint elapsed = bucketEndTime - _lastAccNxmUpdate;
 
         uint newAccNxmPerRewardsShare = elapsed * _rewardPerSecond / _rewardsSharesSupply;
         _accNxmPerRewardsShare = _accNxmPerRewardsShare.uncheckedAdd(newAccNxmPerRewardsShare);
 
         _rewardPerSecond -= rewardBuckets[_firstActiveBucketId].rewardPerSecondCut;
-        _lastAccNxmUpdate = bucketStartTime;
+        _lastAccNxmUpdate = bucketEndTime;
 
         continue;
       }


### PR DESCRIPTION
## Context
Closes #388  To align the naming between start/end, when expiring buckets and tranches.


## Changes proposed in this pull request
This PR renames bucketStartTime to bucketEndTime to match the tranche expiry.

## Test plan
Just a semantic change, no tests were added.

## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
