### PR TITLE
Chore: Rename productAddress in ytcUnderlyingAsset in Product struct

### DIFF
--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -114,7 +114,6 @@ struct ProductUpdate {
 struct ProductType {
   uint8 claimMethod;
   uint16 gracePeriodInDays;
-
 }
 
 interface ICover {

--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -90,7 +90,7 @@ struct IncreaseAmountParams {
 
 struct Product {
   uint16 productType;
-  address productAddress;
+  address ytcUnderlyingAsset;
   /*
     cover assets bitmap. each bit in the base-2 representation represents whether the asset with the index
     of that bit is enabled as a cover asset for this product.
@@ -114,6 +114,7 @@ struct ProductUpdate {
 struct ProductType {
   uint8 claimMethod;
   uint16 gracePeriodInDays;
+
 }
 
 interface ICover {

--- a/contracts/modules/assessment/YieldTokenIncidents.sol
+++ b/contracts/modules/assessment/YieldTokenIncidents.sol
@@ -287,12 +287,12 @@ contract YieldTokenIncidents is IYieldTokenIncidents, MasterAwareV2 {
       ) = abi.decode(optionalParams, (address, address, uint256, uint256, uint8, bytes32, bytes32));
 
       if (spender != address(0)) {
-        IERC20Permit(product.productAddress).permit(owner, spender, value, deadline, v, r, s);
+        IERC20Permit(product.ytcUnderlyingAsset).permit(owner, spender, value, deadline, v, r, s);
       }
     }
 
     SafeERC20.safeTransferFrom(
-      IERC20(product.productAddress),
+      IERC20(product.ytcUnderlyingAsset),
       msg.sender,
       address(this),
       depeggedTokens

--- a/contracts/modules/cover/CoverViewer.sol
+++ b/contracts/modules/cover/CoverViewer.sol
@@ -16,7 +16,7 @@ contract CoverViewer {
   struct CoverView {
     uint24 productId;
     uint16 productType;
-    address productAddress;
+    address ytcUnderlyingAsset;
     uint96 amountPaidOut;
     uint amountRemaining;
     uint coverStart;
@@ -82,7 +82,7 @@ contract CoverViewer {
     return CoverView(
       coverData.productId,
       product.productType,
-      product.productAddress,
+      product.ytcUnderlyingAsset,
       coverData.amountPaidOut,
       amountRemaining,
       coverStart,

--- a/scripts/deploy/deploy.js
+++ b/scripts/deploy/deploy.js
@@ -318,7 +318,7 @@ async function main() {
   const addProductsParams = products.map(product => {
     const underlyingToken = ['ETH', 'DAI'].indexOf(product.underlyingToken);
     const productType = { protocol: 0, custodian: 1, token: 2 }[product.type];
-    const productAddress = product.coveredToken || '0x0000000000000000000000000000000000000000';
+    const ytcUnderlyingAsset = product.coveredToken || '0x0000000000000000000000000000000000000000';
 
     let coverAssets =
       underlyingToken === -1
@@ -331,7 +331,7 @@ async function main() {
 
     return {
       productType,
-      productAddress,
+      ytcUnderlyingAsset,
       coverAssets,
       initialPriceRatio: 100,
       capacityReductionRatio: 0,

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -321,28 +321,28 @@ async function setup() {
     [
       {
         productType: 0, // Protocol Cover
-        productAddress: '0x0000000000000000000000000000000000000000',
+        ytcUnderlyingAsset: '0x0000000000000000000000000000000000000000',
         coverAssets: 0, // Use fallback
         initialPriceRatio: 100,
         capacityReductionRatio: 0,
       },
       {
         productType: 1, // Custody Cover
-        productAddress: '0x0000000000000000000000000000000000000000',
+        ytcUnderlyingAsset: '0x0000000000000000000000000000000000000000',
         coverAssets: 0, // Use fallback
         initialPriceRatio: 100,
         capacityReductionRatio: 0,
       },
       {
         productType: 2, // Yield Token Cover
-        productAddress: '0x0000000000000000000000000000000000000001',
+        ytcUnderlyingAsset: '0x0000000000000000000000000000000000000001',
         coverAssets: 0b01, // ETH
         initialPriceRatio: 100,
         capacityReductionRatio: 0,
       },
       {
         productType: 2, // Yield Token Cover
-        productAddress: '0x0000000000000000000000000000000000000002',
+        ytcUnderlyingAsset: '0x0000000000000000000000000000000000000002',
         coverAssets: 0b10, // DAI
         initialPriceRatio: 100,
         capacityReductionRatio: 0,

--- a/test/unit/Cover/addProducts.js
+++ b/test/unit/Cover/addProducts.js
@@ -8,7 +8,7 @@ describe('addProducts', function () {
 
     const newProduct = {
       productType: 0,
-      productAddress: '0x0000000000000000000000000000000000000001',
+      ytcUnderlyingAsset: '0x0000000000000000000000000000000000000001',
       coverAssets: parseInt('110', 2), // DAI and USDC supported
       initialPriceRatio: 1000, // 10%
       capacityReductionRatio: 0,
@@ -24,7 +24,7 @@ describe('addProducts', function () {
     const productAfter = await cover.products(newProductId);
 
     expect(newProduct.productType).to.be.equal(productAfter.productType);
-    expect(newProduct.productAddress).to.be.equal(productAfter.productAddress);
+    expect(newProduct.ytcUnderlyingAsset).to.be.equal(productAfter.ytcUnderlyingAsset);
     expect(newProduct.coverAssets).to.be.equal(productAfter.coverAssets);
     expect(newProduct.initialPriceRatio).to.be.equal(productAfter.initialPriceRatio);
     expect(newProduct.capacityReductionRatio).to.be.equal(productAfter.capacityReductionRatio);
@@ -37,7 +37,7 @@ describe('addProducts', function () {
 
     const newProduct = {
       productType: '0',
-      productAddress: '0x0000000000000000000000000000000000000001',
+      ytcUnderlyingAsset: '0x0000000000000000000000000000000000000001',
       coverAssets: parseInt('1110', 2), // DAI, USDC and WBTC supported
       initialPriceRatio: '1000', // 10%
       capacityReductionRatio: '0',
@@ -55,7 +55,7 @@ describe('addProducts', function () {
 
     const newProduct = {
       productType: 0,
-      productAddress: '0x0000000000000000000000000000000000000001',
+      ytcUnderlyingAsset: '0x0000000000000000000000000000000000000001',
       coverAssets: parseInt('110', 2), // DAI and USDC supported
       initialPriceRatio: 50, // 0.5%
       capacityReductionRatio: 0,
@@ -73,7 +73,7 @@ describe('addProducts', function () {
 
     const newProduct = {
       productType: 0,
-      productAddress: '0x0000000000000000000000000000000000000001',
+      ytcUnderlyingAsset: '0x0000000000000000000000000000000000000001',
       coverAssets: parseInt('110', 2), // DAI and USDC supported
       initialPriceRatio: 10100, // 101%
       capacityReductionRatio: 0,
@@ -91,7 +91,7 @@ describe('addProducts', function () {
 
     const newProduct = {
       productType: 0,
-      productAddress: '0x0000000000000000000000000000000000000001',
+      ytcUnderlyingAsset: '0x0000000000000000000000000000000000000001',
       coverAssets: parseInt('110', 2), // DAI and USDC supported
       initialPriceRatio: 1000, // 101%
       capacityReductionRatio: 10100,

--- a/test/unit/Cover/editProducts.js
+++ b/test/unit/Cover/editProducts.js
@@ -23,7 +23,7 @@ describe('editProducts', function () {
     const productAfter = await cover.products(productId);
 
     expect(productBefore.productType).to.be.equal(productAfter.productType);
-    expect(productBefore.productAddress).to.be.equal(productAfter.productAddress);
+    expect(productBefore.ytcUnderlyingAsset).to.be.equal(productAfter.ytcUnderlyingAsset);
     expect(newProductValues.coverAssets).to.be.equal(productAfter.coverAssets);
     expect(newProductValues.initialPriceRatio).to.be.equal(productAfter.initialPriceRatio);
     expect(newProductValues.capacityReductionRatio).to.be.equal(productAfter.capacityReductionRatio);

--- a/test/unit/Cover/setup.js
+++ b/test/unit/Cover/setup.js
@@ -189,7 +189,7 @@ async function setup() {
     [
       {
         productType: '0',
-        productAddress: '0x0000000000000000000000000000000000000000',
+        ytcUnderlyingAsset: '0x0000000000000000000000000000000000000000',
         coverAssets: parseInt('111', 2), // ETH DAI and USDC supported
         initialPriceRatio: '1000', // 10%
         capacityReductionRatio: '0',


### PR DESCRIPTION
## Context
Fixes issue https://github.com/NexusMutual/smart-contracts/issues/415.



## Changes proposed in this pull request
We agreed that productAsset is quite confusing in this context, and decided to make it more specific. 

## Test plan
Ran existing tests.

## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
