### PR TITLE
Feature: edit product grace period

### DIFF
--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -51,6 +51,7 @@ struct CoverSegment {
   uint96 amount;
   uint32 start;
   uint32 period;  // seconds
+  uint16 gracePeriodInDays;
   uint16 priceRatio;
   bool expired;
   uint24 globalRewardsRatio;

--- a/contracts/mocks/Claims/CLMockCover.sol
+++ b/contracts/mocks/Claims/CLMockCover.sol
@@ -122,6 +122,17 @@ contract CLMockCover {
     _products.push(product);
   }
 
+  function editProductTypes(
+    uint[] calldata productTypeIds,
+    uint16[] calldata gracePeriodsInDays,
+    string[] calldata ipfsMetadata
+  ) external {
+    ipfsMetadata;
+    for (uint i = 0; i < productTypeIds.length; i++) {
+      _productTypes[productTypeIds[i]].gracePeriodInDays = gracePeriodsInDays[i];
+    }
+  }
+
   function performStakeBurn(uint coverId, uint segmentId, uint amount) external returns (address) {
     performStakeBurnCalledWith = PerformStakeBurnCalledWith(coverId, segmentId, amount);
     return coverNFT.ownerOf(coverId);

--- a/contracts/mocks/Incidents/ICMockCover.sol
+++ b/contracts/mocks/Incidents/ICMockCover.sol
@@ -109,6 +109,17 @@ contract ICMockCover {
     ));
   }
 
+  function editProductTypes(
+    uint[] calldata productTypeIds,
+    uint16[] calldata gracePeriodsInDays,
+    string[] calldata ipfsHash
+  ) external {
+    ipfsHash;
+    for (uint i = 0; i < productTypeIds.length; i++) {
+      _productTypes[productTypeIds[i]].gracePeriodInDays = gracePeriodsInDays[i];
+    }
+  }
+
   function addProduct(Product calldata product) external {
     _products.push(product);
   }

--- a/contracts/modules/assessment/IndividualClaims.sol
+++ b/contracts/modules/assessment/IndividualClaims.sol
@@ -274,7 +274,7 @@ contract IndividualClaims is IIndividualClaims, MasterAwareV2 {
       require(requestedAmount <= segment.amount, "Covered amount exceeded");
       require(segment.start <= block.timestamp, "Cover starts in the future");
       require(
-        segment.start + segment.period + productType.gracePeriodInDays * 1 days > block.timestamp,
+        segment.start + segment.period + segment.gracePeriodInDays * 1 days > block.timestamp,
         "Cover is outside the grace period"
       );
 

--- a/contracts/modules/assessment/YieldTokenIncidents.sol
+++ b/contracts/modules/assessment/YieldTokenIncidents.sol
@@ -221,7 +221,7 @@ contract YieldTokenIncidents is IYieldTokenIncidents, MasterAwareV2 {
         ProductType memory productType = coverContract.productTypes(product.productType);
         require(
           coverSegment.start + coverSegment.period +
-          productType.gracePeriodInDays * 1 days >= block.timestamp,
+          coverSegment.gracePeriodInDays * 1 days >= block.timestamp,
           "Grace period has expired"
         );
       }

--- a/contracts/modules/assessment/YieldTokenIncidents.sol
+++ b/contracts/modules/assessment/YieldTokenIncidents.sol
@@ -218,7 +218,6 @@ contract YieldTokenIncidents is IYieldTokenIncidents, MasterAwareV2 {
       );
 
       {
-        ProductType memory productType = coverContract.productTypes(product.productType);
         require(
           coverSegment.start + coverSegment.period +
           coverSegment.gracePeriodInDays * 1 days >= block.timestamp,

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -290,6 +290,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
         totalCoveredAmountInCoverAsset, // amount
         uint32(block.timestamp + 1), // start
         SafeUintCast.toUint32(params.period), // period
+        _productTypes[_products[params.productId].productType].gracePeriodInDays,
         priceRatio,
         false, // expired,
         globalRewardsRatio
@@ -400,7 +401,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
           cover.productId,
           allocation.coverAmountInNXM,
           lastCoverSegment.period,
-          _productTypes[product.productType].gracePeriodInDays * 1 days,
+          lastCoverSegment.gracePeriodInDays * 1 days,
           // TODO globalCapacityRatio and capacityReductionRatio need to be stored at cover buy
           globalCapacityRatio,
           product.capacityReductionRatio,

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -307,7 +307,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
   ) internal returns (uint coveredAmountInNXM, uint premiumInNXM, uint rewardsInNXM) {
 
     Product memory product = _products[params.productId];
-    uint gracePeriod = _productTypes[product.productType].gracePeriodInDays * 1 days;
+    uint gracePeriod = uint(_productTypes[product.productType].gracePeriodInDays) * 1 days;
 
     return _stakingPool.allocateStake(
       CoverRequest(
@@ -401,7 +401,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
           cover.productId,
           allocation.coverAmountInNXM,
           lastCoverSegment.period,
-          lastCoverSegment.gracePeriodInDays * 1 days,
+          uint(lastCoverSegment.gracePeriodInDays) * 1 days,
           // TODO globalCapacityRatio and capacityReductionRatio need to be stored at cover buy
           globalCapacityRatio,
           product.capacityReductionRatio,

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -681,7 +681,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
     Product memory product,
     uint32 _coverAssetsFallback,
     uint productTypesCount
-  ) internal {
+  ) internal pure {
 
     require(product.productType < productTypesCount, "Cover: Invalid productType");
     require(

--- a/contracts/modules/cover/CoverUtilsLib.sol
+++ b/contracts/modules/cover/CoverUtilsLib.sol
@@ -76,12 +76,11 @@ library CoverUtilsLib {
 
     // Mark cover as migrated to prevent future calls on the same cover
     params.quotationData.changeCoverStatusNo(params.coverId, uint8(LegacyCoverStatus.Migrated));
-
+    ProductType memory productType;
     {
       // Mint the new cover
       uint productId = params.productsV1.getNewProductId(legacyProductId);
-      Product memory product = _products[productId];
-      ProductType memory productType = _productTypes[product.productType];
+      productType = _productTypes[_products[productId].productType];
       require(
         block.timestamp < validUntil + productType.gracePeriodInDays * 1 days,
         "Cover outside of the grace period"
@@ -103,6 +102,7 @@ library CoverUtilsLib {
         SafeUintCast.toUint96(sumAssured * 10 ** 18), // amount
         SafeUintCast.toUint32(validUntil - coverPeriodInDays * 1 days), // start
         SafeUintCast.toUint32(coverPeriodInDays * 1 days), // period
+        productType.gracePeriodInDays,
         uint16(0), // priceRatio
         false, // expired
         0 // global rewards ratio //

--- a/contracts/modules/cover/CoverViewer.sol
+++ b/contracts/modules/cover/CoverViewer.sol
@@ -24,7 +24,7 @@ contract CoverViewer {
     uint8 coverAsset;
     string coverAssetSymbol;
     uint8 claimMethod;
-    uint16[] gracePeriodInDays;
+    uint16 gracePeriodInDays;
   }
 
   uint private constant CAPACITY_REDUCTION_DENOMINATOR = 10000;
@@ -48,7 +48,7 @@ contract CoverViewer {
     uint coverStart;
     uint coverEnd;
     uint amountRemaining;
-    uint16[] memory gracePeriodInDays;  // grace period for each segment
+    uint16 gracePeriodInDays;  // grace period for each segment
     CoverData memory coverData = cover().coverData(coverId);
 
     {
@@ -58,15 +58,12 @@ contract CoverViewer {
       if (segmentCount == 1) {
         coverEnd = coverStart + firstSegment.period;
         amountRemaining = firstSegment.amount;
+        gracePeriodInDays = firstSegment.gracePeriodInDays;
       } else {
         CoverSegment memory lastSegment = cover().coverSegments(coverId, segmentCount - 1);
         coverEnd = lastSegment.start + lastSegment.period;
         amountRemaining = lastSegment.amount;
-      }
-
-      for (uint i = 0; i < segmentCount; i++){
-        CoverSegment memory segment = cover().coverSegments(coverId, i);
-        gracePeriodInDays[i] = segment.gracePeriodInDays;
+        gracePeriodInDays = lastSegment.gracePeriodInDays;
       }
     }
 

--- a/contracts/modules/cover/CoverViewer.sol
+++ b/contracts/modules/cover/CoverViewer.sol
@@ -24,7 +24,7 @@ contract CoverViewer {
     uint8 coverAsset;
     string coverAssetSymbol;
     uint8 claimMethod;
-    uint16 gracePeriodInDays;
+    uint16[] gracePeriodInDays;
   }
 
   uint private constant CAPACITY_REDUCTION_DENOMINATOR = 10000;
@@ -48,6 +48,7 @@ contract CoverViewer {
     uint coverStart;
     uint coverEnd;
     uint amountRemaining;
+    uint16[] memory gracePeriodInDays;  // grace period for each segment
     CoverData memory coverData = cover().coverData(coverId);
 
     {
@@ -61,6 +62,11 @@ contract CoverViewer {
         CoverSegment memory lastSegment = cover().coverSegments(coverId, segmentCount - 1);
         coverEnd = lastSegment.start + lastSegment.period;
         amountRemaining = lastSegment.amount;
+      }
+
+      for (uint i = 0; i < segmentCount; i++){
+        CoverSegment memory segment = cover().coverSegments(coverId, i);
+        gracePeriodInDays[i] = segment.gracePeriodInDays;
       }
     }
 
@@ -90,7 +96,7 @@ contract CoverViewer {
       coverData.coverAsset,
       coverAssetSymbol,
       productType.claimMethod,
-      productType.gracePeriodInDays
+      gracePeriodInDays
     );
   }
 

--- a/test/unit/Cover/buyCover.js
+++ b/test/unit/Cover/buyCover.js
@@ -7,6 +7,7 @@ const { bnEqual } = require('../utils').helpers;
 const { parseEther } = ethers.utils;
 const { AddressZero } = ethers.constants;
 const { BigNumber } = ethers;
+const gracePeriodInDays = 120;
 
 describe('buyCover', function () {
   it('should purchase new cover using 1 staking pool', async function () {
@@ -66,7 +67,14 @@ describe('buyCover', function () {
 
     const expectedCoverId = '0';
 
-    await assertCoverFields(cover, expectedCoverId, { productId, coverAsset, period, amount, targetPriceRatio });
+    await assertCoverFields(cover, expectedCoverId, {
+      productId,
+      coverAsset,
+      period,
+      amount,
+      targetPriceRatio,
+      gracePeriodInDays,
+    });
   });
 
   it('should purchase new cover using 2 staking pools', async function () {
@@ -142,7 +150,14 @@ describe('buyCover', function () {
 
     const expectedCoverId = '0';
 
-    await assertCoverFields(cover, expectedCoverId, { productId, coverAsset, period, amount, targetPriceRatio });
+    await assertCoverFields(cover, expectedCoverId, {
+      productId,
+      coverAsset,
+      period,
+      amount,
+      targetPriceRatio,
+      gracePeriodInDays,
+    });
   });
 
   it('should purchase new cover using NXM with commission', async function () {
@@ -218,7 +233,14 @@ describe('buyCover', function () {
 
     const expectedCoverId = '0';
 
-    await assertCoverFields(cover, expectedCoverId, { productId, coverAsset, period, amount, targetPriceRatio });
+    await assertCoverFields(cover, expectedCoverId, {
+      productId,
+      coverAsset,
+      period,
+      amount,
+      targetPriceRatio,
+      gracePeriodInDays,
+    });
   });
 
   it('should purchase new cover using DAI with commission', async function () {
@@ -299,7 +321,14 @@ describe('buyCover', function () {
 
     const expectedCoverId = '0';
 
-    await assertCoverFields(cover, expectedCoverId, { productId, coverAsset, period, amount, targetPriceRatio });
+    await assertCoverFields(cover, expectedCoverId, {
+      productId,
+      coverAsset,
+      period,
+      amount,
+      targetPriceRatio,
+      gracePeriodInDays,
+    });
   });
 
   it('should purchase new cover using USDC with commission', async function () {
@@ -381,7 +410,14 @@ describe('buyCover', function () {
 
     const expectedCoverId = '0';
 
-    await assertCoverFields(cover, expectedCoverId, { productId, coverAsset, period, amount, targetPriceRatio });
+    await assertCoverFields(cover, expectedCoverId, {
+      productId,
+      coverAsset,
+      period,
+      amount,
+      targetPriceRatio,
+      gracePeriodInDays,
+    });
   });
 
   it('should revert for unavailable product', async function () {

--- a/test/unit/Cover/editCover.js
+++ b/test/unit/Cover/editCover.js
@@ -6,6 +6,7 @@ const { parseEther } = ethers.utils;
 const { AddressZero } = ethers.constants;
 
 const { assertCoverFields, buyCoverOnOnePool, MAX_COVER_PERIOD } = require('./helpers');
+const gracePeriodInDays = 120;
 
 describe('editCover', function () {
   const coverBuyFixture = {
@@ -70,6 +71,7 @@ describe('editCover', function () {
       period,
       amount: increasedAmount,
       targetPriceRatio,
+      gracePeriodInDays,
       segmentId: '1',
     });
   });
@@ -122,6 +124,7 @@ describe('editCover', function () {
       period: increasedPeriod,
       amount,
       targetPriceRatio,
+      gracePeriodInDays,
       segmentId: '1',
     });
   });
@@ -177,6 +180,7 @@ describe('editCover', function () {
       period: increasedPeriod,
       amount: increasedAmount,
       targetPriceRatio,
+      gracePeriodInDays,
       segmentId: '1',
     });
   });
@@ -232,6 +236,7 @@ describe('editCover', function () {
       period: increasedPeriod,
       amount: decreasedAmount,
       targetPriceRatio,
+      gracePeriodInDays,
       segmentId: '1',
     });
   });
@@ -278,6 +283,7 @@ describe('editCover', function () {
       period,
       amount: increasedAmount,
       targetPriceRatio,
+      gracePeriodInDays,
       segmentId: '1',
     });
   });

--- a/test/unit/Cover/helpers.js
+++ b/test/unit/Cover/helpers.js
@@ -43,15 +43,15 @@ async function createStakingPool(cover, productId, capacity, targetPrice, active
 async function assertCoverFields(
   cover,
   coverId,
-  { productId, coverAsset, period, amount, targetPriceRatio, segmentId = '0', amountPaidOut = '0' },
+  { productId, coverAsset, period, amount, targetPriceRatio, gracePeriodInDays, segmentId = '0', amountPaidOut = '0' },
 ) {
   const storedCoverData = await cover.coverData(coverId);
 
   const segment = await cover.coverSegments(coverId, segmentId);
-
   assert.equal(storedCoverData.productId, productId);
   assert.equal(storedCoverData.coverAsset, coverAsset);
   bnEqual(storedCoverData.amountPaidOut, amountPaidOut);
+  assert.equal(segment.gracePeriodInDays, gracePeriodInDays);
   assert.equal(segment.period, period);
   assert.equal(segment.amount.toString(), amount.toString());
   bnEqual(segment.priceRatio, targetPriceRatio);

--- a/test/unit/Cover/performStakeBurn.js
+++ b/test/unit/Cover/performStakeBurn.js
@@ -5,7 +5,7 @@ const { bnEqual } = require('../utils').helpers;
 const { parseEther } = ethers.utils;
 const gracePeriodInDays = 120;
 
-describe.only('performStakeBurn', function () {
+describe('performStakeBurn', function () {
   const coverBuyFixture = {
     productId: 0,
     coverAsset: 0, // ETH

--- a/test/unit/Cover/performStakeBurn.js
+++ b/test/unit/Cover/performStakeBurn.js
@@ -3,8 +3,9 @@ const { assertCoverFields, buyCoverOnOnePool } = require('./helpers');
 const { bnEqual } = require('../utils').helpers;
 
 const { parseEther } = ethers.utils;
+const gracePeriodInDays = 120;
 
-describe('performStakeBurn', function () {
+describe.only('performStakeBurn', function () {
   const coverBuyFixture = {
     productId: 0,
     coverAsset: 0, // ETH
@@ -51,6 +52,7 @@ describe('performStakeBurn', function () {
       period,
       amount: remainingAmount,
       targetPriceRatio,
+      gracePeriodInDays,
       segmentId,
       amountPaidOut: burnAmount,
     });

--- a/test/unit/CoverViewer/views.js
+++ b/test/unit/CoverViewer/views.js
@@ -1,4 +1,4 @@
-const { assert } = require('chai');
+const { expect } = require('chai');
 const { ethers } = require('hardhat');
 const {
   utils: { parseEther },
@@ -24,7 +24,13 @@ describe('views', function () {
 
     const segments = await coverViewer.getCoverSegments(coverId);
 
-    assert.equal(segments.length, 1);
-    assert(segments[0].amount.toString(), coverSegment1.amount.toString());
+    expect(segments.length).to.be.equal(1);
+    expect(segments[0].amount.toString()).to.be.equal(coverSegment1.amount.toString());
+    expect(segments[0].start).to.be.equal(coverSegment1.start);
+    expect(segments[0].period).to.be.equal(coverSegment1.period);
+    expect(segments[0].gracePeriodInDays).to.be.equal(coverSegment1.gracePeriodInDays);
+    expect(segments[0].priceRatio).to.be.equal(coverSegment1.priceRatio);
+    expect(segments[0].expired).to.be.equal(false);
+    expect(segments[0].globalRewardsRatio).to.be.equal(coverSegment1.globalRewardsRatio);
   });
 });

--- a/test/unit/CoverViewer/views.js
+++ b/test/unit/CoverViewer/views.js
@@ -12,6 +12,7 @@ describe('views', function () {
       amount: parseEther('100'),
       start: 1000,
       period: 3600 * 24 * 30, // seconds
+      gracePeriodInDays: 7,
       priceRatio: 3000,
       expired: false,
       globalRewardsRatio: 5000,

--- a/test/unit/IndividualClaims/getClaimsCount.js
+++ b/test/unit/IndividualClaims/getClaimsCount.js
@@ -22,7 +22,7 @@ describe('getClaimsCount', function () {
       coverOwner.address,
       0, // productId
       ASSET.ETH,
-      [[parseEther('100'), timestamp + 1, daysToSeconds(365), 0, false, 0]],
+      [[parseEther('100'), timestamp + 1, daysToSeconds(365), 30, 0, false, 0]],
     );
 
     {

--- a/test/unit/IndividualClaims/getClaimsToDisplay.js
+++ b/test/unit/IndividualClaims/getClaimsToDisplay.js
@@ -35,7 +35,7 @@ describe('getClaimsToDisplay', function () {
         coverOwner.address,
         0, // productId
         ASSET.ETH,
-        [[coverAmount, timestamp + 1, coverPeriod, 0, false, 0]],
+        [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
       );
       expectedCoverStarts[3] = timestamp + 1; // This will be the 4th calim
       await setTime(timestamp + daysToSeconds(1));
@@ -48,7 +48,7 @@ describe('getClaimsToDisplay', function () {
         coverOwner.address,
         0, // productId
         ASSET.DAI,
-        [[coverAmount, timestamp + 1, coverPeriod, 0, false, 0]],
+        [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
       );
       expectedCoverStarts[1] = timestamp + 1; // This will be the 2nd calim
       await setTime(timestamp + daysToSeconds(2));
@@ -61,7 +61,7 @@ describe('getClaimsToDisplay', function () {
         coverOwner.address,
         1, // productId
         ASSET.ETH,
-        [[coverAmount, timestamp + 1, coverPeriod, 0, false, 0]],
+        [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
       );
       expectedCoverStarts[2] = timestamp + 1; // This will be the 3rd calim
       await setTime(timestamp + daysToSeconds(4));
@@ -74,7 +74,7 @@ describe('getClaimsToDisplay', function () {
         coverOwner.address,
         1, // productId
         ASSET.DAI,
-        [[coverAmount, timestamp + 1, coverPeriod, 0, false, 0]],
+        [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
       );
       expectedCoverStarts[0] = timestamp + 1; // This will be the 1st calim
       await setTime(timestamp + daysToSeconds(1));
@@ -87,7 +87,7 @@ describe('getClaimsToDisplay', function () {
         coverOwner.address,
         1, // productId
         ASSET.DAI,
-        [[coverAmount, timestamp + 1, coverPeriod, 0, false, 0]],
+        [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
       );
       expectedCoverStarts[4] = timestamp + 1; // This will be the 5th calim
     }

--- a/test/unit/IndividualClaims/getClaimsToDisplay.js
+++ b/test/unit/IndividualClaims/getClaimsToDisplay.js
@@ -1,7 +1,7 @@
 const { ethers } = require('hardhat');
 const { expect } = require('chai');
 
-const { ASSET, CLAIM_STATUS, PAYOUT_STATUS } = require('./helpers');
+const { ASSET, CLAIM_STATUS, PAYOUT_STATUS, getCoverSegment } = require('./helpers');
 const { mineNextBlock, setNextBlockTime } = require('../../utils/evm');
 
 const { parseEther } = ethers.utils;
@@ -17,8 +17,8 @@ describe('getClaimsToDisplay', function () {
   it('aggregates and displays claims related data in a human-readable form', async function () {
     const { individualClaims, cover, assessment } = this.contracts;
     const [coverOwner] = this.accounts.members;
-    const coverPeriod = daysToSeconds(66);
-    const coverAmount = parseEther('100');
+    const segment = await getCoverSegment();
+    segment.period = daysToSeconds('66');
     const expectedProductIds = ['1', '0', '1', '0', '1'];
     const expectedClaimIds = ['0', '1', '2', '3', '4'];
     const expectedCoverIds = ['3', '1', '2', '0', '4'];
@@ -31,11 +31,12 @@ describe('getClaimsToDisplay', function () {
     {
       // 0
       const { timestamp } = await ethers.provider.getBlock('latest');
+      segment.start = timestamp + 1;
       await cover.createMockCover(
         coverOwner.address,
         0, // productId
         ASSET.ETH,
-        [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
+        [segment],
       );
       expectedCoverStarts[3] = timestamp + 1; // This will be the 4th calim
       await setTime(timestamp + daysToSeconds(1));
@@ -44,11 +45,12 @@ describe('getClaimsToDisplay', function () {
     {
       // 1
       const { timestamp } = await ethers.provider.getBlock('latest');
+      segment.start = timestamp + 1;
       await cover.createMockCover(
         coverOwner.address,
         0, // productId
         ASSET.DAI,
-        [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
+        [segment],
       );
       expectedCoverStarts[1] = timestamp + 1; // This will be the 2nd calim
       await setTime(timestamp + daysToSeconds(2));
@@ -57,11 +59,12 @@ describe('getClaimsToDisplay', function () {
     {
       // 2
       const { timestamp } = await ethers.provider.getBlock('latest');
+      segment.start = timestamp + 1;
       await cover.createMockCover(
         coverOwner.address,
         1, // productId
         ASSET.ETH,
-        [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
+        [segment],
       );
       expectedCoverStarts[2] = timestamp + 1; // This will be the 3rd calim
       await setTime(timestamp + daysToSeconds(4));
@@ -70,11 +73,12 @@ describe('getClaimsToDisplay', function () {
     {
       // 3
       const { timestamp } = await ethers.provider.getBlock('latest');
+      segment.start = timestamp + 1;
       await cover.createMockCover(
         coverOwner.address,
         1, // productId
         ASSET.DAI,
-        [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
+        [segment],
       );
       expectedCoverStarts[0] = timestamp + 1; // This will be the 1st calim
       await setTime(timestamp + daysToSeconds(1));
@@ -83,11 +87,12 @@ describe('getClaimsToDisplay', function () {
     {
       // 4
       const { timestamp } = await ethers.provider.getBlock('latest');
+      segment.start = timestamp + 1;
       await cover.createMockCover(
         coverOwner.address,
         1, // productId
         ASSET.DAI,
-        [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
+        [segment],
       );
       expectedCoverStarts[4] = timestamp + 1; // This will be the 5th calim
     }
@@ -95,7 +100,7 @@ describe('getClaimsToDisplay', function () {
     {
       const [deposit] = await individualClaims.getAssessmentDepositAndReward(
         expectedAmounts[0],
-        coverPeriod,
+        segment.period,
         ASSET.DAI,
       );
       await individualClaims.connect(coverOwner).submitClaim(3, 0, expectedAmounts[0], '', {
@@ -108,7 +113,7 @@ describe('getClaimsToDisplay', function () {
     {
       const [deposit] = await individualClaims.getAssessmentDepositAndReward(
         expectedAmounts[1],
-        coverPeriod,
+        segment.period,
         ASSET.DAI,
       );
       await individualClaims.connect(coverOwner).submitClaim(1, 0, expectedAmounts[1], '', {
@@ -121,7 +126,7 @@ describe('getClaimsToDisplay', function () {
     {
       const [deposit] = await individualClaims.getAssessmentDepositAndReward(
         expectedAmounts[2],
-        coverPeriod,
+        segment.period,
         ASSET.ETH,
       );
       await individualClaims.connect(coverOwner).submitClaim(2, 0, expectedAmounts[2], '', {
@@ -134,7 +139,7 @@ describe('getClaimsToDisplay', function () {
     {
       const [deposit] = await individualClaims.getAssessmentDepositAndReward(
         expectedAmounts[3],
-        coverPeriod,
+        segment.period,
         ASSET.ETH,
       );
       await individualClaims.connect(coverOwner).submitClaim(0, 0, expectedAmounts[3], '', {
@@ -147,7 +152,7 @@ describe('getClaimsToDisplay', function () {
     {
       const [deposit] = await individualClaims.getAssessmentDepositAndReward(
         expectedAmounts[4],
-        coverPeriod,
+        segment.period,
         ASSET.ETH,
       );
       await individualClaims.connect(coverOwner).submitClaim(4, 0, expectedAmounts[4], '', {
@@ -159,7 +164,7 @@ describe('getClaimsToDisplay', function () {
 
     const { minVotingPeriodInDays } = await assessment.config();
     const expectedPollEnds = expectedPollStarts.map(x => x + daysToSeconds(minVotingPeriodInDays));
-    const expectedCoverEnds = expectedCoverStarts.map(x => x + coverPeriod);
+    const expectedCoverEnds = expectedCoverStarts.map(x => x + segment.period);
 
     const res = await individualClaims.getClaimsToDisplay([0, 1, 2, 3, 4]);
     const actualClaimIds = res.map(x => x.id);

--- a/test/unit/IndividualClaims/helpers.js
+++ b/test/unit/IndividualClaims/helpers.js
@@ -62,6 +62,23 @@ const getIncidentDetailsStruct = ({
   minAssessmentDepositRatio,
 }) => [productId, date, coverAsset, activeCoverAmount, expectedPayoutRatio, minAssessmentDepositRatio];
 
+const coverSegmentFixture = {
+  amount: parseEther('100'),
+  start: 0,
+  period: 30 * 24 * 60 * 60,
+  gracePeriodInDays: 7,
+  priceRatio: 0,
+  expired: false,
+  globalRewardsRatio: 0,
+};
+
+const getCoverSegment = async () => {
+  const { timestamp } = await ethers.provider.getBlock('latest');
+  const cover = { ...coverSegmentFixture };
+  cover.start = timestamp + 1;
+  return cover;
+};
+
 module.exports = {
   ASSET,
   CLAIM_STATUS,
@@ -72,4 +89,5 @@ module.exports = {
   getClaimDetailsStruct,
   getIncidentDetailsStruct,
   getVoteStruct,
+  getCoverSegment,
 };

--- a/test/unit/IndividualClaims/redeemClaimPayout.js
+++ b/test/unit/IndividualClaims/redeemClaimPayout.js
@@ -24,7 +24,7 @@ describe('redeemClaimPayout', function () {
       coverOwner.address,
       0, // productId
       ASSET.ETH,
-      [[coverAmount, timestamp + 1, coverPeriod, 0, false, 0]],
+      [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
     );
 
     {
@@ -65,7 +65,7 @@ describe('redeemClaimPayout', function () {
       coverOwner.address,
       0, // productId
       ASSET.ETH,
-      [[coverAmount, timestamp + 1, coverPeriod, 0, false, 0]],
+      [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
     );
 
     await submitClaim(this)({ coverId: 0, sender: coverOwner });
@@ -102,7 +102,7 @@ describe('redeemClaimPayout', function () {
       coverOwner.address,
       0, // productId
       ASSET.ETH,
-      [[coverAmount, timestamp + 1, coverPeriod, 0, false, 0]],
+      [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
     );
 
     await submitClaim(this)({ coverId: 0, sender: coverOwner });
@@ -127,7 +127,7 @@ describe('redeemClaimPayout', function () {
       coverOwner.address,
       0, // productId
       ASSET.ETH,
-      [[coverAmount, timestamp + 1, coverPeriod, 0, false, 0]],
+      [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
     );
 
     await submitClaim(this)({ coverId: 0, sender: coverOwner });
@@ -151,7 +151,7 @@ describe('redeemClaimPayout', function () {
       coverOwner.address,
       0, // productId
       ASSET.ETH,
-      [[coverAmount, timestamp + 1, coverPeriod, 0, false, 0]],
+      [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
     );
 
     await submitClaim(this)({ coverId: 0, sender: coverOwner });
@@ -175,7 +175,7 @@ describe('redeemClaimPayout', function () {
       coverOwner.address,
       0, // productId
       ASSET.ETH,
-      [[coverAmount, timestamp + 1, coverPeriod, 0, false, 0]],
+      [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
     );
     await submitClaim(this)({ coverId: 0, sender: coverOwner });
     await assessment.castVote(0, true, parseEther('1'));
@@ -200,7 +200,7 @@ describe('redeemClaimPayout', function () {
         originalOwner.address,
         0, // productId
         ASSET.ETH,
-        [[coverAmount, timestamp + 1, coverPeriod, 0, false, 0]],
+        [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
         { gasPrice: 0 },
       );
 
@@ -233,7 +233,7 @@ describe('redeemClaimPayout', function () {
         originalOwner.address,
         0, // productId
         ASSET.ETH,
-        [[coverAmount, timestamp + 1, coverPeriod, 0, false, 0]],
+        [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
         { gasPrice: 0 },
       );
 
@@ -275,7 +275,7 @@ describe('redeemClaimPayout', function () {
         originalOwner.address,
         0, // productId
         ASSET.DAI,
-        [[coverAmount, timestamp + 1, coverPeriod, 0, false, 0]],
+        [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
         { gasPrice: 0 },
       );
 
@@ -309,7 +309,7 @@ describe('redeemClaimPayout', function () {
         originalOwner.address,
         0, // productId
         ASSET.DAI,
-        [[coverAmount, timestamp + 1, coverPeriod, 0, false, 0]],
+        [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
         { gasPrice: 0 },
       );
 
@@ -355,9 +355,9 @@ describe('redeemClaimPayout', function () {
         0, // productId
         ASSET.DAI,
         [
-          [0, 0, 0, 0, false, 0],
-          [0, 0, 0, 0, false, 0],
-          [coverAmount, timestamp + 1, coverPeriod, 0, false, 0],
+          [0, 0, 0, 0, 0, false, 0],
+          [0, 0, 0, 0, 0, false, 0],
+          [coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0],
         ],
         { gasPrice: 0 },
       );

--- a/test/unit/IndividualClaims/redeemClaimPayout.js
+++ b/test/unit/IndividualClaims/redeemClaimPayout.js
@@ -1,7 +1,7 @@
 const { ethers } = require('hardhat');
 const { expect } = require('chai');
 
-const { submitClaim, ASSET } = require('./helpers');
+const { submitClaim, ASSET, getCoverSegment } = require('./helpers');
 const { mineNextBlock, setNextBlockTime } = require('../../utils/evm');
 
 const { parseEther } = ethers.utils;
@@ -16,15 +16,13 @@ describe('redeemClaimPayout', function () {
   it('reverts if the claim is not accepted', async function () {
     const { individualClaims, cover, assessment } = this.contracts;
     const [coverOwner] = this.accounts.members;
-    const coverPeriod = daysToSeconds(30);
-    const coverAmount = parseEther('100');
+    const segment = await getCoverSegment();
 
-    const { timestamp } = await ethers.provider.getBlock('latest');
     await cover.createMockCover(
       coverOwner.address,
       0, // productId
       ASSET.ETH,
-      [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
+      [segment],
     );
 
     {
@@ -58,14 +56,13 @@ describe('redeemClaimPayout', function () {
   it('reverts while the claim is being assessed', async function () {
     const { individualClaims, cover, assessment } = this.contracts;
     const [coverOwner] = this.accounts.members;
-    const coverPeriod = daysToSeconds(30);
-    const coverAmount = parseEther('100');
-    const { timestamp } = await ethers.provider.getBlock('latest');
+    const segment = await getCoverSegment();
+
     await cover.createMockCover(
       coverOwner.address,
       0, // productId
       ASSET.ETH,
-      [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
+      [segment],
     );
 
     await submitClaim(this)({ coverId: 0, sender: coverOwner });
@@ -95,14 +92,13 @@ describe('redeemClaimPayout', function () {
   it('reverts while the claim is in cooldown period', async function () {
     const { individualClaims, cover, assessment } = this.contracts;
     const [coverOwner] = this.accounts.members;
-    const coverPeriod = daysToSeconds(30);
-    const coverAmount = parseEther('100');
-    const { timestamp } = await ethers.provider.getBlock('latest');
+    const segment = await getCoverSegment();
+
     await cover.createMockCover(
       coverOwner.address,
       0, // productId
       ASSET.ETH,
-      [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
+      [segment],
     );
 
     await submitClaim(this)({ coverId: 0, sender: coverOwner });
@@ -120,14 +116,13 @@ describe('redeemClaimPayout', function () {
   it('reverts if the redemption period expired', async function () {
     const { individualClaims, cover, assessment } = this.contracts;
     const [coverOwner] = this.accounts.members;
-    const coverPeriod = daysToSeconds(30);
-    const coverAmount = parseEther('100');
-    const { timestamp } = await ethers.provider.getBlock('latest');
+    const segment = await getCoverSegment();
+
     await cover.createMockCover(
       coverOwner.address,
       0, // productId
       ASSET.ETH,
-      [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
+      [segment],
     );
 
     await submitClaim(this)({ coverId: 0, sender: coverOwner });
@@ -144,14 +139,13 @@ describe('redeemClaimPayout', function () {
   it('reverts if a payout has already been redeemed', async function () {
     const { individualClaims, cover, assessment } = this.contracts;
     const [coverOwner] = this.accounts.members;
-    const coverPeriod = daysToSeconds(30);
-    const coverAmount = parseEther('100');
-    const { timestamp } = await ethers.provider.getBlock('latest');
+    const segment = await getCoverSegment();
+
     await cover.createMockCover(
       coverOwner.address,
       0, // productId
       ASSET.ETH,
-      [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
+      [segment],
     );
 
     await submitClaim(this)({ coverId: 0, sender: coverOwner });
@@ -168,14 +162,13 @@ describe('redeemClaimPayout', function () {
   it("sets the claim's payoutRedeemed property to true", async function () {
     const { individualClaims, cover, assessment } = this.contracts;
     const [coverOwner] = this.accounts.members;
-    const coverPeriod = daysToSeconds(30);
-    const coverAmount = parseEther('100');
-    const { timestamp } = await ethers.provider.getBlock('latest');
+    const segment = await getCoverSegment();
+
     await cover.createMockCover(
       coverOwner.address,
       0, // productId
       ASSET.ETH,
-      [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
+      [segment],
     );
     await submitClaim(this)({ coverId: 0, sender: coverOwner });
     await assessment.castVote(0, true, parseEther('1'));
@@ -191,8 +184,37 @@ describe('redeemClaimPayout', function () {
     // also check after NFT transfer
     const { individualClaims, cover, coverNFT, assessment } = this.contracts;
     const [originalOwner, newOwner, otherMember] = this.accounts.members;
-    const coverPeriod = daysToSeconds(30);
-    const coverAmount = parseEther('100');
+    const segment = await getCoverSegment();
+
+    await cover.createMockCover(
+      originalOwner.address,
+      0, // productId
+      ASSET.ETH,
+      [segment],
+      { gasPrice: 0 },
+    );
+
+    const ethBalanceBefore = await ethers.provider.getBalance(originalOwner.address);
+    const coverId = 0;
+    const assessmentId = 0;
+    const claimId = 0;
+    const [deposit] = await individualClaims.getAssessmentDepositAndReward(segment.amount, segment.period, ASSET.ETH);
+    await individualClaims
+      .connect(originalOwner)
+      ['submitClaim(uint32,uint16,uint96,string)'](coverId, 0, segment.amount, '', {
+        value: deposit,
+        gasPrice: 0,
+      });
+
+    await assessment.connect(otherMember).castVote(assessmentId, true, parseEther('1'));
+    const { poll } = await assessment.assessments(assessmentId);
+    const { payoutCooldownInDays } = await assessment.config();
+    await setTime(poll.end + daysToSeconds(payoutCooldownInDays));
+
+    await individualClaims.connect(originalOwner).redeemClaimPayout(claimId, { gasPrice: 0 });
+    const ethBalanceAfter = await ethers.provider.getBalance(originalOwner.address);
+
+    expect(ethBalanceAfter).to.be.equal(ethBalanceBefore.add(segment.amount));
 
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
@@ -200,50 +222,17 @@ describe('redeemClaimPayout', function () {
         originalOwner.address,
         0, // productId
         ASSET.ETH,
-        [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
-        { gasPrice: 0 },
-      );
-
-      const ethBalanceBefore = await ethers.provider.getBalance(originalOwner.address);
-      const coverId = 0;
-      const assessmentId = 0;
-      const claimId = 0;
-      const [deposit] = await individualClaims.getAssessmentDepositAndReward(coverAmount, coverPeriod, ASSET.ETH);
-      await individualClaims
-        .connect(originalOwner)
-        ['submitClaim(uint32,uint16,uint96,string)'](coverId, 0, coverAmount, '', {
-          value: deposit,
-          gasPrice: 0,
-        });
-
-      await assessment.connect(otherMember).castVote(assessmentId, true, parseEther('1'));
-      const { poll } = await assessment.assessments(assessmentId);
-      const { payoutCooldownInDays } = await assessment.config();
-      await setTime(poll.end + daysToSeconds(payoutCooldownInDays));
-
-      await individualClaims.connect(originalOwner).redeemClaimPayout(claimId, { gasPrice: 0 });
-      const ethBalanceAfter = await ethers.provider.getBalance(originalOwner.address);
-
-      expect(ethBalanceAfter).to.be.equal(ethBalanceBefore.add(coverAmount));
-    }
-
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        originalOwner.address,
-        0, // productId
-        ASSET.ETH,
-        [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
+        [[segment.amount, timestamp + 1, segment.period, 7, 0, false, 0]],
         { gasPrice: 0 },
       );
 
       const coverId = 1;
       const assessmentId = 1;
       const claimId = 1;
-      const [deposit] = await individualClaims.getAssessmentDepositAndReward(coverAmount, coverPeriod, ASSET.ETH);
+      const [deposit] = await individualClaims.getAssessmentDepositAndReward(segment.amount, segment.period, ASSET.ETH);
       await individualClaims
         .connect(originalOwner)
-        ['submitClaim(uint32,uint16,uint96,string)'](coverId, 0, coverAmount, '', {
+        ['submitClaim(uint32,uint16,uint96,string)'](coverId, 0, segment.amount, '', {
           value: deposit,
           gasPrice: 0,
         });
@@ -258,7 +247,7 @@ describe('redeemClaimPayout', function () {
       await individualClaims.connect(otherMember).redeemClaimPayout(claimId, { gasPrice: 0 }); // anyone can poke this
       const ethBalanceAfter = await ethers.provider.getBalance(newOwner.address);
 
-      expect(ethBalanceAfter).to.be.equal(ethBalanceBefore.add(coverAmount).add(deposit));
+      expect(ethBalanceAfter).to.be.equal(ethBalanceBefore.add(segment.amount).add(deposit));
     }
   });
 
@@ -266,50 +255,45 @@ describe('redeemClaimPayout', function () {
     // also check after NFT transfer
     const { individualClaims, cover, coverNFT, assessment, dai } = this.contracts;
     const [originalOwner, newOwner, otherMember] = this.accounts.members;
-    const coverPeriod = daysToSeconds(30);
-    const coverAmount = parseEther('100');
+    const segment = await getCoverSegment();
+
+    await cover.createMockCover(
+      originalOwner.address,
+      0, // productId
+      ASSET.DAI,
+      [segment],
+      { gasPrice: 0 },
+    );
+
+    const ethBalanceBefore = await ethers.provider.getBalance(originalOwner.address);
+    const daiBalanceBefore = await dai.balanceOf(originalOwner.address);
+    const coverId = 0;
+    const [deposit] = await individualClaims.getAssessmentDepositAndReward(segment.amount, segment.period, ASSET.DAI);
+    await individualClaims
+      .connect(originalOwner)
+      ['submitClaim(uint32,uint16,uint96,string)'](coverId, 0, segment.amount, '', {
+        value: deposit,
+        gasPrice: 0,
+      });
+
+    await assessment.connect(otherMember).castVote(0, true, parseEther('1'));
+    const { poll } = await assessment.assessments(0);
+    const { payoutCooldownInDays } = await assessment.config();
+    await setTime(poll.end + daysToSeconds(payoutCooldownInDays));
+
+    await individualClaims.connect(originalOwner).redeemClaimPayout(0, { gasPrice: 0 });
+    const ethBalanceAfter = await ethers.provider.getBalance(originalOwner.address);
+    const daiBalanceAfter = await dai.balanceOf(originalOwner.address);
+
+    expect(ethBalanceAfter).to.be.equal(ethBalanceBefore);
+    expect(daiBalanceAfter).to.be.equal(daiBalanceBefore.add(segment.amount));
 
     {
-      const { timestamp } = await ethers.provider.getBlock('latest');
       await cover.createMockCover(
         originalOwner.address,
         0, // productId
         ASSET.DAI,
-        [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
-        { gasPrice: 0 },
-      );
-
-      const ethBalanceBefore = await ethers.provider.getBalance(originalOwner.address);
-      const daiBalanceBefore = await dai.balanceOf(originalOwner.address);
-      const coverId = 0;
-      const [deposit] = await individualClaims.getAssessmentDepositAndReward(coverAmount, coverPeriod, ASSET.DAI);
-      await individualClaims
-        .connect(originalOwner)
-        ['submitClaim(uint32,uint16,uint96,string)'](coverId, 0, coverAmount, '', {
-          value: deposit,
-          gasPrice: 0,
-        });
-
-      await assessment.connect(otherMember).castVote(0, true, parseEther('1'));
-      const { poll } = await assessment.assessments(0);
-      const { payoutCooldownInDays } = await assessment.config();
-      await setTime(poll.end + daysToSeconds(payoutCooldownInDays));
-
-      await individualClaims.connect(originalOwner).redeemClaimPayout(0, { gasPrice: 0 });
-      const ethBalanceAfter = await ethers.provider.getBalance(originalOwner.address);
-      const daiBalanceAfter = await dai.balanceOf(originalOwner.address);
-
-      expect(ethBalanceAfter).to.be.equal(ethBalanceBefore);
-      expect(daiBalanceAfter).to.be.equal(daiBalanceBefore.add(coverAmount));
-    }
-
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        originalOwner.address,
-        0, // productId
-        ASSET.DAI,
-        [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
+        [segment],
         { gasPrice: 0 },
       );
 
@@ -319,10 +303,10 @@ describe('redeemClaimPayout', function () {
       const segmentId = 0;
       const assessmentId = 1;
       const claimId = 1;
-      const [deposit] = await individualClaims.getAssessmentDepositAndReward(coverAmount, coverPeriod, ASSET.DAI);
+      const [deposit] = await individualClaims.getAssessmentDepositAndReward(segment.amount, segment.period, ASSET.DAI);
       await individualClaims
         .connect(originalOwner)
-        ['submitClaim(uint32,uint16,uint96,string)'](coverId, segmentId, coverAmount, '', {
+        ['submitClaim(uint32,uint16,uint96,string)'](coverId, segmentId, segment.amount, '', {
           value: deposit,
           gasPrice: 0,
         });
@@ -338,34 +322,28 @@ describe('redeemClaimPayout', function () {
       const daiBalanceAfter = await dai.balanceOf(newOwner.address);
 
       expect(ethBalanceAfter).to.be.equal(ethBalanceBefore.add(deposit));
-      expect(daiBalanceAfter).to.be.equal(daiBalanceBefore.add(coverAmount));
+      expect(daiBalanceAfter).to.be.equal(daiBalanceBefore.add(segment.amount));
     }
   });
 
   it('calls performStakeBurn from Cover.sol with the amount to be burned, cover and segment IDs', async function () {
     const { individualClaims, cover, assessment } = this.contracts;
     const [coverOwner, otherMember] = this.accounts.members;
-    const coverPeriod = daysToSeconds(30);
-    const coverAmount = parseEther('100');
+    const segment = await getCoverSegment();
 
     for (let i = 0; i <= 3; i++) {
-      const { timestamp } = await ethers.provider.getBlock('latest');
       await cover.createMockCover(
         coverOwner.address,
         0, // productId
         ASSET.DAI,
-        [
-          [0, 0, 0, 0, 0, false, 0],
-          [0, 0, 0, 0, 0, false, 0],
-          [coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0],
-        ],
+        [segment, segment, segment],
         { gasPrice: 0 },
       );
     }
 
     {
-      const [deposit] = await individualClaims.getAssessmentDepositAndReward(coverAmount, coverPeriod, ASSET.ETH);
-      await individualClaims.connect(coverOwner)['submitClaim(uint32,uint16,uint96,string)'](3, 2, coverAmount, '', {
+      const [deposit] = await individualClaims.getAssessmentDepositAndReward(segment.amount, segment.period, ASSET.ETH);
+      await individualClaims.connect(coverOwner)['submitClaim(uint32,uint16,uint96,string)'](3, 2, segment.amount, '', {
         value: deposit,
         gasPrice: 0,
       });
@@ -380,18 +358,18 @@ describe('redeemClaimPayout', function () {
 
       expect(coverId).to.be.equal(3);
       expect(segmentId).to.be.equal(2);
-      expect(amount).to.be.equal(coverAmount);
+      expect(amount).to.be.equal(segment.amount);
     }
 
     {
       const [deposit] = await individualClaims.getAssessmentDepositAndReward(
-        coverAmount.div(2),
-        coverPeriod,
+        segment.amount.div(2),
+        segment.period,
         ASSET.ETH,
       );
       await individualClaims
         .connect(coverOwner)
-        ['submitClaim(uint32,uint16,uint96,string)'](2, 2, coverAmount.div(2), '', {
+        ['submitClaim(uint32,uint16,uint96,string)'](2, 2, segment.amount.div(2), '', {
           value: deposit,
           gasPrice: 0,
         });
@@ -405,7 +383,7 @@ describe('redeemClaimPayout', function () {
       const { coverId, amount } = await cover.performStakeBurnCalledWith();
 
       expect(coverId).to.be.equal(2);
-      expect(amount).to.be.equal(coverAmount.div(2));
+      expect(amount).to.be.equal(segment.amount.div(2));
     }
   });
 });

--- a/test/unit/IndividualClaims/submitClaim.js
+++ b/test/unit/IndividualClaims/submitClaim.js
@@ -12,7 +12,7 @@ const setTime = async timestamp => {
   await mineNextBlock();
 };
 
-describe.only('submitClaim', function () {
+describe('submitClaim', function () {
   it('reverts if the submission deposit is not sent', async function () {
     const { individualClaims, cover } = this.contracts;
     const [coverOwner] = this.accounts.members;
@@ -483,7 +483,7 @@ describe.only('submitClaim', function () {
         coverOwner.address,
         0, // productId
         ASSET.ETH,
-        [[parseEther('100'), timestamp + 1, daysToSeconds(30), 0, false, 0]],
+        [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
       );
     }
     const secondCoverId = 1;

--- a/test/unit/IndividualClaims/submitClaim.js
+++ b/test/unit/IndividualClaims/submitClaim.js
@@ -1,7 +1,7 @@
 const { ethers } = require('hardhat');
 const { assert, expect } = require('chai');
 
-const { submitClaim, ASSET } = require('./helpers');
+const { submitClaim, ASSET, getCoverSegment } = require('./helpers');
 const { mineNextBlock, setNextBlockTime } = require('../../utils/evm');
 
 const { parseEther } = ethers.utils;
@@ -16,17 +16,16 @@ describe('submitClaim', function () {
   it('reverts if the submission deposit is not sent', async function () {
     const { individualClaims, cover } = this.contracts;
     const [coverOwner] = this.accounts.members;
-    const coverAmount = parseEther('100');
-    const { timestamp } = await ethers.provider.getBlock('latest');
+    const segment = await getCoverSegment();
     await cover.createMockCover(
       coverOwner.address,
       0, // productId
       ASSET.ETH,
-      [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
+      [segment],
     );
     const coverId = 0;
     await expect(
-      individualClaims.connect(coverOwner).submitClaim(coverId, 0, coverAmount, '', {
+      individualClaims.connect(coverOwner).submitClaim(coverId, 0, segment.amount, '', {
         value: ethers.constants.Zero,
       }),
     ).to.be.revertedWith('Assessment deposit is insufficient');
@@ -35,12 +34,12 @@ describe('submitClaim', function () {
   it('reverts if a payout on the same cover can be redeemed ', async function () {
     const { cover, assessment } = this.contracts;
     const [coverOwner] = this.accounts.members;
-    const { timestamp } = await ethers.provider.getBlock('latest');
+    const segment = await getCoverSegment();
     await cover.createMockCover(
       coverOwner.address,
       0, // productId
       ASSET.ETH,
-      [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
+      [segment],
     );
     await submitClaim(this)({ coverId: 0, sender: coverOwner });
     await assessment.castVote(0, true, parseEther('1'));
@@ -55,12 +54,12 @@ describe('submitClaim', function () {
   it('reverts if a claim on the same cover is already being assessed', async function () {
     const { cover, assessment } = this.contracts;
     const [coverOwner] = this.accounts.members;
-    const { timestamp } = await ethers.provider.getBlock('latest');
+    const segment = await getCoverSegment();
     await cover.createMockCover(
       coverOwner.address,
       0, // productId
       ASSET.ETH,
-      [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
+      [segment],
     );
     await submitClaim(this)({ coverId: 0, sender: coverOwner });
     await expect(submitClaim(this)({ coverId: 0, sender: coverOwner })).to.be.revertedWith(
@@ -77,25 +76,24 @@ describe('submitClaim', function () {
   it('reverts if covered product uses a claimMethod other than individual claims', async function () {
     const { cover } = this.contracts;
     const [coverOwner] = this.accounts.members;
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        coverOwner.address,
-        2, // productId of type yield token cover
-        ASSET.ETH,
-        [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
-      );
-    }
+    const segment = await getCoverSegment();
+    await cover.createMockCover(
+      coverOwner.address,
+      2, // productId of type yield token cover
+      ASSET.ETH,
+      [segment],
+    );
     await expect(submitClaim(this)({ coverId: 0, sender: coverOwner })).to.be.revertedWith(
       'Invalid claim method for this product type',
     );
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
+      segment.start = timestamp + 1;
       await cover.createMockCover(
         coverOwner.address,
         1, // productId of type custodian cover
         ASSET.ETH,
-        [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
+        [segment],
       );
     }
     await expect(submitClaim(this)({ coverId: 1, sender: coverOwner })).not.to.be.revertedWith(
@@ -103,11 +101,12 @@ describe('submitClaim', function () {
     );
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
+      segment.start = timestamp + 1;
       await cover.createMockCover(
         coverOwner.address,
         0, // productId of type protocol cover
         ASSET.ETH,
-        [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
+        [segment],
       );
     }
     await expect(submitClaim(this)({ coverId: 2, sender: coverOwner })).not.to.be.revertedWith('Invalid redeem method');
@@ -116,15 +115,13 @@ describe('submitClaim', function () {
   it('allows claim submission if an accepted claim is not redeemed during the redemption period', async function () {
     const { individualClaims, cover, assessment } = this.contracts;
     const [coverOwner] = this.accounts.members;
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        coverOwner.address,
-        0, // productId
-        ASSET.ETH,
-        [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
-      );
-    }
+    const segment = await getCoverSegment();
+    await cover.createMockCover(
+      coverOwner.address,
+      0, // productId
+      ASSET.ETH,
+      [segment],
+    );
     await submitClaim(this)({ coverId: 0, sender: coverOwner });
     await assessment.castVote(0, true, parseEther('1'));
     const { poll } = await assessment.assessments(0);
@@ -137,23 +134,20 @@ describe('submitClaim', function () {
   it('reverts if the submission deposit is less than the expected amount', async function () {
     const { individualClaims, cover } = this.contracts;
     const [coverOwner] = this.accounts.members;
-    const coverPeriod = daysToSeconds(30);
-    const coverAmount = parseEther('100');
     const coverAsset = ASSET.ETH;
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        coverOwner.address,
-        0, // productId
-        ASSET.ETH,
-        [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
-      );
-    }
+    const segment = await getCoverSegment();
+
+    await cover.createMockCover(
+      coverOwner.address,
+      0, // productId
+      ASSET.ETH,
+      [segment],
+    );
     const coverId = 0;
 
-    const [deposit] = await individualClaims.getAssessmentDepositAndReward(coverAmount, coverPeriod, coverAsset);
+    const [deposit] = await individualClaims.getAssessmentDepositAndReward(segment.amount, segment.period, coverAsset);
     await expect(
-      individualClaims.connect(coverOwner).submitClaim(coverId, 0, coverAmount, '', {
+      individualClaims.connect(coverOwner).submitClaim(coverId, 0, segment.amount, '', {
         value: deposit.div('2'),
       }),
     ).to.be.revertedWith('Assessment deposit is insufficient');
@@ -162,39 +156,36 @@ describe('submitClaim', function () {
   it('refunds any excess ETH sent as a submission deposit', async function () {
     const { individualClaims, cover } = this.contracts;
     const [coverOwner] = this.accounts.members;
-    const coverPeriod = daysToSeconds(30);
-    const coverAmount = parseEther('100');
     const coverAsset = ASSET.ETH;
+    const segment = await getCoverSegment();
 
-    const [deposit] = await individualClaims.getAssessmentDepositAndReward(coverAmount, coverPeriod, coverAsset);
+    const [deposit] = await individualClaims.getAssessmentDepositAndReward(segment.amount, segment.period, coverAsset);
+
+    await cover.createMockCover(
+      coverOwner.address,
+      0, // productId
+      ASSET.ETH,
+      [segment],
+    );
+    const balanceBefore = await ethers.provider.getBalance(coverOwner.address);
+    await individualClaims.connect(coverOwner).submitClaim(0, 0, segment.amount, '', {
+      value: deposit.mul('2'),
+      gasPrice: 0,
+    });
+    const balanceAfter = await ethers.provider.getBalance(coverOwner.address);
+    expect(balanceAfter).to.be.equal(balanceBefore.sub(deposit));
 
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
+      segment.start = timestamp + 1;
       await cover.createMockCover(
         coverOwner.address,
         0, // productId
         ASSET.ETH,
-        [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
+        [segment],
       );
       const balanceBefore = await ethers.provider.getBalance(coverOwner.address);
-      await individualClaims.connect(coverOwner).submitClaim(0, 0, coverAmount, '', {
-        value: deposit.mul('2'),
-        gasPrice: 0,
-      });
-      const balanceAfter = await ethers.provider.getBalance(coverOwner.address);
-      expect(balanceAfter).to.be.equal(balanceBefore.sub(deposit));
-    }
-
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        coverOwner.address,
-        0, // productId
-        ASSET.ETH,
-        [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
-      );
-      const balanceBefore = await ethers.provider.getBalance(coverOwner.address);
-      await individualClaims.connect(coverOwner).submitClaim(1, 0, coverAmount, '', {
+      await individualClaims.connect(coverOwner).submitClaim(1, 0, segment.amount, '', {
         value: deposit.mul('3'),
         gasPrice: 0,
       });
@@ -204,14 +195,15 @@ describe('submitClaim', function () {
 
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
+      segment.start = timestamp + 1;
       await cover.createMockCover(
         coverOwner.address,
         0, // productId
         ASSET.ETH,
-        [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
+        [segment],
       );
       const balanceBefore = await ethers.provider.getBalance(coverOwner.address);
-      await individualClaims.connect(coverOwner).submitClaim(2, 0, coverAmount, '', {
+      await individualClaims.connect(coverOwner).submitClaim(2, 0, segment.amount, '', {
         value: deposit.mul('10'),
         gasPrice: 0,
       });
@@ -223,33 +215,33 @@ describe('submitClaim', function () {
   it('reverts if the requested amount exceeds cover segment amount', async function () {
     const { individualClaims, cover } = this.contracts;
     const [coverOwner] = this.accounts.members;
-    const coverPeriod = daysToSeconds(30);
-    const coverAmount = parseEther('100');
     const coverAsset = ASSET.ETH;
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        coverOwner.address,
-        0, // productId
-        ASSET.ETH,
-        [
-          [coverAmount, timestamp + 1, 0, 7, 0, false, 0],
-          [coverAmount.add('1'), timestamp + 1, coverPeriod, 7, 0, false, 0],
-        ],
-      );
-    }
+    const segment0 = await getCoverSegment();
+    const segment1 = await getCoverSegment();
+    segment1.amount += 1;
+
+    await cover.createMockCover(
+      coverOwner.address,
+      0, // productId
+      ASSET.ETH,
+      [segment0, segment1],
+    );
     const coverId = 0;
 
-    const [deposit] = await individualClaims.getAssessmentDepositAndReward(coverAmount, coverPeriod, coverAsset);
+    const [deposit] = await individualClaims.getAssessmentDepositAndReward(
+      segment0.amount,
+      segment0.period,
+      coverAsset,
+    );
 
     await expect(
-      individualClaims.connect(coverOwner).submitClaim(coverId, 0, coverAmount.add('1'), '', {
+      individualClaims.connect(coverOwner).submitClaim(coverId, 0, segment0.amount.add('1'), '', {
         value: deposit,
         gasPrice: 0,
       }),
     ).to.be.revertedWith('Covered amount exceeded');
     await expect(
-      individualClaims.connect(coverOwner).submitClaim(coverId, 1, coverAmount.add('1'), '', {
+      individualClaims.connect(coverOwner).submitClaim(coverId, 1, segment0.amount.add('1'), '', {
         value: deposit,
         gasPrice: 0,
       }),
@@ -259,30 +251,32 @@ describe('submitClaim', function () {
   it('reverts if the cover segment starts in the future', async function () {
     const { individualClaims, cover } = this.contracts;
     const [coverOwner] = this.accounts.members;
-    const coverPeriod = daysToSeconds(30);
-    const coverAmount = parseEther('100');
     const coverAsset = ASSET.ETH;
-    const { timestamp } = await ethers.provider.getBlock('latest');
+    const segment0 = await getCoverSegment();
+    const segment1 = await getCoverSegment();
+    segment1.start += segment1.period;
+
     await cover.createMockCover(
       coverOwner.address,
       0, // productId
       ASSET.ETH,
-      [
-        [coverAmount, timestamp, coverPeriod, 7, 0, false, 0],
-        [coverAmount, timestamp + coverPeriod, coverPeriod, 7, 0, false, 0],
-      ],
+      [segment0, segment1],
     );
     const coverId = 0;
 
-    const [deposit] = await individualClaims.getAssessmentDepositAndReward(coverAmount, coverPeriod, coverAsset);
+    const [deposit] = await individualClaims.getAssessmentDepositAndReward(
+      segment0.amount,
+      segment0.period,
+      coverAsset,
+    );
 
     await expect(
-      individualClaims.connect(coverOwner).submitClaim(coverId, 1, coverAmount, '', {
+      individualClaims.connect(coverOwner).submitClaim(coverId, 1, segment0.amount, '', {
         value: deposit,
       }),
     ).to.be.revertedWith('Cover starts in the future');
     await expect(
-      individualClaims.connect(coverOwner).submitClaim(coverId, 0, coverAmount, '', {
+      individualClaims.connect(coverOwner).submitClaim(coverId, 0, segment0.amount, '', {
         value: deposit,
       }),
     ).not.to.be.revertedWith('Cover starts in the future');
@@ -291,38 +285,39 @@ describe('submitClaim', function () {
   it('reverts if the cover segment is outside the grace period', async function () {
     const { individualClaims, cover } = this.contracts;
     const [coverOwner] = this.accounts.members;
-    const coverPeriod = daysToSeconds(30);
-    const coverAmount = parseEther('100');
     const coverAsset = ASSET.ETH;
     const { gracePeriodInDays } = await cover.productTypes(0);
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        coverOwner.address,
-        0, // productId
-        coverAsset,
-        [
-          [coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0],
-          [coverAmount, timestamp + coverPeriod + 1, coverPeriod, 7, 0, false, 0],
-        ],
-      );
-    }
+    const segment0 = await getCoverSegment();
+    segment0.gracePeriodInDays = gracePeriodInDays;
+    const segment1 = { ...segment0 };
+    segment1.start += segment1.period;
+
+    await cover.createMockCover(
+      coverOwner.address,
+      0, // productId
+      coverAsset,
+      [segment0, segment1],
+    );
 
     const latestBlock = await ethers.provider.getBlock('latest');
     const currentTime = latestBlock.timestamp;
-    await setTime(currentTime + coverPeriod + daysToSeconds(gracePeriodInDays) + 1);
+    await setTime(currentTime + segment0.period + daysToSeconds(gracePeriodInDays) + 1);
     const coverId = 0;
 
-    const [deposit] = await individualClaims.getAssessmentDepositAndReward(coverAmount, coverPeriod, coverAsset);
+    const [deposit] = await individualClaims.getAssessmentDepositAndReward(
+      segment0.amount,
+      segment0.period,
+      coverAsset,
+    );
 
     await expect(
-      individualClaims.connect(coverOwner).submitClaim(coverId, 0, coverAmount, '', {
+      individualClaims.connect(coverOwner).submitClaim(coverId, 0, segment0.amount, '', {
         value: deposit,
       }),
     ).to.be.revertedWith('Cover is outside the grace period');
 
     await expect(
-      individualClaims.connect(coverOwner).submitClaim(coverId, 1, coverAmount, '', {
+      individualClaims.connect(coverOwner).submitClaim(coverId, 1, segment0.amount, '', {
         value: deposit,
       }),
     ).not.to.be.revertedWith('Cover is outside the grace period');
@@ -332,42 +327,42 @@ describe('submitClaim', function () {
     const { individualClaims, cover } = this.contracts;
     const [coverOwner] = this.accounts.members;
     const [boardMember] = this.accounts.advisoryBoardMembers;
-
-    const coverPeriod = daysToSeconds(30);
-    const coverAmount = parseEther('100');
     const coverAsset = ASSET.ETH;
     const { gracePeriodInDays } = await cover.productTypes(0);
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        coverOwner.address,
-        0, // productId
-        coverAsset,
-        [
-          [coverAmount, timestamp + 1, coverPeriod, gracePeriodInDays, 0, false, 0],
-          [coverAmount, timestamp + coverPeriod, coverPeriod, gracePeriodInDays + 1, 0, false, 0],
-        ],
-      );
-    }
+    const segment0 = await getCoverSegment();
+    const segment1 = await getCoverSegment();
+    segment0.gracePeriodInDays = gracePeriodInDays;
+    segment1.gracePeriodInDays = gracePeriodInDays + 1;
+    segment1.start += segment1.period;
+    await cover.createMockCover(
+      coverOwner.address,
+      0, // productId
+      coverAsset,
+      [segment0, segment1],
+    );
 
     const longerGracePeriod = gracePeriodInDays * 100;
     await cover.connect(boardMember).editProductTypes([0], [longerGracePeriod], ['ipfs hash']);
 
     const latestBlock = await ethers.provider.getBlock('latest');
     const currentTime = latestBlock.timestamp;
-    await setTime(currentTime + coverPeriod + daysToSeconds(gracePeriodInDays) + 1);
+    await setTime(currentTime + segment0.period + daysToSeconds(gracePeriodInDays) + 1);
     const coverId = 0;
 
-    const [deposit] = await individualClaims.getAssessmentDepositAndReward(coverAmount, coverPeriod, coverAsset);
+    const [deposit] = await individualClaims.getAssessmentDepositAndReward(
+      segment0.amount,
+      segment0.period,
+      coverAsset,
+    );
 
     await expect(
-      individualClaims.connect(coverOwner).submitClaim(coverId, 0, coverAmount, '', {
+      individualClaims.connect(coverOwner).submitClaim(coverId, 0, segment0.amount, '', {
         value: deposit,
       }),
     ).to.be.revertedWith('Cover is outside the grace period');
 
     await expect(
-      individualClaims.connect(coverOwner).submitClaim(coverId, 1, coverAmount, '', {
+      individualClaims.connect(coverOwner).submitClaim(coverId, 1, segment0.amount, '', {
         value: deposit,
       }),
     ).not.to.be.revertedWith('Cover is outside the grace period');
@@ -376,28 +371,24 @@ describe('submitClaim', function () {
   it('calls startAssessment and stores the returned assessmentId in the claim', async function () {
     const { assessment, individualClaims, cover } = this.contracts;
     const [coverOwner] = this.accounts.members;
-    const coverPeriod = daysToSeconds(30);
-    const coverAmount = parseEther('100');
     const coverAsset = ASSET.ETH;
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        coverOwner.address,
-        0, // productId
-        coverAsset,
-        [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
-      );
-    }
+    const segment = await getCoverSegment();
+    await cover.createMockCover(
+      coverOwner.address,
+      0, // productId
+      coverAsset,
+      [segment],
+    );
 
     const coverId = 0;
 
     const [expectedDeposit, expectedTotalReward] = await individualClaims.getAssessmentDepositAndReward(
-      coverAmount,
-      coverPeriod,
+      segment.amount,
+      segment.period,
       coverAsset,
     );
 
-    await individualClaims.connect(coverOwner).submitClaim(coverId, 0, coverAmount, '', { value: expectedDeposit });
+    await individualClaims.connect(coverOwner).submitClaim(coverId, 0, segment.amount, '', { value: expectedDeposit });
 
     const expectedAssessmentId = 0;
     const { assessmentDepositInETH, totalRewardInNXM } = await assessment.assessments(expectedAssessmentId);
@@ -413,15 +404,14 @@ describe('submitClaim', function () {
     const { coverNFT, cover } = this.contracts;
     const [coverOwner] = this.accounts.members;
     const [nonMemberOwner] = this.accounts.nonMembers;
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        coverOwner.address,
-        0, // productId
-        ASSET.ETH,
-        [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
-      );
-    }
+    const segment = await getCoverSegment();
+
+    await cover.createMockCover(
+      coverOwner.address,
+      0, // productId
+      ASSET.ETH,
+      [segment],
+    );
     const coverId = 0;
     coverNFT.connect(coverOwner).transferFrom(coverOwner.address, nonMemberOwner.address, coverId);
     await expect(submitClaim(this)({ coverId, sender: nonMemberOwner })).to.be.reverted;
@@ -430,31 +420,30 @@ describe('submitClaim', function () {
   it('reverts if it is not called by cover owner or an approved address', async function () {
     const { cover, coverNFT } = this.contracts;
     const [coverOwner, otherMember] = this.accounts.members;
+    const segment = await getCoverSegment();
+
+    await cover.createMockCover(
+      coverOwner.address,
+      0, // productId
+      ASSET.ETH,
+      [segment],
+    );
+    const coverId = 0;
+    await expect(submitClaim(this)({ coverId, sender: otherMember })).to.be.revertedWith(
+      'Only the owner or approved addresses can submit a claim',
+    );
+    await expect(submitClaim(this)({ coverId, sender: coverOwner })).not.to.be.revertedWith(
+      'Only the owner or approved addresses can submit a claim',
+    );
 
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
+      segment.start = timestamp + 1;
       await cover.createMockCover(
         coverOwner.address,
         0, // productId
         ASSET.ETH,
-        [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
-      );
-      const coverId = 0;
-      await expect(submitClaim(this)({ coverId, sender: otherMember })).to.be.revertedWith(
-        'Only the owner or approved addresses can submit a claim',
-      );
-      await expect(submitClaim(this)({ coverId, sender: coverOwner })).not.to.be.revertedWith(
-        'Only the owner or approved addresses can submit a claim',
-      );
-    }
-
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        coverOwner.address,
-        0, // productId
-        ASSET.ETH,
-        [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
+        [segment],
       );
       const coverId = 1;
       await coverNFT.connect(coverOwner).approve(otherMember.address, coverId);
@@ -468,12 +457,13 @@ describe('submitClaim', function () {
     const { individualClaims, cover } = this.contracts;
     const ipfsMetadata = 'ipfsProofHashMock';
     const [coverOwner] = this.accounts.members;
-    const { timestamp } = await ethers.provider.getBlock('latest');
+    const segment = await getCoverSegment();
+
     await cover.createMockCover(
       coverOwner.address,
       0, // productId
       ASSET.ETH,
-      [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
+      [segment],
     );
     const coverId = 0;
     await expect(submitClaim(this)({ coverId, ipfsMetadata, sender: coverOwner }))
@@ -484,12 +474,12 @@ describe('submitClaim', function () {
   it("doesn't emit MetadataSubmitted event if ipfsMetadata is an empty string", async function () {
     const { individualClaims, cover } = this.contracts;
     const [coverOwner] = this.accounts.members;
-    const { timestamp } = await ethers.provider.getBlock('latest');
+    const segment = await getCoverSegment();
     await cover.createMockCover(
       coverOwner.address,
       0, // productId
       ASSET.ETH,
-      [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
+      [segment],
     );
     const coverId = 0;
     await expect(submitClaim(this)({ coverId, sender: coverOwner })).not.to.emit(individualClaims, 'MetadataSubmitted');
@@ -498,15 +488,12 @@ describe('submitClaim', function () {
   it('stores the claimId in lastClaimSubmissionOnCover', async function () {
     const { individualClaims, cover } = this.contracts;
     const [coverOwner] = this.accounts.members;
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        coverOwner.address,
-        0, // productId
-        ASSET.ETH,
-        [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
-      );
-    }
+    await cover.createMockCover(
+      coverOwner.address,
+      0, // productId
+      ASSET.ETH,
+      [await getCoverSegment()],
+    );
     const firstCoverId = 0;
 
     {
@@ -522,15 +509,12 @@ describe('submitClaim', function () {
       expect(claimId).to.be.equal(ethers.constants.Zero);
     }
 
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        coverOwner.address,
-        0, // productId
-        ASSET.ETH,
-        [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
-      );
-    }
+    await cover.createMockCover(
+      coverOwner.address,
+      0, // productId
+      ASSET.ETH,
+      [await getCoverSegment()],
+    );
     const secondCoverId = 1;
 
     {

--- a/test/unit/IndividualClaims/submitClaim.js
+++ b/test/unit/IndividualClaims/submitClaim.js
@@ -12,7 +12,7 @@ const setTime = async timestamp => {
   await mineNextBlock();
 };
 
-describe('submitClaim', function () {
+describe.only('submitClaim', function () {
   it('reverts if the submission deposit is not sent', async function () {
     const { individualClaims, cover } = this.contracts;
     const [coverOwner] = this.accounts.members;
@@ -22,7 +22,7 @@ describe('submitClaim', function () {
       coverOwner.address,
       0, // productId
       ASSET.ETH,
-      [[parseEther('100'), timestamp + 1, daysToSeconds(30), 0, false, 0]],
+      [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
     );
     const coverId = 0;
     await expect(
@@ -40,7 +40,7 @@ describe('submitClaim', function () {
       coverOwner.address,
       0, // productId
       ASSET.ETH,
-      [[parseEther('100'), timestamp + 1, daysToSeconds(30), 0, false, 0]],
+      [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
     );
     await submitClaim(this)({ coverId: 0, sender: coverOwner });
     await assessment.castVote(0, true, parseEther('1'));
@@ -60,7 +60,7 @@ describe('submitClaim', function () {
       coverOwner.address,
       0, // productId
       ASSET.ETH,
-      [[parseEther('100'), timestamp + 1, daysToSeconds(30), 0, false, 0]],
+      [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
     );
     await submitClaim(this)({ coverId: 0, sender: coverOwner });
     await expect(submitClaim(this)({ coverId: 0, sender: coverOwner })).to.be.revertedWith(
@@ -83,7 +83,7 @@ describe('submitClaim', function () {
         coverOwner.address,
         2, // productId of type yield token cover
         ASSET.ETH,
-        [[parseEther('100'), timestamp + 1, daysToSeconds(30), 0, false, 0]],
+        [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
       );
     }
     await expect(submitClaim(this)({ coverId: 0, sender: coverOwner })).to.be.revertedWith(
@@ -95,7 +95,7 @@ describe('submitClaim', function () {
         coverOwner.address,
         1, // productId of type custodian cover
         ASSET.ETH,
-        [[parseEther('100'), timestamp + 1, daysToSeconds(30), 0, false, 0]],
+        [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
       );
     }
     await expect(submitClaim(this)({ coverId: 1, sender: coverOwner })).not.to.be.revertedWith(
@@ -107,7 +107,7 @@ describe('submitClaim', function () {
         coverOwner.address,
         0, // productId of type protocol cover
         ASSET.ETH,
-        [[parseEther('100'), timestamp + 1, daysToSeconds(30), 0, false, 0]],
+        [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
       );
     }
     await expect(submitClaim(this)({ coverId: 2, sender: coverOwner })).not.to.be.revertedWith('Invalid redeem method');
@@ -122,7 +122,7 @@ describe('submitClaim', function () {
         coverOwner.address,
         0, // productId
         ASSET.ETH,
-        [[parseEther('100'), timestamp + 1, daysToSeconds(30), 0, false, 0]],
+        [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
       );
     }
     await submitClaim(this)({ coverId: 0, sender: coverOwner });
@@ -146,7 +146,7 @@ describe('submitClaim', function () {
         coverOwner.address,
         0, // productId
         ASSET.ETH,
-        [[coverAmount, timestamp + 1, coverPeriod, 0, false, 0]],
+        [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
       );
     }
     const coverId = 0;
@@ -174,7 +174,7 @@ describe('submitClaim', function () {
         coverOwner.address,
         0, // productId
         ASSET.ETH,
-        [[coverAmount, timestamp + 1, coverPeriod, 0, false, 0]],
+        [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
       );
       const balanceBefore = await ethers.provider.getBalance(coverOwner.address);
       await individualClaims.connect(coverOwner).submitClaim(0, 0, coverAmount, '', {
@@ -191,7 +191,7 @@ describe('submitClaim', function () {
         coverOwner.address,
         0, // productId
         ASSET.ETH,
-        [[coverAmount, timestamp + 1, coverPeriod, 0, false, 0]],
+        [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
       );
       const balanceBefore = await ethers.provider.getBalance(coverOwner.address);
       await individualClaims.connect(coverOwner).submitClaim(1, 0, coverAmount, '', {
@@ -208,7 +208,7 @@ describe('submitClaim', function () {
         coverOwner.address,
         0, // productId
         ASSET.ETH,
-        [[coverAmount, timestamp + 1, coverPeriod, 0, false, 0]],
+        [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
       );
       const balanceBefore = await ethers.provider.getBalance(coverOwner.address);
       await individualClaims.connect(coverOwner).submitClaim(2, 0, coverAmount, '', {
@@ -233,8 +233,8 @@ describe('submitClaim', function () {
         0, // productId
         ASSET.ETH,
         [
-          [coverAmount, timestamp + 1, 0, 0, false, 0],
-          [coverAmount.add('1'), timestamp + 1, coverPeriod, 0, false, 0],
+          [coverAmount, timestamp + 1, 0, 7, 0, false, 0],
+          [coverAmount.add('1'), timestamp + 1, coverPeriod, 7, 0, false, 0],
         ],
       );
     }
@@ -268,8 +268,8 @@ describe('submitClaim', function () {
       0, // productId
       ASSET.ETH,
       [
-        [coverAmount, timestamp, coverPeriod, 0, false, 0],
-        [coverAmount, timestamp + coverPeriod, coverPeriod, 0, false, 0],
+        [coverAmount, timestamp, coverPeriod, 7, 0, false, 0],
+        [coverAmount, timestamp + coverPeriod, coverPeriod, 7, 0, false, 0],
       ],
     );
     const coverId = 0;
@@ -302,8 +302,8 @@ describe('submitClaim', function () {
         0, // productId
         coverAsset,
         [
-          [coverAmount, timestamp + 1, coverPeriod, 0, false, 0],
-          [coverAmount, timestamp + coverPeriod + 1, coverPeriod, 0, false, 0],
+          [coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0],
+          [coverAmount, timestamp + coverPeriod + 1, coverPeriod, 7, 0, false, 0],
         ],
       );
     }
@@ -340,7 +340,7 @@ describe('submitClaim', function () {
         coverOwner.address,
         0, // productId
         coverAsset,
-        [[coverAmount, timestamp + 1, coverPeriod, 0, false, 0]],
+        [[coverAmount, timestamp + 1, coverPeriod, 7, 0, false, 0]],
       );
     }
 
@@ -374,7 +374,7 @@ describe('submitClaim', function () {
         coverOwner.address,
         0, // productId
         ASSET.ETH,
-        [[parseEther('100'), timestamp + 1, daysToSeconds(30), 0, false, 0]],
+        [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
       );
     }
     const coverId = 0;
@@ -392,7 +392,7 @@ describe('submitClaim', function () {
         coverOwner.address,
         0, // productId
         ASSET.ETH,
-        [[parseEther('100'), timestamp + 1, daysToSeconds(30), 0, false, 0]],
+        [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
       );
       const coverId = 0;
       await expect(submitClaim(this)({ coverId, sender: otherMember })).to.be.revertedWith(
@@ -409,7 +409,7 @@ describe('submitClaim', function () {
         coverOwner.address,
         0, // productId
         ASSET.ETH,
-        [[parseEther('100'), timestamp + 1, daysToSeconds(30), 0, false, 0]],
+        [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
       );
       const coverId = 1;
       await coverNFT.connect(coverOwner).approve(otherMember.address, coverId);
@@ -428,7 +428,7 @@ describe('submitClaim', function () {
       coverOwner.address,
       0, // productId
       ASSET.ETH,
-      [[parseEther('100'), timestamp + 1, daysToSeconds(30), 0, false, 0]],
+      [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
     );
     const coverId = 0;
     await expect(submitClaim(this)({ coverId, ipfsMetadata, sender: coverOwner }))
@@ -444,7 +444,7 @@ describe('submitClaim', function () {
       coverOwner.address,
       0, // productId
       ASSET.ETH,
-      [[parseEther('100'), timestamp + 1, daysToSeconds(30), 0, false, 0]],
+      [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
     );
     const coverId = 0;
     await expect(submitClaim(this)({ coverId, sender: coverOwner })).not.to.emit(individualClaims, 'MetadataSubmitted');
@@ -459,7 +459,7 @@ describe('submitClaim', function () {
         coverOwner.address,
         0, // productId
         ASSET.ETH,
-        [[parseEther('100'), timestamp + 1, daysToSeconds(30), 0, false, 0]],
+        [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
       );
     }
     const firstCoverId = 0;

--- a/test/unit/YieldTokenIncidents/redeemPayout.js
+++ b/test/unit/YieldTokenIncidents/redeemPayout.js
@@ -18,7 +18,7 @@ describe('redeemPayout', function () {
         coverOwner.address,
         2, // productId
         ASSET.ETH,
-        [[parseEther('10000'), timestamp + 1, segmentPeriod, 0, false, 0]],
+        [[parseEther('10000'), timestamp + 1, segmentPeriod, 7, 0, false, 0]],
       );
     }
     {
@@ -27,7 +27,7 @@ describe('redeemPayout', function () {
         coverOwner.address,
         2, // productId
         ASSET.ETH,
-        [[parseEther('10000'), timestamp + 1, segmentPeriod, 0, false, 0]],
+        [[parseEther('10000'), timestamp + 1, segmentPeriod, 7, 0, false, 0]],
       );
     }
     {
@@ -36,7 +36,7 @@ describe('redeemPayout', function () {
         coverOwner.address,
         2, // productId
         ASSET.ETH,
-        [[parseEther('10000'), timestamp + 1, segmentPeriod, 0, false, 0]],
+        [[parseEther('10000'), timestamp + 1, segmentPeriod, 7, 0, false, 0]],
       );
     }
 
@@ -91,7 +91,7 @@ describe('redeemPayout', function () {
         member1.address,
         2, // productId
         ASSET.ETH,
-        [[parseEther('10000'), timestamp + 1, daysToSeconds('30'), 0, false, 0]],
+        [[parseEther('10000'), timestamp + 1, daysToSeconds('30'), 7, 0, false, 0]],
       );
     }
 
@@ -140,7 +140,7 @@ describe('redeemPayout', function () {
         member1.address,
         2, // productId
         ASSET.ETH,
-        [[parseEther('10000'), timestamp + 1, daysToSeconds('30'), 0, false, 0]],
+        [[parseEther('10000'), timestamp + 1, daysToSeconds('30'), 7, 0, false, 0]],
       );
     }
 
@@ -190,7 +190,7 @@ describe('redeemPayout', function () {
         member1.address,
         2, // productId
         ASSET.ETH,
-        [[parseEther('10000'), timestamp + 1, daysToSeconds('30'), 0, false, 0]],
+        [[parseEther('10000'), timestamp + 1, daysToSeconds('30'), 7, 0, false, 0]],
       );
     }
 
@@ -227,7 +227,7 @@ describe('redeemPayout', function () {
         member1.address,
         2, // productId
         ASSET.ETH,
-        [[parseEther('100'), timestamp + 1, daysToSeconds('30'), 0, false, 0]],
+        [[parseEther('100'), timestamp + 1, daysToSeconds('30'), 7, 0, false, 0]],
       );
     }
 
@@ -273,8 +273,8 @@ describe('redeemPayout', function () {
         2, // productId
         ASSET.ETH,
         [
-          [parseEther('100'), timestamp + 1, daysToSeconds('30'), 0, false, 0],
-          [parseEther('100'), timestamp + 1 + daysToSeconds('30'), daysToSeconds('30'), 0, false, 0],
+          [parseEther('100'), timestamp + 1, daysToSeconds('30'), 7, 0, false, 0],
+          [parseEther('100'), timestamp + 1 + daysToSeconds('30'), daysToSeconds('30'), 7, 0, false, 0],
         ],
       );
     }
@@ -320,8 +320,8 @@ describe('redeemPayout', function () {
         2, // productId
         ASSET.ETH,
         [
-          [parseEther('100'), timestamp + 1, 1, 0, false, 0], // 1s segment
-          [parseEther('100'), timestamp + 2, daysToSeconds('30'), 0, false, 0], // 30d segment
+          [parseEther('100'), timestamp + 1, 1, 7, 0, false, 0], // 1s segment
+          [parseEther('100'), timestamp + 2, daysToSeconds('30'), 7, 0, false, 0], // 30d segment
         ],
       );
 
@@ -336,7 +336,7 @@ describe('redeemPayout', function () {
         member1.address,
         2, // productId
         ASSET.ETH,
-        [[parseEther('100'), timestamp + 1, daysToSeconds('30'), 0, false, 0]],
+        [[parseEther('100'), timestamp + 1, daysToSeconds('30'), 7, 0, false, 0]],
       );
     }
 
@@ -373,8 +373,8 @@ describe('redeemPayout', function () {
         2, // productId
         ASSET.ETH,
         [
-          [parseEther('100'), timestamp + 1, segmentPeriod, 0, false, 0],
-          [parseEther('100'), timestamp + 1, segmentPeriod + daysToSeconds(gracePeriodInDays), 0, false, 0],
+          [parseEther('100'), timestamp + 1, segmentPeriod, 7, 0, false, 0],
+          [parseEther('100'), timestamp + 1, segmentPeriod + daysToSeconds(gracePeriodInDays), 7, 0, false, 0],
         ],
       );
     }
@@ -414,7 +414,7 @@ describe('redeemPayout', function () {
         member1.address,
         0, // productId
         ASSET.ETH,
-        [[parseEther('100'), timestamp + 1, segmentPeriod, 0, false, 0]],
+        [[parseEther('100'), timestamp + 1, segmentPeriod, 7, 0, false, 0]],
       );
     }
 
@@ -424,7 +424,7 @@ describe('redeemPayout', function () {
         member1.address,
         1, // productId
         ASSET.ETH,
-        [[parseEther('100'), timestamp + 1, segmentPeriod, 0, false, 0]],
+        [[parseEther('100'), timestamp + 1, segmentPeriod, 7, 0, false, 0]],
       );
     }
 
@@ -434,7 +434,7 @@ describe('redeemPayout', function () {
         member1.address,
         validProductId, // productId
         ASSET.ETH,
-        [[parseEther('100'), timestamp + 1, segmentPeriod, 0, false, 0]],
+        [[parseEther('100'), timestamp + 1, segmentPeriod, 7, 0, false, 0]],
       );
     }
 
@@ -444,7 +444,7 @@ describe('redeemPayout', function () {
         member1.address,
         3, // productId
         ASSET.ETH,
-        [[parseEther('100'), timestamp + 1, segmentPeriod, 0, false, 0]],
+        [[parseEther('100'), timestamp + 1, segmentPeriod, 7, 0, false, 0]],
       );
     }
 
@@ -493,7 +493,7 @@ describe('redeemPayout', function () {
         member1.address,
         2, // productId
         ASSET.ETH,
-        [[parseEther('10000'), timestamp + 1, segmentPeriod, 0, false, 0]],
+        [[parseEther('10000'), timestamp + 1, segmentPeriod, 7, 0, false, 0]],
       );
     }
 
@@ -556,7 +556,7 @@ describe('redeemPayout', function () {
         member1.address,
         4, // productId
         ASSET.DAI,
-        [[parseEther('10000'), timestamp + 1, segmentPeriod, 0, false, 0]],
+        [[parseEther('10000'), timestamp + 1, segmentPeriod, 7, 0, false, 0]],
       );
     }
 
@@ -632,21 +632,21 @@ describe('redeemPayout', function () {
       coverOwner1.address,
       2, // productId using ybEth
       ASSET.ETH,
-      [[parseEther('100'), timestamp + 1, daysToSeconds(30), 0, false, 0]],
+      [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
     );
 
     await cover.createMockCover(
       coverOwner1.address,
       2, // productId using ybEth
       ASSET.ETH,
-      [[parseEther('100'), timestamp + 1, daysToSeconds(30), 0, false, 0]],
+      [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
     );
 
     await cover.createMockCover(
       coverOwner2.address,
       3, // productId using ybDai
       ASSET.DAI,
-      [[parseEther('100'), timestamp + 1, daysToSeconds(30), 0, false, 0]],
+      [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
     );
 
     await yieldTokenIncidents

--- a/test/unit/YieldTokenIncidents/redeemPayout.js
+++ b/test/unit/YieldTokenIncidents/redeemPayout.js
@@ -5,46 +5,55 @@ const { setTime, ASSET, signPermit } = require('./helpers');
 const { parseEther, arrayify, hexZeroPad, hexValue } = ethers.utils;
 const daysToSeconds = days => days * 24 * 60 * 60;
 
+const coverSegmentFixture = {
+  amount: parseEther('100'),
+  start: 0,
+  period: daysToSeconds(30),
+  gracePeriodInDays: 7,
+  priceRatio: 0,
+  expired: false,
+  globalRewardsRatio: 0,
+};
+
 describe('redeemPayout', function () {
+  const getCoverSegment = async () => {
+    const { timestamp } = await ethers.provider.getBlock('latest');
+    const cover = { ...coverSegmentFixture };
+    cover.start = timestamp + 1;
+    return cover;
+  };
+
   it("reverts if the address is not the cover owner's or approved", async function () {
     const { yieldTokenIncidents, assessment, cover, coverNFT } = this.contracts;
     const [coverOwner, nonCoverOwner] = this.accounts.members;
     const [advisoryBoard] = this.accounts.advisoryBoardMembers;
-    const segmentPeriod = daysToSeconds(30);
+    const segment = await getCoverSegment();
+    segment.amount = parseEther('10000');
 
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        coverOwner.address,
-        2, // productId
-        ASSET.ETH,
-        [[parseEther('10000'), timestamp + 1, segmentPeriod, 7, 0, false, 0]],
-      );
-    }
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        coverOwner.address,
-        2, // productId
-        ASSET.ETH,
-        [[parseEther('10000'), timestamp + 1, segmentPeriod, 7, 0, false, 0]],
-      );
-    }
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        coverOwner.address,
-        2, // productId
-        ASSET.ETH,
-        [[parseEther('10000'), timestamp + 1, segmentPeriod, 7, 0, false, 0]],
-      );
-    }
+    await cover.createMockCover(
+      coverOwner.address,
+      2, // productId
+      ASSET.ETH,
+      [segment],
+    );
+    await cover.createMockCover(
+      coverOwner.address,
+      2, // productId
+      ASSET.ETH,
+      [segment],
+    );
+    await cover.createMockCover(
+      coverOwner.address,
+      2, // productId
+      ASSET.ETH,
+      [segment],
+    );
 
     {
       const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
       await yieldTokenIncidents
         .connect(advisoryBoard)
-        .submitIncident(2, parseEther('1.1'), currentTime + segmentPeriod / 2, parseEther('100'), '');
+        .submitIncident(2, parseEther('1.1'), currentTime + segment.period / 2, parseEther('100'), '');
     }
 
     await assessment.connect(coverOwner).castVote(0, true, parseEther('100'));
@@ -84,16 +93,15 @@ describe('redeemPayout', function () {
     const { yieldTokenIncidents, assessment, cover } = this.contracts;
     const [member1, member2] = this.accounts.members;
     const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const segment = await getCoverSegment();
+    segment.amount = parseEther('10000');
 
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        member1.address,
-        2, // productId
-        ASSET.ETH,
-        [[parseEther('10000'), timestamp + 1, daysToSeconds('30'), 7, 0, false, 0]],
-      );
-    }
+    await cover.createMockCover(
+      member1.address,
+      2, // productId
+      ASSET.ETH,
+      [segment],
+    );
 
     {
       const productId = 2;
@@ -133,17 +141,15 @@ describe('redeemPayout', function () {
     const { yieldTokenIncidents, assessment, cover } = this.contracts;
     const [member1] = this.accounts.members;
     const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const segment = await getCoverSegment();
+    segment.amount = parseEther('10000');
 
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        member1.address,
-        2, // productId
-        ASSET.ETH,
-        [[parseEther('10000'), timestamp + 1, daysToSeconds('30'), 7, 0, false, 0]],
-      );
-    }
-
+    await cover.createMockCover(
+      member1.address,
+      2, // productId
+      ASSET.ETH,
+      [segment],
+    );
     {
       const productId = 2;
       const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
@@ -183,16 +189,15 @@ describe('redeemPayout', function () {
     const [advisoryBoard] = this.accounts.advisoryBoardMembers;
     const { payoutRedemptionPeriodInDays } = await yieldTokenIncidents.config();
     const { payoutCooldownInDays } = await assessment.config();
+    const segment = await getCoverSegment();
+    segment.amount = parseEther('10000');
 
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        member1.address,
-        2, // productId
-        ASSET.ETH,
-        [[parseEther('10000'), timestamp + 1, daysToSeconds('30'), 7, 0, false, 0]],
-      );
-    }
+    await cover.createMockCover(
+      member1.address,
+      2, // productId
+      ASSET.ETH,
+      [segment],
+    );
 
     {
       const productId = 2;
@@ -220,16 +225,13 @@ describe('redeemPayout', function () {
     const [advisoryBoard] = this.accounts.advisoryBoardMembers;
     const { payoutCooldownInDays } = await assessment.config();
     const productId = 2;
-
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        member1.address,
-        2, // productId
-        ASSET.ETH,
-        [[parseEther('100'), timestamp + 1, daysToSeconds('30'), 7, 0, false, 0]],
-      );
-    }
+    const segment = await getCoverSegment();
+    await cover.createMockCover(
+      member1.address,
+      2, // productId
+      ASSET.ETH,
+      [segment],
+    );
 
     {
       const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
@@ -266,18 +268,16 @@ describe('redeemPayout', function () {
     const { payoutCooldownInDays } = await assessment.config();
     const productId = 2;
 
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        member1.address,
-        2, // productId
-        ASSET.ETH,
-        [
-          [parseEther('100'), timestamp + 1, daysToSeconds('30'), 7, 0, false, 0],
-          [parseEther('100'), timestamp + 1 + daysToSeconds('30'), daysToSeconds('30'), 7, 0, false, 0],
-        ],
-      );
-    }
+    const segment0 = await getCoverSegment();
+    const segment1 = await getCoverSegment();
+    segment1.start += daysToSeconds('30');
+
+    await cover.createMockCover(
+      member1.address,
+      2, // productId
+      ASSET.ETH,
+      [segment0, segment1],
+    );
 
     {
       const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
@@ -313,22 +313,22 @@ describe('redeemPayout', function () {
     const { payoutCooldownInDays } = await assessment.config();
     const productId = 2;
 
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        member1.address,
-        2, // productId
-        ASSET.ETH,
-        [
-          [parseEther('100'), timestamp + 1, 1, 7, 0, false, 0], // 1s segment
-          [parseEther('100'), timestamp + 2, daysToSeconds('30'), 7, 0, false, 0], // 30d segment
-        ],
-      );
+    const { timestamp } = await ethers.provider.getBlock('latest');
+    const segment0 = await getCoverSegment();
+    const segment1 = await getCoverSegment();
+    segment0.period = 1;
+    segment1.start += 1;
 
-      await yieldTokenIncidents
-        .connect(advisoryBoard)
-        .submitIncident(productId, parseEther('1.1'), timestamp + 2, parseEther('100'), '');
-    }
+    await cover.createMockCover(
+      member1.address,
+      2, // productId
+      ASSET.ETH,
+      [segment0, segment1],
+    );
+
+    await yieldTokenIncidents
+      .connect(advisoryBoard)
+      .submitIncident(productId, parseEther('1.1'), timestamp + 2, parseEther('100'), '');
 
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
@@ -364,26 +364,23 @@ describe('redeemPayout', function () {
     const [advisoryBoard] = this.accounts.advisoryBoardMembers;
     const { gracePeriodInDays } = await cover.productTypes(2);
     const productId = 2;
-    const segmentPeriod = daysToSeconds(30);
+    const segment0 = await getCoverSegment();
+    segment0.gracePeriodInDays = gracePeriodInDays;
+    const segment1 = { ...segment0 };
+    segment1.period += daysToSeconds(gracePeriodInDays);
 
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        member1.address,
-        2, // productId
-        ASSET.ETH,
-        [
-          [parseEther('100'), timestamp + 1, segmentPeriod, 7, 0, false, 0],
-          [parseEther('100'), timestamp + 1, segmentPeriod + daysToSeconds(gracePeriodInDays), 7, 0, false, 0],
-        ],
-      );
-    }
+    await cover.createMockCover(
+      member1.address,
+      2, // productId
+      ASSET.ETH,
+      [segment0, segment1],
+    );
 
     const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
-    await setTime(currentTime + segmentPeriod + daysToSeconds(gracePeriodInDays));
+    await setTime(currentTime + segment0.period + daysToSeconds(gracePeriodInDays));
     await yieldTokenIncidents
       .connect(advisoryBoard)
-      .submitIncident(productId, parseEther('1.1'), currentTime + segmentPeriod - 1, parseEther('100'), '');
+      .submitIncident(productId, parseEther('1.1'), currentTime + segment0.period - 1, parseEther('100'), '');
 
     await assessment.connect(member1).castVote(0, true, parseEther('100'));
 
@@ -401,58 +398,93 @@ describe('redeemPayout', function () {
     ).not.to.be.revertedWith('Grace period has expired');
   });
 
+  it('should use coverSegment grace period and not product level grace period', async function () {
+    const { yieldTokenIncidents, assessment, cover } = this.contracts;
+    const [member1] = this.accounts.members;
+    const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const { gracePeriodInDays } = await cover.productTypes(2);
+    const productId = 2;
+    const segment0 = await getCoverSegment();
+    const segment1 = await getCoverSegment();
+    segment0.gracePeriodInDays = gracePeriodInDays;
+    segment1.gracePeriodInDays = gracePeriodInDays * 1000;
+
+    await cover.createMockCover(
+      member1.address,
+      2, // productId
+      ASSET.ETH,
+      [segment0, segment1],
+    );
+
+    const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
+    await setTime(currentTime + segment0.period + daysToSeconds(gracePeriodInDays));
+
+    // Change product grace period
+    const newGracePeriod = gracePeriodInDays * 1000;
+    await cover.connect(advisoryBoard).editProductTypes([2], [newGracePeriod], ['ipfs hash']);
+    {
+      const { gracePeriodInDays } = await cover.productTypes(2);
+      expect(gracePeriodInDays).to.equal(newGracePeriod);
+      expect(currentTime + segment0.period).to.be.lessThan(daysToSeconds(gracePeriodInDays));
+    }
+
+    await yieldTokenIncidents
+      .connect(advisoryBoard)
+      .submitIncident(productId, parseEther('1.1'), currentTime + segment0.period - 1, parseEther('100'), '');
+
+    await assessment.connect(member1).castVote(0, true, parseEther('100'));
+
+    {
+      const { payoutCooldownInDays } = await assessment.config();
+      const { end } = await assessment.getPoll(0);
+      await setTime(end + daysToSeconds(payoutCooldownInDays));
+    }
+
+    await expect(
+      yieldTokenIncidents.connect(member1).redeemPayout(0, 0, 0, parseEther('100'), member1.address, []),
+    ).to.be.revertedWith('Grace period has expired');
+    await expect(
+      yieldTokenIncidents.connect(member1).redeemPayout(0, 1, 0, parseEther('100'), member1.address, []),
+    ).to.not.be.revertedWith('Grace period has expired');
+  });
+
   it("reverts if the cover's productId mismatches the incident's productId", async function () {
     const { yieldTokenIncidents, assessment, cover } = this.contracts;
     const [member1] = this.accounts.members;
     const [advisoryBoard] = this.accounts.advisoryBoardMembers;
-    const segmentPeriod = daysToSeconds(30);
     const validProductId = 2;
+    const segment = await getCoverSegment();
+    await cover.createMockCover(
+      member1.address,
+      0, // productId
+      ASSET.ETH,
+      [segment],
+    );
 
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        member1.address,
-        0, // productId
-        ASSET.ETH,
-        [[parseEther('100'), timestamp + 1, segmentPeriod, 7, 0, false, 0]],
-      );
-    }
-
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        member1.address,
-        1, // productId
-        ASSET.ETH,
-        [[parseEther('100'), timestamp + 1, segmentPeriod, 7, 0, false, 0]],
-      );
-    }
-
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        member1.address,
-        validProductId, // productId
-        ASSET.ETH,
-        [[parseEther('100'), timestamp + 1, segmentPeriod, 7, 0, false, 0]],
-      );
-    }
-
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        member1.address,
-        3, // productId
-        ASSET.ETH,
-        [[parseEther('100'), timestamp + 1, segmentPeriod, 7, 0, false, 0]],
-      );
-    }
+    await cover.createMockCover(
+      member1.address,
+      1, // productId
+      ASSET.ETH,
+      [segment],
+    );
+    await cover.createMockCover(
+      member1.address,
+      validProductId, // productId
+      ASSET.ETH,
+      [segment],
+    );
+    await cover.createMockCover(
+      member1.address,
+      3, // productId
+      ASSET.ETH,
+      [segment],
+    );
 
     {
       const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
       await yieldTokenIncidents
         .connect(advisoryBoard)
-        .submitIncident(validProductId, parseEther('1.1'), currentTime + segmentPeriod / 2, parseEther('100'), '');
+        .submitIncident(validProductId, parseEther('1.1'), currentTime + segment.period / 2, parseEther('100'), '');
     }
 
     await assessment.connect(member1).castVote(0, true, parseEther('100'));
@@ -485,23 +517,21 @@ describe('redeemPayout', function () {
     const [member1] = this.accounts.members;
     const [nonMember1, nonMember2] = this.accounts.nonMembers;
     const [advisoryBoard] = this.accounts.advisoryBoardMembers;
-    const segmentPeriod = daysToSeconds(30);
+    const segment = await getCoverSegment();
+    segment.amount = parseEther('10000');
 
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        member1.address,
-        2, // productId
-        ASSET.ETH,
-        [[parseEther('10000'), timestamp + 1, segmentPeriod, 7, 0, false, 0]],
-      );
-    }
+    await cover.createMockCover(
+      member1.address,
+      2, // productId
+      ASSET.ETH,
+      [segment],
+    );
 
     {
       const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
       await yieldTokenIncidents
         .connect(advisoryBoard)
-        .submitIncident(2, parseEther('1.1'), currentTime + segmentPeriod / 2, parseEther('100'), '');
+        .submitIncident(2, parseEther('1.1'), currentTime + segment.period / 2, parseEther('100'), '');
     }
 
     await assessment.connect(member1).castVote(0, true, parseEther('100'));
@@ -548,23 +578,21 @@ describe('redeemPayout', function () {
     const [member1] = this.accounts.members;
     const [nonMember] = this.accounts.nonMembers;
     const [advisoryBoard] = this.accounts.advisoryBoardMembers;
-    const segmentPeriod = daysToSeconds(30);
+    const segment = await getCoverSegment();
+    segment.amount = parseEther('10000');
 
-    {
-      const { timestamp } = await ethers.provider.getBlock('latest');
-      await cover.createMockCover(
-        member1.address,
-        4, // productId
-        ASSET.DAI,
-        [[parseEther('10000'), timestamp + 1, segmentPeriod, 7, 0, false, 0]],
-      );
-    }
+    await cover.createMockCover(
+      member1.address,
+      4, // productId
+      ASSET.DAI,
+      [segment],
+    );
 
     {
       const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
       await yieldTokenIncidents
         .connect(advisoryBoard)
-        .submitIncident(4, parseEther('1.1'), currentTime + segmentPeriod / 2, parseEther('100'), '');
+        .submitIncident(4, parseEther('1.1'), currentTime + segment.period / 2, parseEther('100'), '');
     }
 
     await assessment.connect(member1).castVote(0, true, parseEther('100'));
@@ -628,25 +656,26 @@ describe('redeemPayout', function () {
     const [coverOwner1, coverOwner2] = this.accounts.members;
     const [advisoryBoard] = this.accounts.advisoryBoardMembers;
     const { timestamp } = await ethers.provider.getBlock('latest');
+    const segment = await getCoverSegment();
     await cover.createMockCover(
       coverOwner1.address,
       2, // productId using ybEth
       ASSET.ETH,
-      [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
+      [segment],
     );
 
     await cover.createMockCover(
       coverOwner1.address,
       2, // productId using ybEth
       ASSET.ETH,
-      [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
+      [segment],
     );
 
     await cover.createMockCover(
       coverOwner2.address,
       3, // productId using ybDai
       ASSET.DAI,
-      [[parseEther('100'), timestamp + 1, daysToSeconds(30), 7, 0, false, 0]],
+      [segment],
     );
 
     await yieldTokenIncidents


### PR DESCRIPTION
## Context

Resolves #287 


## Changes proposed in this pull request

This PR adds the ability to edit gracePeriodInDays. To do this `gracePeriodInDays` was added to the CoverSegments struct. Deallocation and claims should now use the grace period from the cover segment.  Allocations should use the product level grace period.


## Test plan



## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
