### PR TITLE
Test/ Add Assessment submitFraud and processFraud unit tests

### DIFF
--- a/contracts/modules/assessment/Assessment.sol
+++ b/contracts/modules/assessment/Assessment.sol
@@ -36,7 +36,7 @@ contract Assessment is IAssessment, MasterAwareV2 {
   // fraud attempt by one or multiple addresses. Once the root is submitted by adivsory board
   // members through governance, burnFraud uses this root to burn the fraudulent assessors' stakes
   // and correct the outcome of the poll.
-  bytes32[] internal fraudResolution;
+  bytes32[] public fraudResolution;
 
   Assessment[] public override assessments;
 

--- a/test/unit/Assessment/processFraud.js
+++ b/test/unit/Assessment/processFraud.js
@@ -830,6 +830,7 @@ describe('processFraud', function () {
       expect(fraudulentAssessment.poll.accepted).to.be.equal(parseEther('100'));
     }
 
+    const voteBatchSize = 0;
     await assessment.processFraud(
       0, // Index of the merkle tree root hash
       [],
@@ -837,7 +838,7 @@ describe('processFraud', function () {
       0, // The index of the last vote that is considered to be fraudulent
       burnAmount, // The amount of stake to be burned
       0, // The count of previous fraud attempts by this assessor
-      0, // Maximum iterations per tx
+      voteBatchSize, // Maximum iterations per tx
     );
 
     {

--- a/test/unit/Assessment/processFraud.js
+++ b/test/unit/Assessment/processFraud.js
@@ -479,7 +479,8 @@ describe('processFraud', function () {
     const governance = this.accounts.governanceContracts[0];
     const [fraudulentMember] = this.accounts.members;
 
-    await assessment.connect(fraudulentMember).stake(parseEther('100'));
+    const stakeAmount = parseEther('100');
+    await assessment.connect(fraudulentMember).stake(stakeAmount);
 
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
 
@@ -495,7 +496,7 @@ describe('processFraud', function () {
 
     {
       const stake = await assessment.stakeOf(fraudulentMember.address);
-      expect(stake.amount).to.be.equal(parseEther('100'));
+      expect(stake.amount).to.be.equal(stakeAmount);
     }
 
     await assessment.processFraud(
@@ -510,7 +511,7 @@ describe('processFraud', function () {
 
     {
       const stake = await assessment.stakeOf(fraudulentMember.address);
-      expect(stake.amount).to.be.equal(parseEther('67'));
+      expect(stake.amount).to.be.equal(stakeAmount.sub(burnAmount));
       expect(stake.rewardsWithdrawableFromIndex).to.be.equal(1);
     }
   });
@@ -804,7 +805,8 @@ describe('processFraud', function () {
     const governance = this.accounts.governanceContracts[0];
     const [fraudulentMember] = this.accounts.members;
 
-    await assessment.connect(fraudulentMember).stake(parseEther('100'));
+    const stakeAmount = parseEther('100');
+    await assessment.connect(fraudulentMember).stake(stakeAmount);
 
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
 
@@ -820,7 +822,7 @@ describe('processFraud', function () {
 
     {
       const stake = await assessment.stakeOf(fraudulentMember.address);
-      expect(stake.amount).to.be.equal(parseEther('100'));
+      expect(stake.amount).to.be.equal(stakeAmount);
     }
 
     {
@@ -840,7 +842,7 @@ describe('processFraud', function () {
 
     {
       const stake = await assessment.stakeOf(fraudulentMember.address);
-      expect(stake.amount).to.be.equal(parseEther('67'));
+      expect(stake.amount).to.be.equal(stakeAmount.sub(burnAmount));
       expect(stake.rewardsWithdrawableFromIndex).to.be.equal(1);
     }
 
@@ -855,7 +857,8 @@ describe('processFraud', function () {
     const governance = this.accounts.governanceContracts[0];
     const [fraudulentMember] = this.accounts.members;
 
-    await assessment.connect(fraudulentMember).stake(parseEther('100'));
+    const stakeAmount = parseEther('100');
+    await assessment.connect(fraudulentMember).stake(stakeAmount);
 
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
 
@@ -871,7 +874,7 @@ describe('processFraud', function () {
 
     {
       const stake = await assessment.stakeOf(fraudulentMember.address);
-      expect(stake.amount).to.be.equal(parseEther('100'));
+      expect(stake.amount).to.be.equal(stakeAmount);
     }
 
     {
@@ -891,7 +894,7 @@ describe('processFraud', function () {
 
     {
       const stake = await assessment.stakeOf(fraudulentMember.address);
-      expect(stake.amount).to.be.equal(parseEther('67'));
+      expect(stake.amount).to.be.equal(stakeAmount.sub(burnAmount));
       expect(stake.rewardsWithdrawableFromIndex).to.be.equal(1);
     }
 
@@ -912,7 +915,7 @@ describe('processFraud', function () {
 
     {
       const stake = await assessment.stakeOf(fraudulentMember.address);
-      expect(stake.amount).to.be.equal(parseEther('67'));
+      expect(stake.amount).to.be.equal(stakeAmount.sub(burnAmount));
       expect(stake.rewardsWithdrawableFromIndex).to.be.equal(1);
     }
 

--- a/test/unit/Assessment/processFraud.js
+++ b/test/unit/Assessment/processFraud.js
@@ -1,6 +1,6 @@
 const { ethers } = require('hardhat');
 const { expect } = require('chai');
-const { submitFraud, getProof } = require('./helpers');
+const { submitFraud, getProof, finalizePoll } = require('./helpers');
 const { setTime } = require('./helpers');
 
 const { parseEther } = ethers.utils;
@@ -778,5 +778,203 @@ describe('processFraud', function () {
 
   it.skip('consumes less gas to process than the summed fees of the fraudulent voting transactions', async function () {
     // [todo] Move this to integration tests instead
+  });
+
+  it('reverts if system is paused', async function () {
+    const { assessment, master } = this.contracts;
+    const [fraudulentMember] = this.accounts.members;
+
+    await master.setEmergencyPause(true);
+
+    await expect(
+      assessment.processFraud(
+        0, // Index of the merkle tree root hash
+        [],
+        fraudulentMember.address, // The address of the fraudulent assessor
+        1, // The index of the last vote that is considered to be fraudulent
+        parseEther('100'), // The amount of stake to be burned
+        0, // The count of previous fraud attempts by this assessor
+        100, // Maximum iterations per tx
+      ),
+    ).to.be.revertedWith('System is paused');
+  });
+
+  it('allows to set voteBatchSize to 0', async function () {
+    const { assessment, individualClaims } = this.contracts;
+    const governance = this.accounts.governanceContracts[0];
+    const [fraudulentMember] = this.accounts.members;
+
+    await assessment.connect(fraudulentMember).stake(parseEther('100'));
+
+    await individualClaims.submitClaim(0, 0, parseEther('100'), '');
+
+    await assessment.connect(fraudulentMember).castVotes([0], [true], 0);
+
+    const burnAmount = parseEther('33');
+    await submitFraud({
+      assessment,
+      signer: governance,
+      addresses: [fraudulentMember.address],
+      amounts: [burnAmount],
+    });
+
+    {
+      const stake = await assessment.stakeOf(fraudulentMember.address);
+      expect(stake.amount).to.be.equal(parseEther('100'));
+    }
+
+    {
+      const fraudulentAssessment = await assessment.assessments(0);
+      expect(fraudulentAssessment.poll.accepted).to.be.equal(parseEther('100'));
+    }
+
+    await assessment.processFraud(
+      0, // Index of the merkle tree root hash
+      [],
+      fraudulentMember.address, // The address of the fraudulent assessor
+      0, // The index of the last vote that is considered to be fraudulent
+      burnAmount, // The amount of stake to be burned
+      0, // The count of previous fraud attempts by this assessor
+      0, // Maximum iterations per tx
+    );
+
+    {
+      const stake = await assessment.stakeOf(fraudulentMember.address);
+      expect(stake.amount).to.be.equal(parseEther('67'));
+      expect(stake.rewardsWithdrawableFromIndex).to.be.equal(1);
+    }
+
+    {
+      const fraudulentAssessment = await assessment.assessments(0);
+      expect(fraudulentAssessment.poll.accepted).to.be.equal(0);
+    }
+  });
+
+  it('should do nothing when trying to process an already processed fraud', async function () {
+    const { assessment, individualClaims } = this.contracts;
+    const governance = this.accounts.governanceContracts[0];
+    const [fraudulentMember] = this.accounts.members;
+
+    await assessment.connect(fraudulentMember).stake(parseEther('100'));
+
+    await individualClaims.submitClaim(0, 0, parseEther('100'), '');
+
+    await assessment.connect(fraudulentMember).castVotes([0], [true], 0);
+
+    const burnAmount = parseEther('33');
+    await submitFraud({
+      assessment,
+      signer: governance,
+      addresses: [fraudulentMember.address],
+      amounts: [burnAmount],
+    });
+
+    {
+      const stake = await assessment.stakeOf(fraudulentMember.address);
+      expect(stake.amount).to.be.equal(parseEther('100'));
+    }
+
+    {
+      const fraudulentAssessment = await assessment.assessments(0);
+      expect(fraudulentAssessment.poll.accepted).to.be.equal(parseEther('100'));
+    }
+
+    await assessment.processFraud(
+      0, // Index of the merkle tree root hash
+      [],
+      fraudulentMember.address, // The address of the fraudulent assessor
+      0, // The index of the last vote that is considered to be fraudulent
+      burnAmount, // The amount of stake to be burned
+      0, // The count of previous fraud attempts by this assessor
+      100, // Maximum iterations per tx
+    );
+
+    {
+      const stake = await assessment.stakeOf(fraudulentMember.address);
+      expect(stake.amount).to.be.equal(parseEther('67'));
+      expect(stake.rewardsWithdrawableFromIndex).to.be.equal(1);
+    }
+
+    {
+      const fraudulentAssessment = await assessment.assessments(0);
+      expect(fraudulentAssessment.poll.accepted).to.be.equal(0);
+    }
+
+    const tx = await assessment.processFraud(
+      0, // Index of the merkle tree root hash
+      [],
+      fraudulentMember.address, // The address of the fraudulent assessor
+      0, // The index of the last vote that is considered to be fraudulent
+      burnAmount, // The amount of stake to be burned
+      0, // The count of previous fraud attempts by this assessor
+      100, // Maximum iterations per tx
+    );
+
+    {
+      const stake = await assessment.stakeOf(fraudulentMember.address);
+      expect(stake.amount).to.be.equal(parseEther('67'));
+      expect(stake.rewardsWithdrawableFromIndex).to.be.equal(1);
+    }
+
+    {
+      const fraudulentAssessment = await assessment.assessments(0);
+      expect(fraudulentAssessment.poll.accepted).to.be.equal(0);
+    }
+
+    const { events } = await tx.wait();
+    expect(events.length).to.be.equal(0);
+  });
+
+  it('burn all fraudulent member rewards not claimed up to the latest assessment revoked', async function () {
+    const { assessment, individualClaims } = this.contracts;
+    const governance = this.accounts.governanceContracts[0];
+    const [fraudulentMember] = this.accounts.members;
+
+    await assessment.connect(fraudulentMember).stake(parseEther('100'));
+
+    await individualClaims.submitClaim(0, 0, parseEther('100'), '');
+    await individualClaims.submitClaim(1, 0, parseEther('100'), '');
+    await individualClaims.submitClaim(2, 0, parseEther('100'), '');
+    await individualClaims.submitClaim(3, 0, parseEther('100'), '');
+
+    await assessment.connect(fraudulentMember).castVotes([0], [true], 0);
+    await assessment.connect(fraudulentMember).castVotes([1], [true], 0);
+    await assessment.connect(fraudulentMember).castVotes([2], [true], 0);
+    await assessment.connect(fraudulentMember).castVotes([3], [true], 0);
+
+    await finalizePoll(assessment);
+
+    {
+      const rewards = await assessment.getRewards(fraudulentMember.address);
+      expect(rewards.withdrawableAmountInNXM).to.be.gt(0);
+    }
+
+    // Fraudulent claim
+    await individualClaims.submitClaim(4, 0, parseEther('100'), '');
+    await assessment.connect(fraudulentMember).castVotes([4], [true], 0);
+
+    const burnAmount = parseEther('100');
+    await submitFraud({
+      assessment,
+      signer: governance,
+      addresses: [fraudulentMember.address],
+      lastFraudulentVoteIndexes: [4],
+      amounts: [burnAmount],
+    });
+
+    await assessment.processFraud(
+      0, // Index of the merkle tree root hash
+      [], // Proof, empty beacuse the root is also the only leaf
+      fraudulentMember.address, // The address of the fraudulent assessor
+      4, // The index of the last vote that is considered to be fraudulent
+      burnAmount, // The amount of stake to be burned
+      0, // The count of previous fraud attempts by this assessor
+      100, // Maximum iterations per tx
+    );
+
+    {
+      const rewards = await assessment.getRewards(fraudulentMember.address);
+      expect(rewards.withdrawableAmountInNXM).to.be.equal(0);
+    }
   });
 });

--- a/test/unit/Assessment/submitFraud.js
+++ b/test/unit/Assessment/submitFraud.js
@@ -5,8 +5,8 @@ const { arrayify } = ethers.utils;
 describe('submitFraud', function () {
   it('can only be called by governance contract', async function () {
     const { assessment } = this.contracts;
-    const user = this.accounts.members[0];
-    const governance = this.accounts.governanceContracts[0];
+    const [user] = this.accounts.members;
+    const [governance] = this.accounts.governanceContracts;
     const merkleTreeRootMock = arrayify('0x1111111111111111111111111111111111111111111111111111111111111111');
     await expect(assessment.connect(user).submitFraud(merkleTreeRootMock)).to.be.revertedWith(
       'Caller is not authorized to govern',
@@ -14,5 +14,38 @@ describe('submitFraud', function () {
     await expect(assessment.connect(governance).submitFraud(merkleTreeRootMock)).not.to.be.revertedWith(
       'Caller is not authorized to govern',
     );
+  });
+
+  it('Should store the merkle tree root', async function () {
+    const { assessment } = this.contracts;
+    const [governance] = this.accounts.governanceContracts;
+    const merkleTreeRoot = '0x1111111111111111111111111111111111111111111111111111111111111111';
+
+    await assessment.connect(governance).submitFraud(arrayify(merkleTreeRoot));
+
+    expect(await assessment.fraudResolution(0)).to.be.equal(merkleTreeRoot);
+  });
+
+  it('Should emit the event FraudSubmitted', async function () {
+    const { assessment } = this.contracts;
+    const [governance] = this.accounts.governanceContracts;
+    const merkleTreeRoot = '0x1111111111111111111111111111111111111111111111111111111111111111';
+
+    await expect(assessment.connect(governance).submitFraud(arrayify(merkleTreeRoot)))
+      .to.emit(assessment, 'FraudSubmitted')
+      .withArgs(merkleTreeRoot);
+  });
+
+  it("Should allow adding another root even if the existing fraud tree hasn't been processed", async function () {
+    const { assessment } = this.contracts;
+    const [governance] = this.accounts.governanceContracts;
+    const merkleTreeRoot1 = '0x1111111111111111111111111111111111111111111111111111111111111111';
+    const merkleTreeRoot2 = '0x1111111111111111111111111111111111111111111111111111111111111112';
+
+    await assessment.connect(governance).submitFraud(arrayify(merkleTreeRoot1));
+    await assessment.connect(governance).submitFraud(arrayify(merkleTreeRoot2));
+
+    expect(await assessment.fraudResolution(0)).to.be.equal(merkleTreeRoot1);
+    expect(await assessment.fraudResolution(1)).to.be.equal(merkleTreeRoot2);
   });
 });

--- a/test/unit/Assessment/submitFraud.js
+++ b/test/unit/Assessment/submitFraud.js
@@ -16,7 +16,7 @@ describe('submitFraud', function () {
     );
   });
 
-  it('Should store the merkle tree root', async function () {
+  it('should store the merkle tree root', async function () {
     const { assessment } = this.contracts;
     const [governance] = this.accounts.governanceContracts;
     const merkleTreeRoot = '0x1111111111111111111111111111111111111111111111111111111111111111';
@@ -26,7 +26,7 @@ describe('submitFraud', function () {
     expect(await assessment.fraudResolution(0)).to.be.equal(merkleTreeRoot);
   });
 
-  it('Should emit the event FraudSubmitted', async function () {
+  it('should emit the event FraudSubmitted', async function () {
     const { assessment } = this.contracts;
     const [governance] = this.accounts.governanceContracts;
     const merkleTreeRoot = '0x1111111111111111111111111111111111111111111111111111111111111111';
@@ -36,7 +36,7 @@ describe('submitFraud', function () {
       .withArgs(merkleTreeRoot);
   });
 
-  it("Should allow adding another root even if the existing fraud tree hasn't been processed", async function () {
+  it("should allow adding another root even if the existing fraud tree hasn't been processed", async function () {
     const { assessment } = this.contracts;
     const [governance] = this.accounts.governanceContracts;
     const merkleTreeRoot1 = '0x1111111111111111111111111111111111111111111111111111111111111111';


### PR DESCRIPTION
## Context

Closes #431 


## Changes proposed in this pull request

Adds new unit tests for `submitFraud` and `processFraud`. Implemented the list of test cases from the issue.

As part of the testing of `submitFraud` the state variable `fraudResolution` from the `Assessment` contract was changed from `internal` to `public`. This allows verifying the stored fraud merkle tree roots, which should also facilitate getting the root index of the array that needs to be passed as a parameter in the `processFraud` method.

## Test plan

New tests were added in `test/unit/Assessment/submitFraud.js` and `test/unit/Assessment/processFraud.js`


## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
