### PR TITLE
Test/ Add IndividualClaims tests

### DIFF
--- a/contracts/mocks/Claims/CLMockPool.sol
+++ b/contracts/mocks/Claims/CLMockPool.sol
@@ -45,8 +45,8 @@ contract CLMockPool {
     }
   }
 
-  fallback() external payable {}
+  fallback() external payable virtual {}
 
-  receive() external payable {}
+  receive() external payable virtual {}
 
 }

--- a/contracts/mocks/Claims/CLMockPoolEtherRejecter.sol
+++ b/contracts/mocks/Claims/CLMockPoolEtherRejecter.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity ^0.8.16;
+
+import "./CLMockPool.sol";
+
+contract CLMockPoolEtherRejecter is CLMockPool {
+  receive() external payable override {
+    revert("I secretly hate ether");
+  }
+
+  fallback() external payable override {
+    revert("I secretly hate ether");
+  }
+}

--- a/contracts/modules/assessment/IndividualClaims.sol
+++ b/contracts/modules/assessment/IndividualClaims.sol
@@ -25,8 +25,8 @@ contract IndividualClaims is IIndividualClaims, MasterAwareV2 {
   // Used in operations involving NXM tokens and divisions
   uint internal constant PRECISION = 10 ** 18;
 
-  INXMToken internal immutable nxm;
-  ICoverNFT internal immutable coverNFT;
+  INXMToken public immutable nxm;
+  ICoverNFT public immutable coverNFT;
 
   /* ========== STATE VARIABLES ========== */
 

--- a/test/unit/IndividualClaims/constructor.js
+++ b/test/unit/IndividualClaims/constructor.js
@@ -1,0 +1,17 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+
+describe('constructor', function () {
+  it('should set nxm and coverNFT addresses correctly', async function () {
+    const { nxm, coverNFT } = this.contracts;
+
+    const IndividualClaims = await ethers.getContractFactory('IndividualClaims');
+    const individualClaims = await IndividualClaims.deploy(nxm.address, coverNFT.address);
+
+    const nxmAddress = await individualClaims.nxm();
+    const coverNFTAddress = await individualClaims.coverNFT();
+
+    expect(nxmAddress).to.be.equal(nxm.address);
+    expect(coverNFTAddress).to.be.equal(coverNFT.address);
+  });
+});

--- a/test/unit/IndividualClaims/index.js
+++ b/test/unit/IndividualClaims/index.js
@@ -12,6 +12,7 @@ describe('IndividualClaims', function () {
     await revertToSnapshot(this.snapshotId);
   });
 
+  require('./constructor');
   require('./initialize');
   require('./submitClaim');
   require('./redeemClaimPayout');

--- a/test/unit/IndividualClaims/initialize.js
+++ b/test/unit/IndividualClaims/initialize.js
@@ -1,8 +1,31 @@
 const { expect } = require('chai');
+const { ethers } = require('hardhat');
 
 describe('initialize', function () {
   it('reverts if the contract was already initialized', async function () {
     const { individualClaims } = this.contracts;
     await expect(individualClaims.initialize()).to.be.revertedWith('Already initialized');
+  });
+
+  it('should set config parameters', async function () {
+    const { nxm, coverNFT } = this.contracts;
+
+    const IndividualClaims = await ethers.getContractFactory('IndividualClaims');
+    const individualClaims = await IndividualClaims.deploy(nxm.address, coverNFT.address);
+
+    const preInitializeConfig = await individualClaims.config();
+
+    expect(preInitializeConfig.rewardRatio).to.be.equal(0);
+    expect(preInitializeConfig.maxRewardInNXMWad).to.be.equal(0);
+    expect(preInitializeConfig.minAssessmentDepositRatio).to.be.equal(0);
+    expect(preInitializeConfig.payoutRedemptionPeriodInDays).to.be.equal(0);
+
+    await individualClaims.initialize();
+    const afterInitializeConfig = await individualClaims.config();
+
+    expect(afterInitializeConfig.rewardRatio).to.be.equal(130);
+    expect(afterInitializeConfig.maxRewardInNXMWad).to.be.equal(50);
+    expect(afterInitializeConfig.minAssessmentDepositRatio).to.be.equal(500);
+    expect(afterInitializeConfig.payoutRedemptionPeriodInDays).to.be.equal(14);
   });
 });

--- a/test/unit/IndividualClaims/redeemClaimPayout.js
+++ b/test/unit/IndividualClaims/redeemClaimPayout.js
@@ -200,10 +200,9 @@ describe('redeemClaimPayout', function () {
     const { payoutCooldownInDays } = await assessment.config();
     await setTime(poll.end + daysToSeconds(payoutCooldownInDays));
 
-    await expect(individualClaims.connect(coverOwner).redeemClaimPayout(0)).to.emit(
-      individualClaims,
-      'ClaimPayoutRedeemed',
-    );
+    await expect(individualClaims.connect(coverOwner).redeemClaimPayout(0))
+      .to.emit(individualClaims, 'ClaimPayoutRedeemed')
+      .withArgs(coverOwner.address, parseEther('1'), 0, 0);
   });
 
   it("sets the claim's payoutRedeemed property to true", async function () {

--- a/test/unit/IndividualClaims/setup.js
+++ b/test/unit/IndividualClaims/setup.js
@@ -98,6 +98,7 @@ async function setup() {
     distributor,
     coverNFT,
     master,
+    memberRoles,
   };
 }
 

--- a/test/unit/IndividualClaims/submitClaim.js
+++ b/test/unit/IndividualClaims/submitClaim.js
@@ -606,9 +606,9 @@ describe('submitClaim', function () {
 
     const coverId = 0;
     const [deposit] = await individualClaims.getAssessmentDepositAndReward(segment.amount, segment.period, ASSET.ETH);
-    expect(
-      await individualClaims.connect(coverOwner).submitClaim(coverId, 0, segment.amount, '', { value: deposit }),
-    ).to.emit(individualClaims, 'ClaimSubmitted');
+    await expect(individualClaims.connect(coverOwner).submitClaim(coverId, 0, segment.amount, '', { value: deposit }))
+      .to.emit(individualClaims, 'ClaimSubmitted')
+      .withArgs(coverOwner.address, 0, coverId, 0);
   });
 
   it('should revert if ETH refund fails', async function () {


### PR DESCRIPTION
## Context

Closes #433

## Changes proposed in this pull request

Adds new unit tests for the constructor, initialize, submitClaim and redeemClaimPayout. Implemented the list of test cases from the issue. nxm and coverNFT were changed to public in `IndividualClaims` contract to be able to fetch it for testing. 

A new mock `CLMockPoolEtherRejecter` was added extending the one that was used in the setup to have available the necessary pool methods used inside `submitClaim` but also to revert on`fallback/receive` to test that.


## Test plan

New tests were added in `test/unit/IndividualClaims/initialize.js`,`test/unit/IndividualClaims/constructor.js`, `test/unit/IndividualClaims/submitClaim.js` and `test/unit/IndividualClaims/redeemClaimPayout.js`


## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
