### PR TITLE
Use v1 cover sumAssured as it is (already in wei)

### DIFF
--- a/contracts/modules/cover/CoverUtilsLib.sol
+++ b/contracts/modules/cover/CoverUtilsLib.sol
@@ -99,7 +99,7 @@ library CoverUtilsLib {
 
     _coverSegments[newCoverId].push(
       CoverSegment(
-        SafeUintCast.toUint96(sumAssured * 10 ** 18), // amount
+        SafeUintCast.toUint96(sumAssured), // amount
         SafeUintCast.toUint32(validUntil - coverPeriodInDays * 1 days), // start
         SafeUintCast.toUint32(coverPeriodInDays * 1 days), // period
         productType.gracePeriodInDays,


### PR DESCRIPTION
## Context

The cover migrate transaction for a v1 cover got reverted with reason string `SafeCast: value doesn't fit in 96 bits` on the amount param.

## Changes proposed in this pull request

I noticed that the `sumAssured` value of a v1 cover (at runtime) was already in wei (had 18 0s) so there was no need to convert it further. The change in this PR removes that conversion.

## Test plan

I've only tested it locally, using the deploy script and calling the migrate contract method from the FE app. With this change, the v1 cover gets migrated successfully.

## Checklist

- [ ] Rebased the base branch
- [ ] Attached corresponding Github issue
- [ ] Prefixed the name with the type of change (i.e. feat, chore, test)
- [ ] Performed a self-review of my own code
- [ ] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [ ] Didn't generate new warnings
- [ ] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
