### PR TITLE
Feature/deprecate products

### DIFF
--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -179,6 +179,8 @@ interface ICover {
     string[] calldata ipfsMetadata
   ) external;
 
+  function deprecateProducts(uint[] calldata productIds) external;
+
   function performStakeBurn(
     uint coverId,
     uint segmentId,

--- a/contracts/interfaces/IStakingPool.sol
+++ b/contracts/interfaces/IStakingPool.sol
@@ -71,7 +71,7 @@ interface IStakingPool {
     uint rewardsShares;
   }
 
-  struct Product {
+  struct StakedProduct {
     uint8 lastWeight;
     uint8 targetWeight;
     uint96 targetPrice;
@@ -118,6 +118,8 @@ interface IStakingPool {
   function setPoolFee(uint newFee) external;
 
   function setPoolPrivacy(bool isPrivatePool) external;
+
+  function setProducts(ProductParams[] memory params) external;
 
   function manager() external view returns (address);
 

--- a/contracts/interfaces/IStakingPool.sol
+++ b/contracts/interfaces/IStakingPool.sol
@@ -34,9 +34,9 @@ struct DepositRequest {
 struct ProductParams {
   uint productId;
   bool setWeight;
-  uint targetWeight;
+  uint8 targetWeight;
   bool setPrice;
-  uint targetPrice;
+  uint96 targetPrice;
 }
 
 struct ProductInitializationParams {
@@ -114,12 +114,6 @@ interface IStakingPool {
   function withdraw(
     WithdrawRequest[] memory params
   ) external returns (uint stakeToWithdraw, uint rewardsToWithdraw);
-
-  function addProducts(ProductParams[] memory params) external;
-
-  function removeProducts(uint[] memory productIds) external;
-
-  function setProductDetails(ProductParams[] memory params) external;
 
   function setPoolFee(uint newFee) external;
 

--- a/contracts/mocks/Cover/CoverMockProductStaking.sol
+++ b/contracts/mocks/Cover/CoverMockProductStaking.sol
@@ -1,0 +1,28 @@
+pragma solidity ^0.8.0;
+
+import "../../interfaces/ICover.sol";
+
+contract CoverMockProductStaking {
+
+  mapping(uint => Product) internal _products;
+
+  function products(uint id) external returns (Product memory) {
+    return _products[id];
+  }
+
+  function setProduct(Product memory product_, uint id) public {
+    _products[id] = product_;
+  }
+
+  function initializeStaking(
+    address staking_,
+    address _manager,
+    bool _isPrivatePool,
+    uint _initialPoolFee,
+    uint _maxPoolFee,
+    ProductInitializationParams[] calldata params,
+    uint _poolId
+  ) external {
+      IStakingPool(staking_).initialize(_manager, _isPrivatePool, _initialPoolFee, _maxPoolFee, params, _poolId);
+  }
+}

--- a/contracts/mocks/Cover/CoverMockProductStaking.sol
+++ b/contracts/mocks/Cover/CoverMockProductStaking.sol
@@ -6,7 +6,7 @@ contract CoverMockProductStaking {
 
   mapping(uint => Product) internal _products;
 
-  function products(uint id) external returns (Product memory) {
+  function products(uint id) external view returns (Product memory) {
     return _products[id];
   }
 

--- a/contracts/mocks/Cover/CoverMockProductStaking.sol
+++ b/contracts/mocks/Cover/CoverMockProductStaking.sol
@@ -14,6 +14,13 @@ contract CoverMockProductStaking {
     _products[id] = product_;
   }
 
+  function deprecateProducts(uint[] calldata productIds) external {
+    uint numProducts = productIds.length;
+    for (uint i = 0; i < numProducts; i++){
+      _products[productIds[i]].initialPriceRatio = 0;
+    }
+  }
+
   function initializeStaking(
     address staking_,
     address _manager,

--- a/contracts/mocks/Cover/CoverMockQuotationData.sol
+++ b/contracts/mocks/Cover/CoverMockQuotationData.sol
@@ -24,6 +24,7 @@ contract CoverMockQuotationData {
 
   mapping(bytes4 => uint) internal currencyCSA;
   mapping(address => uint[]) internal userCover;
+  mapping(uint => uint8) public coverStatus;
 
   Cover[] internal allCovers;
 
@@ -55,5 +56,64 @@ contract CoverMockQuotationData {
   /// @dev Gets the Total Sum Assured amount of a given currency.
   function setTotalSumAssured(bytes4 currency, uint amount) public {
       sumAssuredByCurrency[currency] = amount;
+  }
+
+  /// @dev Gets the status of a given cover.
+  function getCoverStatusNo(uint _cid) external view returns (uint8) {
+    return coverStatus[_cid];
+  }
+
+  /// @dev Changes the status of a given cover.
+  function changeCoverStatusNo(uint _cid, uint8 _stat) public {
+    coverStatus[_cid] = _stat;
+  }
+
+  /// @dev Provides the details of a cover Id
+  function getCoverDetailsByCoverID1(
+    uint _cid
+  )
+  external
+  view
+  returns (
+    uint cid,
+    address _memberAddress,
+    address _scAddress,
+    bytes4 _currencyCode,
+    uint _sumAssured,
+    uint premiumNXM
+  )
+  {
+    return (
+    _cid,
+    allCovers[_cid].memberAddress,
+    allCovers[_cid].scAddress,
+    allCovers[_cid].currencyCode,
+    allCovers[_cid].sumAssured,
+    allCovers[_cid].premiumNXM
+    );
+  }
+
+  /// @dev Provides details of a cover Id
+  function getCoverDetailsByCoverID2(
+    uint _cid
+  )
+  external
+  view
+  returns (
+    uint cid,
+    uint8 status,
+    uint sumAssured,
+    uint16 coverPeriod,
+    uint validUntil
+  )
+  {
+
+    return (
+    _cid,
+    coverStatus[_cid],
+    allCovers[_cid].sumAssured,
+    allCovers[_cid].coverPeriod,
+    allCovers[_cid].validUntil
+    );
   }
 }

--- a/contracts/mocks/Cover/CoverMockStakingPool.sol
+++ b/contracts/mocks/Cover/CoverMockStakingPool.sol
@@ -6,6 +6,7 @@ import "../Tokens/ERC721Mock.sol";
 import "@openzeppelin/contracts-v4/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts-v4/utils/Strings.sol";
 import "../../modules/staking/StakingPool.sol";
+import "../../interfaces/IStakingPool.sol";
 
 
 contract CoverMockStakingPool is IStakingPool, ERC721Mock {
@@ -22,8 +23,8 @@ contract CoverMockStakingPool is IStakingPool, ERC721Mock {
 
   mapping (uint => uint) public usedCapacity;
   mapping (uint => uint) public stakedAmount;
-  // product id => Product
-  mapping(uint => Product) public products;
+  // product id => StakedProduct
+  mapping(uint => StakedProduct) public products;
   mapping (uint => uint) public mockPrices;
 
   uint public constant MAX_PRICE_RATIO = 10_000;
@@ -90,6 +91,10 @@ contract CoverMockStakingPool is IStakingPool, ERC721Mock {
     uint /*coverStartTime*/,
     uint /*premium*/
   ) external {
+  }
+
+  function setProducts(ProductParams[] memory params) external {
+    params;
   }
 
   function calculatePremium(uint priceRatio, uint coverAmount, uint period) public pure returns (uint) {

--- a/contracts/mocks/TokenControllerMock.sol
+++ b/contracts/mocks/TokenControllerMock.sol
@@ -12,11 +12,21 @@ contract TokenControllerMock is MasterAware {
     uint128 deposits;
   }
 
+  struct CoverInfo {
+    uint16 claimCount;
+    bool hasOpenClaim;
+    bool hasAcceptedClaim;
+    // note: still 224 bits available here, can be used later
+  }
+
   NXMToken public token;
   address public addToWhitelistLastCalledWtih;
   address public removeFromWhitelistLastCalledWtih;
 
   mapping(uint => StakingPoolNXMBalances) stakingPoolNXMBalances;
+
+  mapping(uint => CoverInfo) public coverInfo;
+
 
   function mint(address _member, uint256 _amount) public onlyInternal {
     token.mint(_member, _amount);

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -176,7 +176,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
     require(_products.length > params.productId, "Cover: Product not found");
 
     Product memory product = _products[params.productId];
-    require(product.initialPriceRatio != 0, "Cover: Product not initialized");
+    require(product.initialPriceRatio != 0, "Cover: Product deprecated or not initialized");
 
     IPool _pool = pool();
     uint32 deprecatedCoverAssetsBitmap = _pool.deprecatedCoverAssetsBitmap();
@@ -352,6 +352,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
       !_isCoverAssetDeprecated(deprecatedCoverAssetsBitmap, buyCoverParams.paymentAsset),
       "Cover: payment asset deprecated"
     );
+    require(product.initialPriceRatio != 0, "Cover: Product deprecated or not initialized");
 
     uint refundInCoverAsset;
 
@@ -652,6 +653,13 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
       _productTypes[productTypeIds[i]].gracePeriodInDays = gracePeriodsInDays[i];
       emit ProductTypeSet(productTypeIds[i], ipfsMetadata[i]);
     }
+  }
+
+  function deprecateProducts(uint[] calldata productIds) external override onlyAdvisoryBoard {
+      uint numProducts = productIds.length;
+      for (uint i = 0; i < numProducts; i++){
+        _products[productIds[i]].initialPriceRatio = 0;
+      }
   }
 
   function editProducts(

--- a/contracts/modules/cover/CoverUtilsLib.sol
+++ b/contracts/modules/cover/CoverUtilsLib.sol
@@ -137,7 +137,9 @@ library CoverUtilsLib {
 
       // override with initial price
       for (uint i = 0; i < productInitParams.length; i++) {
-        productInitParams[0].initialPrice = products[productInitParams[i].productId].initialPriceRatio;
+        uint96 initialPriceRatio = products[productInitParams[i].productId].initialPriceRatio;
+        require(initialPriceRatio > 0, "CoverUtils: Product deprecated or uninitialized");
+        productInitParams[0].initialPrice = initialPriceRatio;
       }
     }
 

--- a/contracts/modules/cover/CoverUtilsLib.sol
+++ b/contracts/modules/cover/CoverUtilsLib.sol
@@ -81,6 +81,7 @@ library CoverUtilsLib {
       // Mint the new cover
       uint productId = params.productsV1.getNewProductId(legacyProductId);
       Product memory product = _products[productId];
+      require(product.initialPriceRatio != 0, "Product deprecated or not initialized");
       ProductType memory productType = _productTypes[product.productType];
       require(
         block.timestamp < validUntil + productType.gracePeriodInDays * 1 days,

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -1223,23 +1223,25 @@ contract StakingPool is IStakingPool, ERC721 {
 
   function _setProducts(ProductParams[] memory params) internal {
     uint32 _targetWeight = targetWeight;
+
     for (uint i = 0; i < params.length; i++) {
       ProductParams memory _param = params[i];
       StakedProduct memory _product = products[_param.productId];
+
       if (_product.nextPriceUpdateTime == 0) {
         Product memory coverProduct = ICover(coverContract).products(_param.productId);
-        require(coverProduct.initialPriceRatio > 0, "Failed to get initial price for product");
+        require(coverProduct.initialPriceRatio > 0, "StakingPool: Failed to get initial price for product");
         _product.nextPrice = coverProduct.initialPriceRatio;
         _product.nextPriceUpdateTime = uint32(block.timestamp);
       }
 
       if (_param.setPrice) {
-        require(_param.targetPrice <= SURGE_PRICE_DENOMINATOR, "Target price too high");
+        require(_param.targetPrice <= SURGE_PRICE_DENOMINATOR, "StakingPool: Target price too high");
         _product.targetPrice = _param.targetPrice;
       }
 
       if (_param.setWeight) {
-          require(_param.targetWeight <= WEIGHT_DENOMINATOR, "Cannot set weight beyond 1");
+          require(_param.targetWeight <= WEIGHT_DENOMINATOR, "StakingPool: Cannot set weight beyond 1");
 
           if (_product.targetWeight < _param.targetWeight) {
              _targetWeight += _param.targetWeight - _product.targetWeight;
@@ -1251,7 +1253,7 @@ contract StakingPool is IStakingPool, ERC721 {
       products[_param.productId] = _product;
     // End for loop
     }
-    require(_targetWeight <= 2000, "Target weight above 20");
+    require(_targetWeight <= 2000, "StakingPool: Target weight above 20");
     targetWeight = _targetWeight;
   }
 

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -1230,7 +1230,7 @@ contract StakingPool is IStakingPool, ERC721 {
 
       if (_product.nextPriceUpdateTime == 0) {
         Product memory coverProduct = ICover(coverContract).products(_param.productId);
-        require(coverProduct.initialPriceRatio > 0, "StakingPool: Failed to get initial price for product");
+        require(coverProduct.initialPriceRatio > 0, "StakingPool: Product deprecated or not initialized");
         _product.nextPrice = coverProduct.initialPriceRatio;
         _product.nextPriceUpdateTime = uint32(block.timestamp);
       }

--- a/test/unit/Cover/deprecateProducts.js
+++ b/test/unit/Cover/deprecateProducts.js
@@ -1,0 +1,261 @@
+const { ethers } = require('hardhat');
+const { expect } = require('chai');
+const { createStakingPool, assertCoverFields } = require('./helpers');
+const { parseEther } = ethers.utils;
+const { AddressZero } = ethers.constants;
+
+describe('deprecateProducts', function () {
+  const productId = 0;
+  const coverAsset = 0; // ETH
+  const period = 3600 * 24 * 364; // 30 days
+  const amount = parseEther('1000');
+  const targetPriceRatio = '260';
+  const priceDenominator = '10000';
+  const activeCover = parseEther('8000');
+  const capacity = parseEther('10000');
+  const capacityFactor = '10000';
+
+  it('should deprecate product and set initialPriceRatio to 0', async function () {
+    const { cover } = this;
+    const [advisoryBoardMember0] = this.accounts.advisoryBoardMembers;
+    await cover.connect(advisoryBoardMember0).deprecateProducts([0]);
+    const product = await cover.products(0);
+    expect(product.initialPriceRatio).to.be.equal(0);
+  });
+
+  it('should re-enable deprecated product by editing initialPriceRatio', async function () {
+    const { cover } = this;
+    const [advisoryBoardMember0] = this.accounts.advisoryBoardMembers;
+    const initialPriceRatio = 100; // 10%
+    await cover.connect(advisoryBoardMember0).deprecateProducts([0]);
+    const product = await cover.products(0);
+    const newProductValues = {
+      coverAssets: product.coverAssets,
+      initialPriceRatio: 100,
+      capacityReductionRatio: product.capacityReductionRatio,
+    };
+    await cover.connect(advisoryBoardMember0).editProducts([0], [newProductValues], ['ipfs hash']);
+    const productAfter = await cover.products(0);
+    expect(productAfter.initialPriceRatio).to.be.equal(initialPriceRatio);
+    await cover.connect(advisoryBoardMember0).deprecateProducts([0]);
+  });
+
+  it('should fail to deprecate product using editProducts()', async function () {
+    const { cover } = this;
+    const [advisoryBoardMember0] = this.accounts.advisoryBoardMembers;
+    const productId = 0;
+    const product = await cover.products(productId);
+    const newProductValues = {
+      coverAssets: product.coverAssets,
+      initialPriceRatio: 0,
+      capacityReductionRatio: product.capacityReductionRatio,
+    };
+    await expect(
+      cover.connect(advisoryBoardMember0).editProducts([productId], [newProductValues], ['ipfs hash']),
+    ).to.be.revertedWith('Cover: initialPriceRatio < GLOBAL_MIN_PRICE_RATIO');
+  });
+
+  it('should fail to buy cover for deprecated product', async function () {
+    const { cover } = this;
+    const {
+      governanceContracts: [gv1],
+      members: [coverBuyer, stakingPoolManager],
+      advisoryBoardMembers: [advisoryBoardMember0],
+    } = this.accounts;
+
+    // create staking pool
+    await cover.connect(gv1).updateUintParameters([0], [capacityFactor]);
+    await createStakingPool(
+      cover,
+      productId,
+      capacity,
+      targetPriceRatio,
+      activeCover,
+      stakingPoolManager,
+      stakingPoolManager,
+      targetPriceRatio,
+    );
+
+    // deprecate product
+    await cover.connect(advisoryBoardMember0).deprecateProducts([productId]);
+
+    const expectedPremium = amount.mul(targetPriceRatio).div(priceDenominator);
+    await expect(
+      cover.connect(coverBuyer).buyCover(
+        {
+          owner: coverBuyer.address,
+          productId,
+          coverAsset,
+          amount,
+          period,
+          maxPremiumInAsset: expectedPremium,
+          paymentAsset: coverAsset,
+          payWitNXM: false,
+          commissionRatio: parseEther('0'),
+          commissionDestination: AddressZero,
+          ipfsData: '',
+        },
+        [{ poolId: '0', coverAmountInAsset: amount }],
+        {
+          value: expectedPremium,
+        },
+      ),
+    ).to.be.revertedWith('Cover: Product deprecated or not initialized');
+  });
+
+  it('should purchase cover after deprecated product has been restored', async function () {
+    const { cover } = this;
+    const {
+      governanceContracts: [gv1],
+      members: [coverBuyer, stakingPoolManager],
+      advisoryBoardMembers: [advisoryBoardMember0],
+    } = this.accounts;
+
+    await cover.connect(gv1).updateUintParameters([0], [capacityFactor]);
+
+    await createStakingPool(
+      cover,
+      productId,
+      capacity,
+      targetPriceRatio,
+      activeCover,
+      stakingPoolManager,
+      stakingPoolManager,
+      targetPriceRatio,
+    );
+
+    // Deprecate product
+    await cover.connect(advisoryBoardMember0).deprecateProducts([productId]);
+
+    // Restore product
+    const product = await cover.products(productId);
+    const newProductValues = {
+      coverAssets: product.coverAssets,
+      initialPriceRatio: 100,
+      capacityReductionRatio: product.capacityReductionRatio,
+    };
+    await cover.connect(advisoryBoardMember0).editProducts([productId], [newProductValues], ['ipfs hash']);
+
+    const expectedPremium = amount.mul(targetPriceRatio).div(priceDenominator);
+
+    const tx = await cover.connect(coverBuyer).buyCover(
+      {
+        owner: coverBuyer.address,
+        productId,
+        coverAsset,
+        amount,
+        period,
+        maxPremiumInAsset: expectedPremium,
+        paymentAsset: coverAsset,
+        payWitNXM: false,
+        commissionRatio: parseEther('0'),
+        commissionDestination: AddressZero,
+        ipfsData: '',
+      },
+      [{ poolId: '0', coverAmountInAsset: amount }],
+      {
+        value: expectedPremium,
+      },
+    );
+    await tx.wait();
+
+    const expectedCoverId = '0';
+
+    await assertCoverFields(cover, expectedCoverId, { productId, coverAsset, period, amount, targetPriceRatio });
+  });
+
+  it('should fail to edit cover for a deprecated product', async function () {
+    const { cover } = this;
+    const {
+      governanceContracts: [gv1],
+      members: [coverBuyer, stakingPoolManager],
+      advisoryBoardMembers: [advisoryBoardMember0],
+    } = this.accounts;
+
+    await cover.connect(gv1).updateUintParameters([0], [capacityFactor]);
+
+    await createStakingPool(
+      cover,
+      productId,
+      capacity,
+      targetPriceRatio,
+      activeCover,
+      stakingPoolManager,
+      stakingPoolManager,
+      targetPriceRatio,
+    );
+
+    // buy cover
+    const expectedPremium = amount.mul(targetPriceRatio).div(priceDenominator);
+    const tx = await cover.connect(coverBuyer).buyCover(
+      {
+        owner: coverBuyer.address,
+        productId,
+        coverAsset,
+        amount,
+        period,
+        maxPremiumInAsset: expectedPremium,
+        paymentAsset: coverAsset,
+        payWitNXM: false,
+        commissionRatio: parseEther('0'),
+        commissionDestination: AddressZero,
+        ipfsData: '',
+      },
+      [{ poolId: '0', coverAmountInAsset: amount }],
+      {
+        value: expectedPremium,
+      },
+    );
+    await tx.wait();
+
+    await cover.connect(advisoryBoardMember0).deprecateProducts([productId]);
+
+    const increasedAmount = amount.add(1);
+
+    await expect(
+      cover.connect(coverBuyer).editCover(
+        0,
+        {
+          owner: coverBuyer.address,
+          productId,
+          coverAsset,
+          amount: increasedAmount,
+          period: period / 2,
+          maxPremiumInAsset: expectedPremium.add(1),
+          paymentAsset: coverAsset,
+          payWitNXM: false,
+          commissionRatio: parseEther('0'),
+          commissionDestination: AddressZero,
+          ipfsData: '',
+        },
+        [{ poolId: '0', coverAmountInAsset: increasedAmount.toString() }],
+        {
+          value: expectedPremium.add(1),
+        },
+      ),
+    ).to.be.revertedWith('Cover: Product deprecated or not initialized');
+  });
+
+  it('should fail to create staking pool using deprecated product', async function () {
+    const { cover } = this;
+    const {
+      advisoryBoardMembers: [advisoryBoardMember0],
+      members: [stakingPoolManager],
+    } = this.accounts;
+    const productId = 0;
+    await cover.connect(advisoryBoardMember0).deprecateProducts([0]);
+
+    await expect(
+      createStakingPool(
+        cover,
+        productId,
+        capacity,
+        targetPriceRatio,
+        activeCover,
+        stakingPoolManager,
+        stakingPoolManager,
+        targetPriceRatio,
+      ),
+    ).to.be.revertedWith('CoverUtils: Product deprecated or uninitialized');
+  });
+});

--- a/test/unit/Cover/helpers.js
+++ b/test/unit/Cover/helpers.js
@@ -1,6 +1,5 @@
 const { ethers } = require('hardhat');
-const { assert } = require('chai');
-const { bnEqual } = require('../../../lib/helpers');
+const { assert, expect } = require('chai');
 
 const { parseEther } = ethers.utils;
 const { AddressZero } = ethers.constants;
@@ -51,10 +50,10 @@ async function assertCoverFields(
 
   assert.equal(storedCoverData.productId, productId);
   assert.equal(storedCoverData.coverAsset, coverAsset);
-  bnEqual(storedCoverData.amountPaidOut, amountPaidOut);
+  expect(storedCoverData.amountPaidOut).to.be.equal(amountPaidOut);
   assert.equal(segment.period, period);
   assert.equal(segment.amount.toString(), amount.toString());
-  bnEqual(segment.priceRatio, targetPriceRatio);
+  expect(segment.priceRatio.toString()).to.be.equal(targetPriceRatio.toString());
 }
 
 async function buyCoverOnOnePool({

--- a/test/unit/Cover/index.js
+++ b/test/unit/Cover/index.js
@@ -23,4 +23,5 @@ describe('Cover unit tests', function () {
   require('./editProducts');
   require('./addProducts');
   require('./editProductTypes');
+  require('./deprecateProducts');
 });

--- a/test/unit/Cover/index.js
+++ b/test/unit/Cover/index.js
@@ -24,4 +24,5 @@ describe('Cover unit tests', function () {
   require('./addProducts');
   require('./editProductTypes');
   require('./deprecateProducts');
+  require('./migrateCovers');
 });

--- a/test/unit/Cover/migrateCovers.js
+++ b/test/unit/Cover/migrateCovers.js
@@ -1,0 +1,41 @@
+const { ethers } = require('hardhat');
+const { expect } = require('chai');
+const { parseEther, toUtf8Bytes } = ethers.utils;
+
+describe('initialize', function () {
+  it('reverts when calling migrateCoverFromOwner for a deprecated product', async function () {
+    const { coverMigrator, cover, quotationData, productsV1 } = this;
+    const [coverOwner] = this.accounts.members;
+    const {
+      governanceContracts: [gv1],
+      members: [coverBuyer],
+      advisoryBoardMembers: [advisoryBoardMember0],
+    } = this.accounts;
+
+    const legacyProductId = '0x8B3d70d628Ebd30D4A2ea82DB95bA2e906c71633';
+    const productId = await productsV1.getNewProductId(legacyProductId);
+
+    const amount = parseEther('0.0000000000001');
+    const targetPriceRatio = '260';
+    const priceDenominator = '10000';
+    const capacityFactor = '10000';
+
+    await cover.connect(gv1).updateUintParameters([0], [capacityFactor]);
+    const expectedPremium = amount.mul(targetPriceRatio).div(priceDenominator);
+
+    await quotationData.addCover(
+      100,
+      amount,
+      coverBuyer.address,
+      toUtf8Bytes('NXM0'),
+      legacyProductId,
+      10,
+      expectedPremium,
+    );
+
+    await cover.connect(advisoryBoardMember0).deprecateProducts([productId]);
+    await expect(coverMigrator.connect(coverOwner).submitClaim(0)).to.be.revertedWith(
+      'Product deprecated or not initialized',
+    );
+  });
+});

--- a/test/unit/StakingPool/index.js
+++ b/test/unit/StakingPool/index.js
@@ -16,4 +16,5 @@ describe('StakingPool unit tests', function () {
   // require('./interpolatePrice');
   // require('./getPrices');
   require('./calculateNewRewardShares');
+  require('./setProducts');
 });

--- a/test/unit/StakingPool/setProducts.js
+++ b/test/unit/StakingPool/setProducts.js
@@ -1,8 +1,16 @@
 const { expect } = require('chai');
+const { ethers } = require('hardhat');
+const { AddressZero } = ethers.constants;
 
 describe('setProducts unit tests', function () {
-  const initializePool = async function (stakingPool, manager, poolId, productInitParams) {
-    await stakingPool.initialize(manager, false, 5, 5, productInitParams, poolId);
+  const initializePool = async function (cover, stakingPool, manager, poolId, productInitParams) {
+    // Set products in mock cover contract
+    await Promise.all(
+      productInitParams.map(p => {
+        return cover.setProduct(getCoverProduct(p.initialPrice), p.productId);
+      }),
+    );
+    await cover.initializeStaking(stakingPool.address, manager, false, 5, 5, productInitParams, poolId);
   };
 
   const getInitialProduct = (weight, targetPrice, initialPrice, id) => {
@@ -13,7 +21,7 @@ describe('setProducts unit tests', function () {
       targetPrice,
     };
   };
-  // ProductParams
+  // Staking.Product
   const getNewProduct = (weight, price, id) => {
     return {
       productId: id,
@@ -23,6 +31,23 @@ describe('setProducts unit tests', function () {
       targetPrice: price,
     };
   };
+  // Cover.Product
+  const getCoverProduct = initialPriceRatio => {
+    return {
+      productType: 1,
+      productAddress: AddressZero,
+      coverAssets: 1111,
+      initialPriceRatio,
+      capacityReductionRatio: 111,
+    };
+  };
+
+  // Get product and set in cover contract
+  const initProduct = async (cover, initialPriceRatio, weight, price, id) => {
+    const coverProduct = getCoverProduct(initialPriceRatio);
+    await cover.setProduct(coverProduct, id);
+    return getNewProduct(weight, price, id);
+  };
 
   const verifyProduct = (product, weight, price) => {
     expect(product.targetWeight).to.be.equal(weight);
@@ -30,106 +55,117 @@ describe('setProducts unit tests', function () {
   };
 
   it('should fail to be called by non manager', async function () {
-    const { stakingPool } = this;
+    const { stakingPool, cover } = this;
     const { defaultSender, members } = this.accounts;
-    await initializePool(stakingPool, defaultSender.address, 0, []);
-    const product = getNewProduct(100, 100, 0);
+    await initializePool(cover, stakingPool, defaultSender.address, 0, []);
+    const product = await initProduct(cover, 100, 100, 0, 0);
     await expect(stakingPool.connect(members[3]).setProducts([product])).to.be.revertedWith(
       'StakingPool: Only pool manager can call this function',
     );
   });
 
   it('should initialize products successfully', async function () {
-    const { stakingPool } = this;
+    const { stakingPool, cover } = this;
     const { defaultSender } = this.accounts;
     let i = 0;
     const initialProducts = Array.from({ length: 20 }, () => getInitialProduct(100, 100, 500, i++));
-    await initializePool(stakingPool, defaultSender.address, 0, initialProducts);
+    await initializePool(cover, stakingPool, defaultSender.address, 0, initialProducts);
     const product = await stakingPool.products(0);
     verifyProduct(product, 100, 100);
+    expect(product.nextPriceUpdateTime).to.be.greaterThan(0);
     expect(product.nextPrice).to.be.equal(500);
   });
 
   it('should fail to initialize too many products with full weight', async function () {
-    const { stakingPool } = this;
+    const { stakingPool, cover } = this;
     const { defaultSender } = this.accounts;
     let i = 0;
     const initialProducts = Array.from({ length: 21 }, () => getInitialProduct(100, 100, 500, i++));
-    await expect(initializePool(stakingPool, defaultSender.address, 0, initialProducts)).to.be.revertedWith(
+    await expect(initializePool(cover, stakingPool, defaultSender.address, 0, initialProducts)).to.be.revertedWith(
       'Target weight above 20',
     );
   });
 
   it('should set products and store values correctly', async function () {
-    const { stakingPool } = this;
+    const { stakingPool, cover } = this;
     const { defaultSender } = this.accounts;
-    await initializePool(stakingPool, defaultSender.address, 0, []);
-    const product = getNewProduct(100, 100, 0);
+    await initializePool(cover, stakingPool, defaultSender.address, 0, []);
+    const product = await initProduct(cover, 50, 100, 100, 0);
     await stakingPool.setProducts([product]);
-    const products = await stakingPool.products(0);
+    const product0 = await stakingPool.products(0);
     verifyProduct(product, 100, 100);
-    // TODO: set initial price
-    expect(products.nextPrice).to.be.equal(0);
-    expect(products.nextPriceUpdateTime).to.be.equal(0);
+    expect(product0.nextPrice).to.be.equal(50);
+    // TODO: verify nextPriceUpdateTime
+    expect(product0.nextPriceUpdateTime).to.be.greaterThan(0);
   });
 
   it('should add and remove products in same tx', async function () {
-    const { stakingPool } = this;
+    const { stakingPool, cover } = this;
     const { defaultSender } = this.accounts;
-    await initializePool(stakingPool, defaultSender.address, 0, []);
-    const products = [getNewProduct(50, 50, 0), getNewProduct(50, 50, 1)];
+    const initialPriceRatio = 1000;
+    await initializePool(cover, stakingPool, defaultSender.address, 0, []);
+    const products = [
+      await initProduct(cover, initialPriceRatio, 50, 50, 0),
+      await initProduct(cover, initialPriceRatio, 50, 50, 1),
+    ];
     await stakingPool.setProducts(products);
-    // remove product0, add product2
+
     products[0].targetWeight = 0;
-    products[1] = getNewProduct(50, 50, 2);
+    products[1] = await initProduct(cover, initialPriceRatio, 50, 50, 2);
+    // remove product0, add product2
     await stakingPool.setProducts(products);
+
     const product0 = await stakingPool.products(0);
     const product1 = await stakingPool.products(1);
     const product2 = await stakingPool.products(2);
-    // expect(product1).to.be.equal(await stakingPool.products(1));
     verifyProduct(product1, 50, 50);
     verifyProduct(product0, 0, 50);
     verifyProduct(product2, 50, 50);
+    expect(product1.nextPrice).to.equal(initialPriceRatio);
   });
 
   it('should add maximum products with full weight (20)', async function () {
-    const { stakingPool } = this;
+    const { stakingPool, cover } = this;
     const { defaultSender } = this.accounts;
-    await initializePool(stakingPool, defaultSender.address, 0, []);
+    await initializePool(cover, stakingPool, defaultSender.address, 0, []);
     let i = 0;
-    const products = Array.from({ length: 20 }, () => getNewProduct(100, 100, i++));
+    const products = await Promise.all(Array.from({ length: 20 }, () => initProduct(cover, 999, 100, 100, i++)));
     await stakingPool.setProducts(products);
     expect(await stakingPool.targetWeight()).to.be.equal(2000);
-    verifyProduct(await stakingPool.products(19), 100, 100, 19);
+    const product19 = await stakingPool.products(19);
+    verifyProduct(product19, 100, 100, 19);
+    expect(product19.nextPrice).to.be.equal(999);
   });
 
   it('should fail to add weights beyond 20x', async function () {
-    const { stakingPool } = this;
+    const { stakingPool, cover } = this;
     const { defaultSender } = this.accounts;
-    await initializePool(stakingPool, defaultSender.address, 0, []);
+    await initializePool(cover, stakingPool, defaultSender.address, 0, []);
     let i = 0;
-    const products = Array.from({ length: 20 }, () => getNewProduct(100, 100, i++));
+    const products = await Promise.all(Array.from({ length: 20 }, () => initProduct(cover, 1, 100, 100, i++)));
     await stakingPool.setProducts(products);
-    const newProduct = [getNewProduct(1, 1, 50)];
+    const newProduct = [await initProduct(cover, 1, 1, 1, 50)];
     await expect(stakingPool.setProducts(newProduct)).to.be.revertedWith('Target weight above 20');
     expect(await stakingPool.targetWeight()).to.be.equal(2000);
-    verifyProduct(await stakingPool.products(19), 100, 100, 19);
+    const product0 = await stakingPool.products(0);
+    verifyProduct(product0, 100, 100, 19);
+    expect(product0.nextPrice).to.be.equal(1);
   });
 
   it('should fail to make product weight higher than 1', async function () {
-    const { stakingPool } = this;
+    const { stakingPool, cover } = this;
     const { defaultSender } = this.accounts;
-    await initializePool(stakingPool, defaultSender.address, 0, []);
-    await expect(stakingPool.setProducts([getNewProduct(101, 101, 0)])).to.be.revertedWith(
+    await initializePool(cover, stakingPool, defaultSender.address, 0, []);
+    await expect(stakingPool.setProducts([await initProduct(cover, 1, 101, 101, 0)])).to.be.revertedWith(
       'Cannot set weight beyond 1',
     );
   });
 
   it('should edit weights, and skip price', async function () {
-    const { stakingPool } = this;
+    const { stakingPool, cover } = this;
     const { defaultSender } = this.accounts;
-    await initializePool(stakingPool, defaultSender.address, 0, []);
-    const product = getNewProduct(0, 20, 0);
+    await initializePool(cover, stakingPool, defaultSender.address, 0, []);
+    const product = await initProduct(cover, 1, 0, 20, 0);
     product.setPrice = false;
     expect(product.targetPrice).to.be.equal(20);
     await stakingPool.setProducts([product]);
@@ -140,10 +176,10 @@ describe('setProducts unit tests', function () {
   });
 
   it('should edit prices and skip weights', async function () {
-    const { stakingPool } = this;
+    const { stakingPool, cover } = this;
     const { defaultSender } = this.accounts;
-    await initializePool(stakingPool, defaultSender.address, 0, []);
-    const product = getNewProduct(80, 50, 0);
+    await initializePool(cover, stakingPool, defaultSender.address, 0, []);
+    const product = await initProduct(cover, 1, 80, 50, 0);
     product.setWeight = false;
     await stakingPool.setProducts([product]);
     verifyProduct(await stakingPool.products(0), 0, 50);
@@ -153,10 +189,18 @@ describe('setProducts unit tests', function () {
   });
 
   it('should fail with targetPrice too high', async function () {
-    const { stakingPool } = this;
+    const { stakingPool, cover } = this;
     const { defaultSender } = this.accounts;
-    await initializePool(stakingPool, defaultSender.address, 0, []);
-    const product = getNewProduct(80, 10001, 0);
+    await initializePool(cover, stakingPool, defaultSender.address, 0, []);
+    const product = await initProduct(cover, 1, 80, 10001, 0);
     await expect(stakingPool.setProducts([product])).to.be.revertedWith('Target price too high');
+  });
+
+  it('should fail to add non-existing product', async function () {
+    const { stakingPool, cover } = this;
+    const { defaultSender } = this.accounts;
+    await initializePool(cover, stakingPool, defaultSender.address, 0, []);
+    const product = getNewProduct(100, 100, 0);
+    await expect(stakingPool.setProducts([product])).to.be.revertedWith('Failed to get initial price for product');
   });
 });

--- a/test/unit/StakingPool/setProducts.js
+++ b/test/unit/StakingPool/setProducts.js
@@ -1,0 +1,162 @@
+const { expect } = require('chai');
+
+describe('setProducts unit tests', function () {
+  const initializePool = async function (stakingPool, manager, poolId, productInitParams) {
+    await stakingPool.initialize(manager, false, 5, 5, productInitParams, poolId);
+  };
+
+  const getInitialProduct = (weight, targetPrice, initialPrice, id) => {
+    return {
+      productId: id,
+      weight,
+      initialPrice,
+      targetPrice,
+    };
+  };
+  // ProductParams
+  const getNewProduct = (weight, price, id) => {
+    return {
+      productId: id,
+      setWeight: true,
+      targetWeight: weight,
+      setPrice: true,
+      targetPrice: price,
+    };
+  };
+
+  const verifyProduct = (product, weight, price) => {
+    expect(product.targetWeight).to.be.equal(weight);
+    expect(product.targetPrice).to.be.equal(price);
+  };
+
+  it('should fail to be called by non manager', async function () {
+    const { stakingPool } = this;
+    const { defaultSender, members } = this.accounts;
+    await initializePool(stakingPool, defaultSender.address, 0, []);
+    const product = getNewProduct(100, 100, 0);
+    await expect(stakingPool.connect(members[3]).setProducts([product])).to.be.revertedWith(
+      'StakingPool: Only pool manager can call this function',
+    );
+  });
+
+  it('should initialize products successfully', async function () {
+    const { stakingPool } = this;
+    const { defaultSender } = this.accounts;
+    let i = 0;
+    const initialProducts = Array.from({ length: 20 }, () => getInitialProduct(100, 100, 500, i++));
+    await initializePool(stakingPool, defaultSender.address, 0, initialProducts);
+    const product = await stakingPool.products(0);
+    verifyProduct(product, 100, 100);
+    expect(product.nextPrice).to.be.equal(500);
+  });
+
+  it('should fail to initialize too many products with full weight', async function () {
+    const { stakingPool } = this;
+    const { defaultSender } = this.accounts;
+    let i = 0;
+    const initialProducts = Array.from({ length: 21 }, () => getInitialProduct(100, 100, 500, i++));
+    await expect(initializePool(stakingPool, defaultSender.address, 0, initialProducts)).to.be.revertedWith(
+      'Target weight above 20',
+    );
+  });
+
+  it('should set products and store values correctly', async function () {
+    const { stakingPool } = this;
+    const { defaultSender } = this.accounts;
+    await initializePool(stakingPool, defaultSender.address, 0, []);
+    const product = getNewProduct(100, 100, 0);
+    await stakingPool.setProducts([product]);
+    const products = await stakingPool.products(0);
+    verifyProduct(product, 100, 100);
+    // TODO: set initial price
+    expect(products.nextPrice).to.be.equal(0);
+    expect(products.nextPriceUpdateTime).to.be.equal(0);
+  });
+
+  it('should add and remove products in same tx', async function () {
+    const { stakingPool } = this;
+    const { defaultSender } = this.accounts;
+    await initializePool(stakingPool, defaultSender.address, 0, []);
+    const products = [getNewProduct(50, 50, 0), getNewProduct(50, 50, 1)];
+    await stakingPool.setProducts(products);
+    // remove product0, add product2
+    products[0].targetWeight = 0;
+    products[1] = getNewProduct(50, 50, 2);
+    await stakingPool.setProducts(products);
+    const product0 = await stakingPool.products(0);
+    const product1 = await stakingPool.products(1);
+    const product2 = await stakingPool.products(2);
+    // expect(product1).to.be.equal(await stakingPool.products(1));
+    verifyProduct(product1, 50, 50);
+    verifyProduct(product0, 0, 50);
+    verifyProduct(product2, 50, 50);
+  });
+
+  it('should add maximum products with full weight (20)', async function () {
+    const { stakingPool } = this;
+    const { defaultSender } = this.accounts;
+    await initializePool(stakingPool, defaultSender.address, 0, []);
+    let i = 0;
+    const products = Array.from({ length: 20 }, () => getNewProduct(100, 100, i++));
+    await stakingPool.setProducts(products);
+    expect(await stakingPool.targetWeight()).to.be.equal(2000);
+    verifyProduct(await stakingPool.products(19), 100, 100, 19);
+  });
+
+  it('should fail to add weights beyond 20x', async function () {
+    const { stakingPool } = this;
+    const { defaultSender } = this.accounts;
+    await initializePool(stakingPool, defaultSender.address, 0, []);
+    let i = 0;
+    const products = Array.from({ length: 20 }, () => getNewProduct(100, 100, i++));
+    await stakingPool.setProducts(products);
+    const newProduct = [getNewProduct(1, 1, 50)];
+    await expect(stakingPool.setProducts(newProduct)).to.be.revertedWith('Target weight above 20');
+    expect(await stakingPool.targetWeight()).to.be.equal(2000);
+    verifyProduct(await stakingPool.products(19), 100, 100, 19);
+  });
+
+  it('should fail to make product weight higher than 1', async function () {
+    const { stakingPool } = this;
+    const { defaultSender } = this.accounts;
+    await initializePool(stakingPool, defaultSender.address, 0, []);
+    await expect(stakingPool.setProducts([getNewProduct(101, 101, 0)])).to.be.revertedWith(
+      'Cannot set weight beyond 1',
+    );
+  });
+
+  it('should edit weights, and skip price', async function () {
+    const { stakingPool } = this;
+    const { defaultSender } = this.accounts;
+    await initializePool(stakingPool, defaultSender.address, 0, []);
+    const product = getNewProduct(0, 20, 0);
+    product.setPrice = false;
+    expect(product.targetPrice).to.be.equal(20);
+    await stakingPool.setProducts([product]);
+    verifyProduct(await stakingPool.products(0), 0, 0);
+    product.targetWeight = 100;
+    await stakingPool.setProducts([product]);
+    verifyProduct(await stakingPool.products(0), 100, 0);
+  });
+
+  it('should edit prices and skip weights', async function () {
+    const { stakingPool } = this;
+    const { defaultSender } = this.accounts;
+    await initializePool(stakingPool, defaultSender.address, 0, []);
+    const product = getNewProduct(80, 50, 0);
+    product.setWeight = false;
+    await stakingPool.setProducts([product]);
+    verifyProduct(await stakingPool.products(0), 0, 50);
+    product.targetPrice = 100;
+    await stakingPool.setProducts([product]);
+    verifyProduct(await stakingPool.products(0), 0, 100);
+  });
+
+  it('should fail with targetPrice too high', async function () {
+    const { stakingPool } = this;
+    const { defaultSender } = this.accounts;
+    await initializePool(stakingPool, defaultSender.address, 0, []);
+    const product = getNewProduct(80, 10001, 0);
+    await expect(stakingPool.setProducts([product])).to.be.revertedWith('Target price too high');
+  });
+});

--- a/test/unit/StakingPool/setProducts.js
+++ b/test/unit/StakingPool/setProducts.js
@@ -83,7 +83,7 @@ describe('setProducts unit tests', function () {
     let i = 0;
     const initialProducts = Array.from({ length: 21 }, () => getInitialProduct(100, 100, 500, i++));
     await expect(initializePool(cover, stakingPool, defaultSender.address, 0, initialProducts)).to.be.revertedWith(
-      'Target weight above 20',
+      'StakingPool: Target weight above 20',
     );
   });
 
@@ -141,7 +141,7 @@ describe('setProducts unit tests', function () {
     const products = await Promise.all(Array.from({ length: 20 }, () => initProduct(cover, 1, 100, 100, i++)));
     await stakingPool.setProducts(products);
     const newProduct = [await initProduct(cover, 1, 1, 1, 50)];
-    await expect(stakingPool.setProducts(newProduct)).to.be.revertedWith('Target weight above 20');
+    await expect(stakingPool.setProducts(newProduct)).to.be.revertedWith('StakingPool: Target weight above 20');
     expect(await stakingPool.targetWeight()).to.be.equal(2000);
     const product0 = await stakingPool.products(0);
     verifyProduct(product0, 100, 100, 1);
@@ -153,7 +153,7 @@ describe('setProducts unit tests', function () {
     const { defaultSender } = this.accounts;
     await initializePool(cover, stakingPool, defaultSender.address, 0, []);
     await expect(stakingPool.setProducts([await initProduct(cover, 1, 101, 101, 0)])).to.be.revertedWith(
-      'Cannot set weight beyond 1',
+      'StakingPool: Cannot set weight beyond 1',
     );
   });
 
@@ -189,7 +189,7 @@ describe('setProducts unit tests', function () {
     const { defaultSender } = this.accounts;
     await initializePool(cover, stakingPool, defaultSender.address, 0, []);
     const product = await initProduct(cover, 1, 80, 10001, 0);
-    await expect(stakingPool.setProducts([product])).to.be.revertedWith('Target price too high');
+    await expect(stakingPool.setProducts([product])).to.be.revertedWith('StakingPool: Target price too high');
   });
 
   it('should fail to add non-existing product', async function () {
@@ -197,6 +197,8 @@ describe('setProducts unit tests', function () {
     const { defaultSender } = this.accounts;
     await initializePool(cover, stakingPool, defaultSender.address, 0, []);
     const product = getNewProduct(100, 100, 0);
-    await expect(stakingPool.setProducts([product])).to.be.revertedWith('Failed to get initial price for product');
+    await expect(stakingPool.setProducts([product])).to.be.revertedWith(
+      'StakingPool: Failed to get initial price for product',
+    );
   });
 });

--- a/test/unit/StakingPool/setProducts.js
+++ b/test/unit/StakingPool/setProducts.js
@@ -52,7 +52,6 @@ describe('setProducts unit tests', function () {
   const verifyProduct = (product, weight, price, initialPrice) => {
     expect(product.targetWeight).to.be.equal(weight);
     expect(product.targetPrice).to.be.equal(price);
-    // TODO: verify exact nextPriceUpdateTime
     expect(product.nextPriceUpdateTime).to.be.greaterThan(0);
     expect(product.nextPrice).to.be.equal(initialPrice);
   };
@@ -198,7 +197,18 @@ describe('setProducts unit tests', function () {
     await initializePool(cover, stakingPool, defaultSender.address, 0, []);
     const product = getNewProduct(100, 100, 0);
     await expect(stakingPool.setProducts([product])).to.be.revertedWith(
-      'StakingPool: Failed to get initial price for product',
+      'StakingPool: Product deprecated or not initialized',
+    );
+  });
+
+  it('should fail to add deprecated product', async function () {
+    const { stakingPool, cover } = this;
+    const { defaultSender } = this.accounts;
+    await initializePool(cover, stakingPool, defaultSender.address, 0, []);
+    const product = await initProduct(cover, 50, 100, 100, 0);
+    await cover.deprecateProducts([0]);
+    await expect(stakingPool.setProducts([product])).to.be.revertedWith(
+      'StakingPool: Product deprecated or not initialized',
     );
   });
 });

--- a/test/unit/StakingPool/setup.js
+++ b/test/unit/StakingPool/setup.js
@@ -8,6 +8,7 @@ async function setup() {
   const MasterMock = await ethers.getContractFactory('MasterMock');
   const ERC20Mock = await ethers.getContractFactory('ERC20Mock');
   const QuotationData = await ethers.getContractFactory('CoverMockQuotationData');
+  const CoverProductStaking = await ethers.getContractFactory('CoverMockProductStaking');
   const MemberRolesMock = await ethers.getContractFactory('MemberRolesMock');
   const TokenController = await ethers.getContractFactory('TokenControllerMock');
   const NXMToken = await ethers.getContractFactory('NXMTokenMock');
@@ -47,7 +48,10 @@ async function setup() {
   const signers = await ethers.getSigners();
   const accounts = getAccounts(signers);
 
-  const stakingPool = await StakingPool.deploy(nxm.address, accounts.defaultSender.address, tokenController.address);
+  const coverMockProductStaking = await CoverProductStaking.deploy();
+  await coverMockProductStaking.deployed();
+
+  const stakingPool = await StakingPool.deploy(nxm.address, coverMockProductStaking.address, tokenController.address);
 
   for (const member of accounts.members) {
     await master.enrollMember(member.address, Role.Member);
@@ -73,6 +77,7 @@ async function setup() {
 
   this.master = master;
   this.stakingPool = stakingPool;
+  this.cover = coverMockProductStaking;
   this.dai = dai;
   this.accounts = accounts;
   this.config = {

--- a/test/unit/StakingPool/setup.js
+++ b/test/unit/StakingPool/setup.js
@@ -1,5 +1,4 @@
 const { ethers } = require('hardhat');
-const { ZERO_ADDRESS } = require('@openzeppelin/test-helpers').constants;
 const { parseEther } = ethers.utils;
 const { getAccounts } = require('../../utils/accounts');
 const { Role } = require('../utils').constants;
@@ -45,10 +44,10 @@ async function setup() {
   await mcr.deployed();
   await mcr.setMCR(parseEther('600000'));
 
-  const stakingPool = await StakingPool.deploy(nxm.address, ZERO_ADDRESS, tokenController.address);
-
   const signers = await ethers.getSigners();
   const accounts = getAccounts(signers);
+
+  const stakingPool = await StakingPool.deploy(nxm.address, accounts.defaultSender.address, tokenController.address);
 
   for (const member of accounts.members) {
     await master.enrollMember(member.address, Role.Member);

--- a/test/utils/address.js
+++ b/test/utils/address.js
@@ -1,0 +1,15 @@
+const { ethers } = require('hardhat');
+const { getContractAddress } = require('@ethersproject/address');
+const { getAccounts } = require('./accounts');
+
+const getDeployAddressAfter = async txCount => {
+  const signers = await ethers.getSigners();
+  const { defaultSender } = getAccounts(signers);
+  const transactionCount = await defaultSender.getTransactionCount();
+  return getContractAddress({
+    from: defaultSender.address,
+    nonce: transactionCount + txCount,
+  });
+};
+
+module.exports = { getDeployAddressAfter };

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -8,9 +8,11 @@ const buyCover = require('./buyCover');
 const getQuote = require('./getQuote');
 const governance = require('./governance');
 const membership = require('./membership');
+const address = require('./address');
 
 module.exports = {
   accounts,
+  address,
   constants,
   evm,
   helpers,


### PR DESCRIPTION
## Context

resolves #412 To add the ability to deprecate products


## Changes proposed in this pull request

This PR adds the function `deprecateProducts(uint[] productIds)` to `Cover.sol`

Products are deprecated by setting `product.initialPriceRatio` to 0. 

Products can be reinstated using `editProducts()` by setting initialPriceRatio back above 0

The contracts will now revert when:
- New staking pools are created containing a deprecated product.
- A staking pool adds a deprecated product after being created
- Cover buys are made for a deprecated product
- Cover edits made for a deprecated product
- Cover migrations occur on a deprecated product

## Test plan
added a new unit test file for the function at: `test/unit/Cover/deprecateProducts.js`
unit tests were also added to:
- `test/unit/StakingPool/setProducts.js`
- `test/unit/Cover/migrateCovers.js`

## Checklist

- [ ] Rebased the base branch
- [ ] Attached corresponding Github issue
- [ ] Prefixed the name with the type of change (i.e. feat, chore, test)
- [ ] Performed a self-review of my own code
- [ ] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [ ] Didn't generate new warnings
- [ ] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
