### PR TITLE
Test/ Add Assessment startAssessment and castVotes unit tests

### DIFF
--- a/test/unit/Assessment/castVotes.js
+++ b/test/unit/Assessment/castVotes.js
@@ -432,14 +432,13 @@ describe('castVotes', function () {
   });
 
   it('accounts votes from multiple members correctly', async function () {
-    const { assessment, individualClaims, master, memberRoles, nxm, tokenController } = this.contracts;
+    const { assessment, individualClaims, memberRoles, nxm, tokenController } = this.contracts;
 
-    // 5 members + 5 AB + 4 nonMembers
-    const voters = [...this.accounts.members, ...this.accounts.advisoryBoardMembers, ...this.accounts.nonMembers];
+    // 5 members + 5 AB
+    const voters = [...this.accounts.members, ...this.accounts.advisoryBoardMembers];
 
     // Add AB and nonMember accounts as new members
-    for (const member of [...this.accounts.advisoryBoardMembers, ...this.accounts.nonMembers]) {
-      await master.enrollMember(member.address, 1);
+    for (const member of this.accounts.advisoryBoardMembers) {
       await memberRoles.enrollMember(member.address, 2);
       await nxm.mint(member.address, parseEther('10000'));
       await nxm.connect(member).approve(tokenController.address, parseEther('10000'));
@@ -455,14 +454,14 @@ describe('castVotes', function () {
     const assessmentId = 0;
 
     // 8 true - 6 false
-    const votes = [true, false, true, false, false, true, true, false, true, true, true, true, false, false, true];
+    const votes = [true, false, true, false, false, true, true, false, true, true, true];
 
     for (let i = 0; i < voters.length; i++) {
       await assessment.connect(voters[i]).castVotes([assessmentId], [votes[i]], 0);
     }
 
     const { poll } = await assessment.assessments(assessmentId);
-    expect(poll.accepted).to.be.equal(stakeAmount.mul(8));
-    expect(poll.denied).to.be.equal(stakeAmount.mul(6));
+    expect(poll.accepted).to.be.equal(stakeAmount.mul(6));
+    expect(poll.denied).to.be.equal(stakeAmount.mul(4));
   });
 });

--- a/test/unit/Assessment/castVotes.js
+++ b/test/unit/Assessment/castVotes.js
@@ -338,21 +338,9 @@ describe('castVotes', function () {
     await expect(assessment.connect(user).castVotes([0], [true, true], 0)).to.revertedWith(
       'The lengths of the assessment ids and votes arrays mismatch',
     );
-
-    await expect(assessment.connect(user).castVotes([0, 1], [true], 0)).to.revertedWith(
-      'The lengths of the assessment ids and votes arrays mismatch',
-    );
-
-    await expect(assessment.connect(user).castVotes([], [true], 0)).to.revertedWith(
-      'The lengths of the assessment ids and votes arrays mismatch',
-    );
-
-    await expect(assessment.connect(user).castVotes([0], [], 0)).to.revertedWith(
-      'The lengths of the assessment ids and votes arrays mismatch',
-    );
   });
 
-  it('does not revert if empty arrays', async function () {
+  it('does not revert on empty arrays', async function () {
     const { assessment } = this.contracts;
     const [user] = this.accounts.members;
 
@@ -392,29 +380,31 @@ describe('castVotes', function () {
     const { timestamp: timestampAtVoteTime } = await ethers.provider.getBlock('latest');
 
     {
-      const { assessmentId, accepted, timestamp, stakedAmount } = await assessment.votesOf(user.address, 0);
+      const voteId = 0;
+      const { assessmentId, accepted, timestamp, stakedAmount } = await assessment.votesOf(user.address, voteId);
       expect(assessmentId).to.be.equal(0);
       expect(accepted).to.be.equal(true);
       expect(timestamp).to.be.equal(timestampAtVoteTime);
       expect(stakedAmount).to.be.equal(parseEther('100'));
 
-      const { poll } = await assessment.assessments(0);
+      const { poll } = await assessment.assessments(assessmentId);
       expect(poll.accepted).to.be.equal(parseEther('100'));
     }
 
     {
-      const { assessmentId, accepted, timestamp, stakedAmount } = await assessment.votesOf(user.address, 1);
+      const voteId = 1;
+      const { assessmentId, accepted, timestamp, stakedAmount } = await assessment.votesOf(user.address, voteId);
       expect(assessmentId).to.be.equal(1);
       expect(accepted).to.be.equal(true);
       expect(timestamp).to.be.equal(timestampAtVoteTime);
       expect(stakedAmount).to.be.equal(parseEther('100'));
 
-      const { poll } = await assessment.assessments(1);
+      const { poll } = await assessment.assessments(assessmentId);
       expect(poll.accepted).to.be.equal(parseEther('100'));
     }
   });
 
-  it('allows a non staker to stake and vote', async function () {
+  it('allows to stake for the first time and vote', async function () {
     const { assessment, individualClaims } = this.contracts;
     const [user] = this.accounts.members;
 

--- a/test/unit/Assessment/setup.js
+++ b/test/unit/Assessment/setup.js
@@ -83,6 +83,8 @@ async function setup() {
     master,
     individualClaims,
     yieldTokenIncidents,
+    tokenController,
+    memberRoles,
   };
 }
 

--- a/test/unit/Assessment/startAssessment.js
+++ b/test/unit/Assessment/startAssessment.js
@@ -125,4 +125,28 @@ describe('startAssessment', function () {
       expect(poll.denied).to.be.equal(0);
     }
   });
+
+  it('reverts if caller is not an internal contract', async function () {
+    const { assessment } = this.contracts;
+    const [user] = this.accounts.members;
+    const [AB] = this.accounts.advisoryBoardMembers;
+    const [governance] = this.accounts.governanceContracts;
+    const admin = this.accounts.emergencyAdmin;
+
+    await expect(assessment.connect(admin).startAssessment(parseEther('100'), parseEther('10'))).to.be.revertedWith(
+      'Caller is not an internal contract',
+    );
+
+    await expect(
+      assessment.connect(governance).startAssessment(parseEther('100'), parseEther('10')),
+    ).to.be.revertedWith('Caller is not an internal contract');
+
+    await expect(assessment.connect(AB).startAssessment(parseEther('100'), parseEther('10'))).to.be.revertedWith(
+      'Caller is not an internal contract',
+    );
+
+    await expect(assessment.connect(user).startAssessment(parseEther('100'), parseEther('10'))).to.be.revertedWith(
+      'Caller is not an internal contract',
+    );
+  });
 });

--- a/test/unit/Assessment/startAssessment.js
+++ b/test/unit/Assessment/startAssessment.js
@@ -128,24 +128,9 @@ describe('startAssessment', function () {
 
   it('reverts if caller is not an internal contract', async function () {
     const { assessment } = this.contracts;
-    const [user] = this.accounts.members;
-    const [AB] = this.accounts.advisoryBoardMembers;
-    const [governance] = this.accounts.governanceContracts;
     const admin = this.accounts.emergencyAdmin;
 
     await expect(assessment.connect(admin).startAssessment(parseEther('100'), parseEther('10'))).to.be.revertedWith(
-      'Caller is not an internal contract',
-    );
-
-    await expect(
-      assessment.connect(governance).startAssessment(parseEther('100'), parseEther('10')),
-    ).to.be.revertedWith('Caller is not an internal contract');
-
-    await expect(assessment.connect(AB).startAssessment(parseEther('100'), parseEther('10'))).to.be.revertedWith(
-      'Caller is not an internal contract',
-    );
-
-    await expect(assessment.connect(user).startAssessment(parseEther('100'), parseEther('10'))).to.be.revertedWith(
       'Caller is not an internal contract',
     );
   });


### PR DESCRIPTION
## Context

Closes #430


## Changes proposed in this pull request

Adds new unit tests for `startAssessment` and `castVotes`.  Implemented the list of test cases from the issue, with the following exceptions:
- `Should emit an event on each vote` was already implemented in another PR.
- `Should correctly extend the end date up to 1 day maximum if polls ends in less than 24 hours` was already tested as part of one of the implemented tests.

## Test plan

New tests were added in `test/unit/Assessment/startAssessment.js` and `test/unit/Assessment/castVotes.js`


## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
