### PR TITLE
Chore: staking pool management tests stylistic changes

### DIFF
--- a/contracts/mocks/StakingPool/SPMockCover.sol
+++ b/contracts/mocks/StakingPool/SPMockCover.sol
@@ -6,7 +6,7 @@ import "../../interfaces/IStakingPool.sol";
 import "../../interfaces/ICover.sol";
 import "../../modules/cover/CoverUtilsLib.sol";
 
-contract SPMockCoverProducts {
+contract SPMockCover {
   uint24 public constant globalCapacityRatio = 2;
   uint256 public constant globalRewardsRatio = 1;
 

--- a/test/unit/StakingPool/setProducts.js
+++ b/test/unit/StakingPool/setProducts.js
@@ -94,9 +94,8 @@ describe('setProducts unit tests', function () {
 
   it('should fail to be called by non manager', async function () {
     const { stakingPool, cover } = this;
-    const {
-      members: [manager, nonManager],
-    } = this.accounts;
+    const [manager, nonManager] = this.accounts.members;
+
     await initializePool(cover, stakingPool, manager.address, 0, []);
     const product = await initProduct(cover, 100, 100, 100, 0);
     await expect(stakingPool.connect(nonManager).setProducts([product])).to.be.revertedWith(
@@ -106,9 +105,8 @@ describe('setProducts unit tests', function () {
 
   it('should initialize products successfully', async function () {
     const { stakingPool, cover } = this;
-    const {
-      members: [manager],
-    } = this.accounts;
+    const [manager] = this.accounts.members;
+
     let i = 0;
     const initialProducts = Array.from({ length: 20 }, () => getInitialProduct(100, 100, 500, i++));
     await initializePool(cover, stakingPool, manager.address, 0, initialProducts);
@@ -119,9 +117,8 @@ describe('setProducts unit tests', function () {
 
   it('should fail to initialize too many products with full weight', async function () {
     const { stakingPool, cover } = this;
-    const {
-      members: [manager],
-    } = this.accounts;
+    const [manager] = this.accounts.members;
+
     let i = 0;
     const initialProducts = Array.from({ length: 21 }, () => getInitialProduct(100, 100, 500, i++));
     await expect(initializePool(cover, stakingPool, manager.address, 0, initialProducts)).to.be.revertedWith(
@@ -131,9 +128,8 @@ describe('setProducts unit tests', function () {
 
   it('should set products and store values correctly', async function () {
     const { stakingPool, cover } = this;
-    const {
-      members: [manager],
-    } = this.accounts;
+    const [manager] = this.accounts.members;
+
     await initializePool(cover, stakingPool, manager.address, 0, []);
     const product = await initProduct(cover, 50, 100, 100, 0);
     await stakingPool.connect(manager).setProducts([product]);
@@ -156,9 +152,8 @@ describe('setProducts unit tests', function () {
 
   it('should revert if adding a product without setting the targetPrice', async function () {
     const { stakingPool, cover } = this;
-    const {
-      members: [manager],
-    } = this.accounts;
+    const [manager] = this.accounts.members;
+
     await initializePool(cover, stakingPool, manager.address, 0, []);
     const product = await initProduct(cover, 50, 100, 100, 0);
     product.setTargetPrice = false;
@@ -169,9 +164,8 @@ describe('setProducts unit tests', function () {
 
   it('should add and remove products in same tx', async function () {
     const { stakingPool, cover } = this;
-    const {
-      members: [manager],
-    } = this.accounts;
+    const [manager] = this.accounts.members;
+
     const initialPriceRatio = 1000;
     await initializePool(cover, stakingPool, manager.address, 0, []);
     const products = [
@@ -195,9 +189,8 @@ describe('setProducts unit tests', function () {
 
   it('should add maximum products with full weight (20)', async function () {
     const { stakingPool, cover } = this;
-    const {
-      members: [manager],
-    } = this.accounts;
+    const [manager] = this.accounts.members;
+
     await initializePool(cover, stakingPool, manager.address, 0, []);
     let i = 0;
     const products = await Promise.all(Array.from({ length: 20 }, () => initProduct(cover, 999, 100, 100, i++)));
@@ -209,9 +202,8 @@ describe('setProducts unit tests', function () {
 
   it('should fail to add weights beyond 20x', async function () {
     const { stakingPool, cover } = this;
-    const {
-      members: [manager],
-    } = this.accounts;
+    const [manager] = this.accounts.members;
+
     await initializePool(cover, stakingPool, manager.address, 0, []);
     let i = 0;
     const products = await Promise.all(Array.from({ length: 20 }, () => initProduct(cover, 1, 100, 100, i++)));
@@ -230,9 +222,8 @@ describe('setProducts unit tests', function () {
   it('should fail to initialize product with targetWeight greater that 1', async function () {
     const { stakingPool, cover } = this;
     const { GLOBAL_MIN_PRICE_RATIO } = this.config;
-    const {
-      members: [manager],
-    } = this.accounts;
+    const [manager] = this.accounts.members;
+
     const initialProduct = getInitialProduct(101, GLOBAL_MIN_PRICE_RATIO, 1, 1);
     await expect(initializePool(cover, stakingPool, manager.address, 0, [initialProduct])).to.be.revertedWith(
       'StakingPool: Cannot set weight beyond 1',
@@ -241,9 +232,8 @@ describe('setProducts unit tests', function () {
 
   it('should fail to make product weight higher than 1', async function () {
     const { stakingPool, cover } = this;
-    const {
-      members: [manager],
-    } = this.accounts;
+    const [manager] = this.accounts.members;
+
     await initializePool(cover, stakingPool, manager.address, 0, []);
     await expect(
       stakingPool.connect(manager).setProducts([await initProduct(cover, 1, 101, 500, 0)]),
@@ -252,9 +242,8 @@ describe('setProducts unit tests', function () {
 
   it('should edit weights, and skip price', async function () {
     const { stakingPool, cover } = this;
-    const {
-      members: [manager],
-    } = this.accounts;
+    const [manager] = this.accounts.members;
+
     await initializePool(cover, stakingPool, manager.address, 0, []);
     const product = await initProduct(cover, 1, 100, 500, 0);
     await stakingPool.connect(manager).setProducts([product]);
@@ -268,9 +257,8 @@ describe('setProducts unit tests', function () {
 
   it('should not be able to change targetWeight without recalculating effectiveWeight ', async function () {
     const { stakingPool, cover } = this;
-    const {
-      members: [manager],
-    } = this.accounts;
+    const [manager] = this.accounts.members;
+
     await initializePool(cover, stakingPool, manager.address, 0, []);
     const product = await initProduct(cover, 1, 0, 500, 0);
     await stakingPool.connect(manager).setProducts([product]);
@@ -284,9 +272,8 @@ describe('setProducts unit tests', function () {
 
   it('should not use param.targetWeight if not explicityly setting targetWeight', async function () {
     const { stakingPool, cover } = this;
-    const {
-      members: [manager],
-    } = this.accounts;
+    const [manager] = this.accounts.members;
+
     await initializePool(cover, stakingPool, manager.address, 0, []);
     const products = [await initProduct(cover, 1, 0, 200, 0), await initProduct(cover, 1, 100, 200, 1)];
     await stakingPool.connect(manager).setProducts(products);
@@ -306,10 +293,8 @@ describe('setProducts unit tests', function () {
   it('should edit prices and skip weights', async function () {
     const { stakingPool, cover } = this;
     const { GLOBAL_MIN_PRICE_RATIO } = this.config;
-    const {
-      members: [manager],
-    } = this.accounts;
-    const { GLOBAL_MIN_PRICE_RATIO } = this.config;
+    const [manager] = this.accounts.members;
+
     await initializePool(cover, stakingPool, manager.address, 0, []);
     const product = await initProduct(cover, 1, 80, 500, 0);
     product.setTargetWeight = false;
@@ -322,9 +307,8 @@ describe('setProducts unit tests', function () {
 
   it('should fail with targetPrice too high', async function () {
     const { stakingPool, cover } = this;
-    const {
-      members: [manager],
-    } = this.accounts;
+    const [manager] = this.accounts.members;
+
     await initializePool(cover, stakingPool, manager.address, 0, []);
     const product = await initProduct(cover, 1, 80, 10001, 0);
     await expect(stakingPool.connect(manager).setProducts([product])).to.be.revertedWith(
@@ -334,9 +318,8 @@ describe('setProducts unit tests', function () {
 
   it('should fail to initialize products with targetPrice below global minimum', async function () {
     const { stakingPool, cover } = this;
-    const {
-      members: [manager],
-    } = this.accounts;
+    const [manager] = this.accounts.members;
+
     const product = getInitialProduct(100, 1, 10, 0);
     await expect(initializePool(cover, stakingPool, manager.address, 0, [product])).to.be.revertedWith(
       'CoverUtilsLib: Target price below GLOBAL_MIN_PRICE_RATIO',
@@ -346,9 +329,8 @@ describe('setProducts unit tests', function () {
   it('should fail with targetPrice below global min price ratio', async function () {
     const { stakingPool, cover } = this;
     const { GLOBAL_MIN_PRICE_RATIO } = this.config;
-    const {
-      members: [manager],
-    } = this.accounts;
+    const [manager] = this.accounts.members;
+
     await initializePool(cover, stakingPool, manager.address, 0, []);
     const product = await initProduct(cover, 1, 80, GLOBAL_MIN_PRICE_RATIO - 1, 0);
     await expect(stakingPool.connect(manager).setProducts([product])).to.be.revertedWith(
@@ -358,9 +340,8 @@ describe('setProducts unit tests', function () {
 
   it('should fail to add non-existing product', async function () {
     const { stakingPool, cover } = this;
-    const {
-      members: [manager],
-    } = this.accounts;
+    const [manager] = this.accounts.members;
+
     await initializePool(cover, stakingPool, manager.address, 0, []);
     const product = getNewProduct(100, 100, 10);
     await expect(stakingPool.connect(manager).setProducts([product])).to.be.revertedWith(
@@ -370,9 +351,8 @@ describe('setProducts unit tests', function () {
 
   it('should fail to change product weights when fully allocated', async function () {
     const { stakingPool, cover, nxm, tokenController } = this;
-    const {
-      members: [manager, staker, coverBuyer],
-    } = this.accounts;
+    const [manager, staker, coverBuyer] = this.accounts.members;
+
     const amount = parseEther('1');
     await initializePool(cover, stakingPool, manager.address, 0, []);
 
@@ -407,9 +387,7 @@ describe('setProducts unit tests', function () {
 
   it('should fail to change products when fully allocated after initializing', async function () {
     const { stakingPool, cover, nxm, tokenController } = this;
-    const {
-      members: [manager, staker, coverBuyer],
-    } = this.accounts;
+    const [manager, staker, coverBuyer] = this.accounts.members;
     const amount = parseEther('1');
 
     let i = 0;

--- a/test/unit/StakingPool/setProducts.js
+++ b/test/unit/StakingPool/setProducts.js
@@ -13,11 +13,10 @@ describe('setProducts unit tests', function () {
   const initializePool = async function (cover, stakingPool, manager, poolId, productInitParams) {
     // Set products in mock cover contract
     await Promise.all(
-      productInitParams.map(p => {
-        return [
-          cover.setProduct(getCoverProduct(p.initialPrice), p.productId),
-          cover.setProductType(ProductTypeFixture, p.productId),
-        ];
+      productInitParams.map(p => [
+        cover.setProduct(getCoverProduct(p.initialPrice), p.productId),
+        cover.setProductType(ProductTypeFixture, p.productId),
+      ]),
     );
     await cover.initializeStaking(stakingPool.address, manager, false, 5, 5, productInitParams, poolId);
   };

--- a/test/unit/StakingPool/setProducts.js
+++ b/test/unit/StakingPool/setProducts.js
@@ -18,14 +18,13 @@ describe('setProducts unit tests', function () {
           cover.setProduct(getCoverProduct(p.initialPrice), p.productId),
           cover.setProductType(ProductTypeFixture, p.productId),
         ];
-      }),
     );
     await cover.initializeStaking(stakingPool.address, manager, false, 5, 5, productInitParams, poolId);
   };
 
   const depositRequest = async (stakingPool, amount, tokenId, destination) => {
     const block = await ethers.provider.getBlock('latest');
-    const currentTrancheId = parseInt(block.timestamp / daysToSeconds(91));
+    const currentTrancheId = Math.floor(block.timestamp / daysToSeconds(91));
     return {
       amount,
       trancheId: currentTrancheId + 2,
@@ -307,6 +306,7 @@ describe('setProducts unit tests', function () {
 
   it('should edit prices and skip weights', async function () {
     const { stakingPool, cover } = this;
+    const { GLOBAL_MIN_PRICE_RATIO } = this.config;
     const {
       members: [manager],
     } = this.accounts;

--- a/test/unit/StakingPool/setProducts.js
+++ b/test/unit/StakingPool/setProducts.js
@@ -9,13 +9,21 @@ const ProductTypeFixture = {
   gracePeriodInDays: 7,
 };
 
+const coverProductTemplate = {
+  productType: 1,
+  yieldTokenAddress: AddressZero,
+  coverAssets: 1111,
+  initialPriceRatio: 500,
+  capacityReductionRatio: 0,
+};
+
 describe('setProducts unit tests', function () {
   const initializePool = async function (cover, stakingPool, manager, poolId, productInitParams) {
     // Set products in mock cover contract
     await Promise.all(
-      productInitParams.map(p => [
-        cover.setProduct(getCoverProduct(p.initialPrice), p.productId),
-        cover.setProductType(ProductTypeFixture, p.productId),
+      productInitParams.map(({ productId, initialPrice: initialPriceRatio }) => [
+        cover.setProduct({ ...coverProductTemplate, initialPriceRatio }, productId),
+        cover.setProductType(ProductTypeFixture, productId),
       ]),
     );
     await cover.initializeStaking(stakingPool.address, manager, false, 5, 5, productInitParams, poolId);
@@ -51,16 +59,6 @@ describe('setProducts unit tests', function () {
       targetPrice: price,
     };
   };
-  // Cover.Product
-  const getCoverProduct = initialPriceRatio => {
-    return {
-      productType: 1,
-      yieldTokenAddress: AddressZero,
-      coverAssets: 1111,
-      initialPriceRatio,
-      capacityReductionRatio: 0,
-    };
-  };
   const buyCoverParams = (owner, productId, period, amount) => {
     return {
       owner,
@@ -79,7 +77,7 @@ describe('setProducts unit tests', function () {
 
   // Get product and set in cover contract
   const initProduct = async (cover, initialPriceRatio, weight, price, id) => {
-    const coverProduct = getCoverProduct(initialPriceRatio);
+    const coverProduct = { ...coverProductTemplate, initialPriceRatio };
     await cover.setProduct(coverProduct, id);
     return getNewProduct(weight, price, id);
   };

--- a/test/unit/StakingPool/setup.js
+++ b/test/unit/StakingPool/setup.js
@@ -8,7 +8,7 @@ async function setup() {
   const MasterMock = await ethers.getContractFactory('MasterMock');
   const ERC20Mock = await ethers.getContractFactory('ERC20Mock');
   const QuotationData = await ethers.getContractFactory('CoverMockQuotationData');
-  const SPCoverProducts = await ethers.getContractFactory('SPMockCoverProducts');
+  const SPCoverProducts = await ethers.getContractFactory('SPMockCover');
   const MemberRolesMock = await ethers.getContractFactory('MemberRolesMock');
   const TokenController = await ethers.getContractFactory('TokenControllerMock');
   const NXMToken = await ethers.getContractFactory('NXMTokenMock');


### PR DESCRIPTION
## Context
closes #460 


## Changes proposed in this pull request
This PR refactors the StakingPool.setProducts unit tests.


## Test plan
`test/unit/StakingPool/setProducts.js`


## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [x] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
