### PR TITLE
Test/ Add buyCover revert unit tests

### DIFF
--- a/test/unit/Cover/buyCover.js
+++ b/test/unit/Cover/buyCover.js
@@ -929,7 +929,6 @@ describe('buyCover', function () {
 
     const {
       members: [coverBuyer],
-      governanceContracts: [gv1],
     } = this.accounts;
 
     const productId = 0;

--- a/test/unit/Cover/buyCover.js
+++ b/test/unit/Cover/buyCover.js
@@ -2,7 +2,6 @@ const { expect } = require('chai');
 const { ethers } = require('hardhat');
 
 const { createStakingPool, assertCoverFields } = require('./helpers');
-const { bnEqual } = require('../utils').helpers;
 
 const { parseEther } = ethers.utils;
 const { AddressZero } = ethers.constants;
@@ -226,10 +225,10 @@ describe('buyCover', function () {
     const commissionNxmBalanceAfter = await nxm.balanceOf(stakingPoolManager.address);
 
     const difference = nxmBalanceBefore.sub(nxmBalanceAfter);
-    bnEqual(difference, expectedPremium);
+    expect(difference).to.be.equal(expectedPremium);
 
     const commissionDifference = commissionNxmBalanceAfter.sub(commissionNxmBalanceBefore);
-    bnEqual(commissionDifference, expectedCommission);
+    expect(commissionDifference).to.be.equal(expectedCommission);
 
     const expectedCoverId = '0';
 
@@ -314,10 +313,10 @@ describe('buyCover', function () {
     const commissionDaiBalanceAfter = await dai.balanceOf(commissionReceiver.address);
 
     const difference = daiBalanceBefore.sub(daiBalanceAfter);
-    bnEqual(difference, expectedPremium);
+    expect(difference).to.be.equal(expectedPremium);
 
     const commissionDifference = commissionDaiBalanceAfter.sub(commissionDaiBalanceBefore);
-    bnEqual(commissionDifference, expectedCommission);
+    expect(commissionDifference).to.be.equal(expectedCommission);
 
     const expectedCoverId = '0';
 
@@ -403,10 +402,10 @@ describe('buyCover', function () {
     const commissionDaiBalanceAfter = await usdc.balanceOf(commissionReceiver.address);
 
     const difference = daiBalanceBefore.sub(daiBalanceAfter);
-    bnEqual(difference, expectedPremium);
+    expect(difference).to.be.equal(expectedPremium);
 
     const commissionDifference = commissionDaiBalanceAfter.sub(commissionDaiBalanceBefore);
-    bnEqual(commissionDifference, expectedCommission);
+    expect(commissionDifference).to.be.equal(expectedCommission);
 
     const expectedCoverId = '0';
 

--- a/test/unit/Cover/editCover.js
+++ b/test/unit/Cover/editCover.js
@@ -16,8 +16,8 @@ describe('editCover', function () {
 
     amount: parseEther('1000'),
 
-    targetPriceRatio: '260',
-    priceDenominator: '10000',
+    targetPriceRatio: 260,
+    priceDenominator: 10000,
     activeCover: parseEther('5000'),
     capacity: parseEther('10000'),
     capacityFactor: '10000',

--- a/test/unit/Cover/helpers.js
+++ b/test/unit/Cover/helpers.js
@@ -42,18 +42,18 @@ async function createStakingPool(cover, productId, capacity, targetPrice, active
 async function assertCoverFields(
   cover,
   coverId,
-  { productId, coverAsset, period, amount, targetPriceRatio, gracePeriodInDays, segmentId = '0', amountPaidOut = '0' },
+  { productId, coverAsset, period, amount, targetPriceRatio, gracePeriodInDays, segmentId = 0, amountPaidOut = 0 },
 ) {
   const storedCoverData = await cover.coverData(coverId);
 
   const segment = await cover.coverSegments(coverId, segmentId);
   assert.equal(storedCoverData.productId, productId);
   assert.equal(storedCoverData.coverAsset, coverAsset);
-  expect(storedCoverData.amountPaidOut.toString()).to.be.equal(amountPaidOut);
+  expect(storedCoverData.amountPaidOut).to.be.equal(amountPaidOut);
   assert.equal(segment.gracePeriodInDays, gracePeriodInDays);
   assert.equal(segment.period, period);
   assert.equal(segment.amount.toString(), amount.toString());
-  expect(segment.priceRatio.toString()).to.be.equal(targetPriceRatio);
+  expect(segment.priceRatio).to.be.equal(targetPriceRatio);
 }
 
 async function buyCoverOnOnePool({

--- a/test/unit/Cover/helpers.js
+++ b/test/unit/Cover/helpers.js
@@ -1,6 +1,5 @@
 const { ethers } = require('hardhat');
-const { assert } = require('chai');
-const { bnEqual } = require('../../../lib/helpers');
+const { assert, expect } = require('chai');
 
 const { parseEther } = ethers.utils;
 const { AddressZero } = ethers.constants;
@@ -50,11 +49,11 @@ async function assertCoverFields(
   const segment = await cover.coverSegments(coverId, segmentId);
   assert.equal(storedCoverData.productId, productId);
   assert.equal(storedCoverData.coverAsset, coverAsset);
-  bnEqual(storedCoverData.amountPaidOut, amountPaidOut);
+  expect(storedCoverData.amountPaidOut.toString()).to.be.equal(amountPaidOut);
   assert.equal(segment.gracePeriodInDays, gracePeriodInDays);
   assert.equal(segment.period, period);
   assert.equal(segment.amount.toString(), amount.toString());
-  bnEqual(segment.priceRatio, targetPriceRatio);
+  expect(segment.priceRatio.toString()).to.be.equal(targetPriceRatio);
 }
 
 async function buyCoverOnOnePool({

--- a/test/unit/Cover/performStakeBurn.js
+++ b/test/unit/Cover/performStakeBurn.js
@@ -13,8 +13,8 @@ describe('performStakeBurn', function () {
 
     amount: parseEther('1000'),
 
-    targetPriceRatio: '260',
-    priceDenominator: '10000',
+    targetPriceRatio: 260,
+    priceDenominator: 10000,
     activeCover: parseEther('5000'),
     capacity: parseEther('10000'),
     capacityFactor: '10000',


### PR DESCRIPTION
## Context

Partial implementation of #268

## Changes proposed in this pull request

Adds new revert unit tests for `buyCover`. Implemented some of the listed test cases, especially the reverts one.
 
I couldn't find a way to test `Cover: Product not initialized`, it seems that when a product is listed it also initializes the parameters so I couldn't reproduce a state of listed but with `initialPriceRatio = 0` as the code is checking.

Also, I removed the usage of `bnEqual` in the `buyCover` tests as it triggers a warning `Warning: Use Hardhat Chai Matchers instead of bnEqual: https://hardhat.org/hardhat-chai-matchers/docs/overview#big-numbers`

## Test plan

New tests were added in `test/unit/Cover/buyCover.js`


## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
