### PR TITLE
Fix: Add event for migrateCover

### DIFF
--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -149,9 +149,9 @@ interface ICover {
 
   /* === MUTATIVE FUNCTIONS ==== */
 
-  function migrateCovers(uint[] calldata coverIds, address toNewOwner) external returns (uint[] memory newCoverIds);
+  function migrateCovers(uint[] calldata coverIds, address newOwner) external returns (uint[] memory newCoverIds);
 
-  function migrateCoverFromOwner(uint coverId, address fromOwner, address toNewOwner) external;
+  function migrateCoverFromOwner(uint coverId, address fromOwner, address newOwner) external;
 
   function buyCover(
     BuyCoverParams calldata params,
@@ -208,5 +208,5 @@ interface ICover {
   event CoverBought(uint coverId, uint productId, uint segmentId, address buyer, string ipfsMetadata);
   event CoverEdited(uint coverId, uint productId, uint segmentId, address buyer);
   event CoverExpired(uint coverId, uint segmentId);
-  event CoverMigrated(uint oldCoverId, address fromOwner, address toNewOwner, uint newCoverId);
+  event CoverMigrated(uint oldCoverId, address fromOwner, address newOwner, uint newCoverId);
 }

--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -149,9 +149,9 @@ interface ICover {
 
   /* === MUTATIVE FUNCTIONS ==== */
 
-  function migrateCovers(uint[] calldata coverIds, address toNewOwner) external;
+  function migrateCovers(uint[] calldata coverIds, address toNewOwner) external returns (uint[] memory newCoverIds);
 
-  function migrateCoverFromOwner(uint coverId, address fromOwner, address toNewOwner) external;
+  function migrateCoverFromOwner(uint coverId, address fromOwner, address toNewOwner) external returns (uint);
 
   function buyCover(
     BuyCoverParams calldata params,

--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -151,7 +151,7 @@ interface ICover {
 
   function migrateCovers(uint[] calldata coverIds, address toNewOwner) external returns (uint[] memory newCoverIds);
 
-  function migrateCoverFromOwner(uint coverId, address fromOwner, address toNewOwner) external returns (uint);
+  function migrateCoverFromOwner(uint coverId, address fromOwner, address toNewOwner) external;
 
   function buyCover(
     BuyCoverParams calldata params,

--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -208,4 +208,5 @@ interface ICover {
   event CoverBought(uint coverId, uint productId, uint segmentId, address buyer, string ipfsMetadata);
   event CoverEdited(uint coverId, uint productId, uint segmentId, address buyer);
   event CoverExpired(uint coverId, uint segmentId);
+  event CoverMigrated(uint oldCoverId, address fromOwner, address toNewOwner, uint newCoverId);
 }

--- a/contracts/mocks/Claims/CLMockCover.sol
+++ b/contracts/mocks/Claims/CLMockCover.sol
@@ -19,7 +19,7 @@ contract CLMockCover {
   struct MigrateCoverFromOwnerCalledWith {
     uint coverId;
     address fromOwner;
-    address toNewOwner;
+    address newOwner;
   }
 
   PerformStakeBurnCalledWith public performStakeBurnCalledWith;
@@ -141,9 +141,9 @@ contract CLMockCover {
   function migrateCoverFromOwner(
     uint coverId,
     address fromOwner,
-    address toNewOwner
+    address newOwner
   ) external returns (address) {
-    migrateCoverFromOwnerCalledWith = MigrateCoverFromOwnerCalledWith(coverId, fromOwner, toNewOwner);
+    migrateCoverFromOwnerCalledWith = MigrateCoverFromOwnerCalledWith(coverId, fromOwner, newOwner);
     // silence compiler warning:
     return address(0);
   }

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -128,9 +128,13 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
   ///
   /// @param coverIds    Legacy (V1) cover identifiers
   /// @param toNewOwner  The address for which the V2 cover NFT is minted
-  function migrateCovers(uint[] calldata coverIds, address toNewOwner) external override {
+  function migrateCovers(
+    uint[] calldata coverIds,
+    address toNewOwner
+  ) external override returns (uint[] memory newCoverIds) {
+    newCoverIds = new uint[](coverIds.length);
     for (uint i = 0; i < coverIds.length; i++) {
-      _migrateCoverFromOwner(coverIds[i], msg.sender, toNewOwner);
+      newCoverIds[i] = _migrateCoverFromOwner(coverIds[i], msg.sender, toNewOwner);
     }
   }
 
@@ -144,8 +148,8 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
     uint coverId,
     address fromOwner,
     address toNewOwner
-  ) external override onlyInternal {
-    _migrateCoverFromOwner(coverId, fromOwner, toNewOwner);
+  ) external override onlyInternal returns (uint) {
+    return _migrateCoverFromOwner(coverId, fromOwner, toNewOwner);
   }
 
   /// @dev Migrates covers from V1
@@ -157,9 +161,9 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
     uint coverId,
     address fromOwner,
     address toNewOwner
-  ) internal {
+  ) internal returns (uint) {
 
-    CoverUtilsLib.migrateCoverFromOwner(
+     CoverUtilsLib.migrateCoverFromOwner(
       CoverUtilsLib.MigrateParams(
         coverId,
         fromOwner,
@@ -175,7 +179,9 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
       _coverSegments
     );
 
-    emit CoverMigrated(coverId, fromOwner, toNewOwner, _coverData.length - 1);
+    uint newCoverId = _coverData.length - 1;
+    emit CoverMigrated(coverId, fromOwner, toNewOwner, newCoverId);
+    return newCoverId;
   }
 
   function buyCover(

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -174,6 +174,8 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
       _coverData,
       _coverSegments
     );
+
+    emit CoverMigrated(coverId, fromOwner, toNewOwner, _coverData.length - 1);
   }
 
   function buyCover(

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -127,14 +127,14 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
   /// @dev Migrates covers from V1. Meant to be used by EOA Nexus Mutual members
   ///
   /// @param coverIds    Legacy (V1) cover identifiers
-  /// @param toNewOwner  The address for which the V2 cover NFT is minted
+  /// @param newOwner  The address for which the V2 cover NFT is minted
   function migrateCovers(
     uint[] calldata coverIds,
-    address toNewOwner
+    address newOwner
   ) external override returns (uint[] memory newCoverIds) {
     newCoverIds = new uint[](coverIds.length);
     for (uint i = 0; i < coverIds.length; i++) {
-      newCoverIds[i] = _migrateCoverFromOwner(coverIds[i], msg.sender, toNewOwner);
+      newCoverIds[i] = _migrateCoverFromOwner(coverIds[i], msg.sender, newOwner);
     }
   }
 
@@ -143,31 +143,31 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
   ///
   /// @param coverId     V1 cover identifier
   /// @param fromOwner   The address from where this function is called that needs to match the
-  /// @param toNewOwner  The address for which the V2 cover NFT is minted
+  /// @param newOwner  The address for which the V2 cover NFT is minted
   function migrateCoverFromOwner(
     uint coverId,
     address fromOwner,
-    address toNewOwner
+    address newOwner
   ) external override onlyInternal {
-    _migrateCoverFromOwner(coverId, fromOwner, toNewOwner);
+    _migrateCoverFromOwner(coverId, fromOwner, newOwner);
   }
 
   /// @dev Migrates covers from V1
   ///
   /// @param coverId     V1 cover identifier
   /// @param fromOwner   The address from where this function is called that needs to match the
-  /// @param toNewOwner  The address for which the V2 cover NFT is minted
+  /// @param newOwner  The address for which the V2 cover NFT is minted
   function _migrateCoverFromOwner(
     uint coverId,
     address fromOwner,
-    address toNewOwner
+    address newOwner
   ) internal returns (uint) {
 
     CoverUtilsLib.migrateCoverFromOwner(
       CoverUtilsLib.MigrateParams(
         coverId,
         fromOwner,
-        toNewOwner,
+        newOwner,
         ICoverNFT(coverNFT),
         quotationData,
         tokenController(),
@@ -180,7 +180,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
     );
 
     uint newCoverId = _coverData.length - 1;
-    emit CoverMigrated(coverId, fromOwner, toNewOwner, newCoverId);
+    emit CoverMigrated(coverId, fromOwner, newOwner, newCoverId);
     return newCoverId;
   }
 

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -148,8 +148,8 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
     uint coverId,
     address fromOwner,
     address toNewOwner
-  ) external override onlyInternal returns (uint) {
-    return _migrateCoverFromOwner(coverId, fromOwner, toNewOwner);
+  ) external override onlyInternal {
+    _migrateCoverFromOwner(coverId, fromOwner, toNewOwner);
   }
 
   /// @dev Migrates covers from V1
@@ -163,7 +163,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
     address toNewOwner
   ) internal returns (uint) {
 
-     CoverUtilsLib.migrateCoverFromOwner(
+    CoverUtilsLib.migrateCoverFromOwner(
       CoverUtilsLib.MigrateParams(
         coverId,
         fromOwner,

--- a/contracts/modules/cover/CoverUtilsLib.sol
+++ b/contracts/modules/cover/CoverUtilsLib.sol
@@ -24,7 +24,7 @@ library CoverUtilsLib {
   struct MigrateParams {
     uint coverId;
     address fromOwner;
-    address toNewOwner;
+    address newOwner;
     ICoverNFT coverNFT;
     IQuotationData quotationData;
     ITokenController tokenController;
@@ -109,7 +109,7 @@ library CoverUtilsLib {
       )
     );
 
-    params.coverNFT.mint(params.toNewOwner, newCoverId);
+    params.coverNFT.mint(params.newOwner, newCoverId);
   }
 
   function calculateProxyCodeHash(address coverProxyAddress) external pure returns (bytes32) {

--- a/test/unit/CoverMigrator/submitClaim.js
+++ b/test/unit/CoverMigrator/submitClaim.js
@@ -10,7 +10,7 @@ describe('submitClaim', function () {
       const migrateCoverFromOwnerCalledWith = await cover.migrateCoverFromOwnerCalledWith();
       expect(migrateCoverFromOwnerCalledWith.coverId).to.be.equal(123);
       expect(migrateCoverFromOwnerCalledWith.fromOwner).to.be.equal(coverOwner.address);
-      expect(migrateCoverFromOwnerCalledWith.toNewOwner).to.be.equal(coverOwner.address);
+      expect(migrateCoverFromOwnerCalledWith.newOwner).to.be.equal(coverOwner.address);
     }
 
     {
@@ -18,7 +18,7 @@ describe('submitClaim', function () {
       const migrateCoverFromOwnerCalledWith = await cover.migrateCoverFromOwnerCalledWith();
       expect(migrateCoverFromOwnerCalledWith.coverId).to.be.equal(444);
       expect(migrateCoverFromOwnerCalledWith.fromOwner).to.be.equal(distributor.address);
-      expect(migrateCoverFromOwnerCalledWith.toNewOwner).to.be.equal(coverOwner.address);
+      expect(migrateCoverFromOwnerCalledWith.newOwner).to.be.equal(coverOwner.address);
     }
   });
 });


### PR DESCRIPTION
## Context
Solves issue: https://github.com/NexusMutual/smart-contracts/issues/437

There's no easy way to know what's the new cover id of the cover you just migrated. This is necessary in the UI to know what use as a parameter for claim submission.

This PR adds an event for each migrated cover.

## Changes proposed in this pull request

1 new event type CoverMigrated and an emit call.


## Test plan

We do not have tests for `migrateCovers`. We can add a verification for the event when we get there.

We can add the check when those tests are written. 

## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
