### PR TITLE
Feature/ Add Assessment stake and unstake unit tests

### DIFF
--- a/contracts/mocks/MasterMock.sol
+++ b/contracts/mocks/MasterMock.sol
@@ -32,6 +32,10 @@ contract MasterMock {
     emergencyAdmin = _emergencyAdmin;
   }
 
+  function setEmergencyPause(bool _paused) external {
+    paused = _paused;
+  }
+
   function enrollGovernance(address newGov) public {
     governanceAddresses[newGov] = true;
   }

--- a/test/unit/Assessment/stake.js
+++ b/test/unit/Assessment/stake.js
@@ -1,4 +1,4 @@
-const { assert } = require('chai');
+const { assert, expect } = require('chai');
 const { ethers } = require('hardhat');
 
 const { parseEther } = ethers.utils;
@@ -39,5 +39,12 @@ describe('stake', function () {
       const balance = await nxm.balanceOf(assessment.address);
       assert(balance.eq(parseEther('200')));
     }
+  });
+
+  it('reverts if system is paused', async function () {
+    const { assessment, master } = this.contracts;
+    await master.setEmergencyPause(true);
+
+    await expect(assessment.stake(parseEther('100'))).to.revertedWith('System is paused');
   });
 });


### PR DESCRIPTION
## Context

No related issue.

## Changes proposed in this pull request

This PR adds more unit tests for the `stake()` and `unstake()` functions. It also updates the `MasterMock` contract to include the `setEmergencyPause()` function so that scenarios can be tested. 


## Test plan

More tests were added in `test/unit/Assessment/stake.js` and `test/unit/Assessment/unstake.js`


## Checklist

- [x] Rebased the base branch
- [ ] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
