### PR TITLE
Fix: check weight on all tranches

### DIFF
--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -29,7 +29,6 @@ enum CoverUintParams {
   coverAssetsFallback
 }
 
-
 struct PoolAllocationRequest {
   uint40 poolId;
   uint coverAmountInAsset;
@@ -71,31 +70,15 @@ struct BuyCoverParams {
   string ipfsData;
 }
 
-struct IncreaseAmountAndReducePeriodParams {
-  uint coverId;
-  uint32 periodReduction;
-  uint96 amount;
-  uint8 paymentAsset;
-  uint maxPremiumInAsset;
-}
-
 struct ProductBucket {
   uint96 coverAmountExpiring;
-}
-
-struct IncreaseAmountParams {
-  uint coverId;
-  uint8 paymentAsset;
-  PoolAllocationRequest[] coverChunkRequests;
 }
 
 struct Product {
   uint16 productType;
   address yieldTokenAddress;
-  /*
-    cover assets bitmap. each bit in the base-2 representation represents whether the asset with the index
-    of that bit is enabled as a cover asset for this product.
-  */
+  // cover assets bitmap. each bit represents whether the asset with
+  // the index of that bit is enabled as a cover asset for this product
   uint32 coverAssets;
   uint16 initialPriceRatio;
   uint16 capacityReductionRatio;

--- a/contracts/mocks/StakingPool/SPMockCover.sol
+++ b/contracts/mocks/StakingPool/SPMockCover.sol
@@ -7,8 +7,9 @@ import "../../interfaces/ICover.sol";
 import "../../modules/cover/CoverUtilsLib.sol";
 
 contract SPMockCover {
-  uint24 public constant globalCapacityRatio = 2;
-  uint256 public constant globalRewardsRatio = 1;
+
+  uint public constant globalCapacityRatio = 20000;
+  uint public constant globalRewardsRatio = 5000;
 
   uint public constant GLOBAL_MIN_PRICE_RATIO = 100; // 1%
 
@@ -28,17 +29,18 @@ contract SPMockCover {
     productTypes[id] = product;
   }
 
-
   function getPriceAndCapacityRatios(uint[] calldata productIds) public view returns (
     uint _globalCapacityRatio,
     uint _globalMinPriceRatio,
     uint[] memory _initialPrices,
     uint[] memory _capacityReductionRatios
   ) {
-    _globalCapacityRatio = uint(globalCapacityRatio);
+
+    _globalCapacityRatio = globalCapacityRatio;
     _globalMinPriceRatio = GLOBAL_MIN_PRICE_RATIO;
     _capacityReductionRatios = new uint[](productIds.length);
     _initialPrices  = new uint[](productIds.length);
+
     for (uint i = 0; i < productIds.length; i++) {
       Product memory product = products[productIds[i]];
       require(product.initialPriceRatio > 0, "Cover: Product deprecated or not initialized");

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -637,10 +637,10 @@ contract StakingPool is IStakingPool, ERC721 {
         trancheAllocations
       );
 
-      uint targetBucketId =
-        (block.timestamp + request.period + request.gracePeriod)
-        / BUCKET_DURATION
-        + 1;
+      uint targetBucketId = Math.divCeil(
+        block.timestamp + request.period + request.gracePeriod,
+        BUCKET_DURATION
+      );
 
       updateExpiringCoverAmounts(
         request.coverId,
@@ -750,7 +750,7 @@ contract StakingPool is IStakingPool, ERC721 {
         request.productId,
         firstTrancheIdToUse,
         trancheCount,
-        gracePeriodExpiration / BUCKET_DURATION + 1,
+        Math.divCeil(gracePeriodExpiration, BUCKET_DURATION),
         coverTrancheAllocation,
         false // isAllocation
       );
@@ -1447,6 +1447,7 @@ contract StakingPool is IStakingPool, ERC721 {
     uint targetPrice
   ) {
 
+    // TODO: this is probably wrong, needs to be reimplemented
     uint maxTranches = maxCoverPeriod / TRANCHE_DURATION + 1;
     staked = new uint[](maxTranches);
 

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -945,24 +945,26 @@ contract StakingPool is IStakingPool, ERC721 {
       * CAPACITY_REDUCTION_DENOMINATOR
       * WEIGHT_DENOMINATOR;
 
-    uint _firstActiveTrancheId = block.timestamp / TRANCHE_DURATION;
+    uint lastTrancheId = (block.timestamp / TRANCHE_DURATION) + MAX_ACTIVE_TRANCHES - 1;
 
-    for (uint i = 0; i < MAX_ACTIVE_TRANCHES; i++) {
-      // SLOAD
-      uint trancheId = _firstActiveTrancheId + i;
-      uint trancheStakeShares = tranches[trancheId].stakeShares;
+    for (
+      uint trancheId = block.timestamp / TRANCHE_DURATION;
+      trancheId <= lastTrancheId;
+      trancheId++
+    ) {
+
       uint trancheCapacity =
-        (_activeStake * trancheStakeShares / _stakeSharesSupply) // tranche stake
+        (_activeStake * tranches[trancheId].stakeShares / _stakeSharesSupply) // tranche stake
         * multiplier
         / denominator
         / NXM_PER_ALLOCATION_UNIT;
 
       if (trancheId >= firstTrancheId) {
+        trancheCapacities[trancheId - firstTrancheId] = trancheCapacity;
         requestedTranchesCapacity += trancheCapacity;
       }
 
       totalCapacity += trancheCapacity;
-      trancheCapacities[i] = trancheCapacity;
     }
 
     return (trancheCapacities, requestedTranchesCapacity, totalCapacity);

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -650,7 +650,11 @@ contract StakingPool is IStakingPool, ERC721 {
         trancheAllocations
       );
 
-      uint targetBucketId = (block.timestamp + request.period + request.gracePeriod) / BUCKET_DURATION + 1;
+      uint targetBucketId;
+      {
+        uint gracePeriodExpiration = block.timestamp + request.period + request.gracePeriod;
+        targetBucketId = gracePeriodExpiration / BUCKET_DURATION + 1;
+      }
 
       updateExpiringCoverAmounts(
         request.coverId,

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -929,7 +929,7 @@ contract StakingPool is IStakingPool, ERC721 {
     uint totalCapacity
   ) {
 
-    uint _activeStake = Math.divCeil(activeStake, 1e12);
+    uint _activeStake = activeStake;
     uint _stakeSharesSupply = stakeSharesSupply;
 
     if (_stakeSharesSupply == 0) {
@@ -951,7 +951,7 @@ contract StakingPool is IStakingPool, ERC721 {
       uint trancheId = _firstActiveTrancheId + i;
       uint trancheStakeShares = tranches[trancheId].stakeShares;
       uint trancheStake = _activeStake * trancheStakeShares / _stakeSharesSupply;
-      uint trancheCapacity = trancheStake * multiplier / denominator;
+      uint trancheCapacity = trancheStake * multiplier / denominator / NXM_PER_ALLOCATION_UNIT;
 
       if (trancheId >= firstTrancheId) {
         requestedTranchesCapacity += trancheCapacity;

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -47,7 +47,6 @@ contract StakingPool is IStakingPool, ERC721 {
   // applies to active stake only and does not need update on deposits
   uint public rewardPerSecond;
 
-  // TODO: this should be allowed to overflow (similar to uniswapv2 twap)
   // accumulated rewarded nxm per reward share
   uint public accNxmPerRewardsShare;
 

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -890,7 +890,12 @@ contract StakingPool is IStakingPool, ERC721 {
     return (allocatedCapacities, allocatedCapacity);
   }
 
-  function getTotalCapacitiesForActiveTranches(uint productId, uint24 globalCapacityRatio, uint16 capacityReductionRatio) public view returns (uint[] memory totalCapacities, uint totalCapacity) {
+  function getTotalCapacitiesForActiveTranches(
+    uint productId,
+    uint globalCapacityRatio,
+    uint capacityReductionRatio
+  ) public view returns (uint[] memory totalCapacities, uint totalCapacity) {
+
     uint firstTrancheIdToUse = block.timestamp / TRANCHE_DURATION;
 
     (totalCapacities, totalCapacity) = getTotalCapacitiesForTranches(

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -381,7 +381,7 @@ contract StakingPool is IStakingPool, ERC721 {
         address to = request.destination == address(0) ? msg.sender : request.destination;
         _mint(to, tokenIds[i]);
       } else {
-        // TODO: make sure the token is already minted
+        require(ownerOf(request.tokenId) != address(0), "StakingPool: Token does not exist");
         tokenIds[i] = request.tokenId;
       }
 

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -102,13 +102,14 @@ contract StakingPool is IStakingPool, ERC721 {
   uint public constant BUCKET_DURATION = 28 days;
   uint public constant TRANCHE_DURATION = 91 days;
   uint public constant MAX_ACTIVE_TRANCHES = 8; // 7 whole quarters + 1 partial quarter
+
   uint public constant COVER_TRANCHE_GROUP_SIZE = 4;
   uint public constant BUCKET_TRANCHE_GROUP_SIZE = 8;
-  uint public constant MAX_WEIGHT_MULTIPLIER = 20;
 
   uint public constant REWARD_BONUS_PER_TRANCHE_RATIO = 10_00; // 10.00%
   uint public constant REWARD_BONUS_PER_TRANCHE_DENOMINATOR = 100_00;
   uint public constant WEIGHT_DENOMINATOR = 100;
+  uint public constant MAX_WEIGHT_MULTIPLIER = 20;
   uint public constant MAX_TOTAL_WEIGHT = WEIGHT_DENOMINATOR * MAX_WEIGHT_MULTIPLIER;
   uint public constant REWARDS_DENOMINATOR = 100_00;
   uint public constant POOL_FEE_DENOMINATOR = 100;

--- a/contracts/modules/staking/StakingTypesLib.sol
+++ b/contracts/modules/staking/StakingTypesLib.sol
@@ -2,9 +2,12 @@
 
 pragma solidity ^0.8.9;
 
-// 4 x (uint48 activeCoverAmount, uint16 lastBucketId)
-type CoverAmountGroup is uint;
+// 1 x (uint48 activeCoverAmount, uint16 lastBucketId)
 type CoverAmount is uint64;
+
+// 4 x CoverAmount
+type CoverAmountGroup is uint;
+
 // 8 x (uint32 expiringCoverAmount)
 type BucketTrancheGroup is uint;
 

--- a/test/integration/Cover/expireCover.js
+++ b/test/integration/Cover/expireCover.js
@@ -50,7 +50,7 @@ describe('expireCover', function () {
       {
         amount: stakingAmount,
         trancheId: firstTrancheId,
-        tokenId: 1, // new position
+        tokenId: 0, // new position
         destination: AddressZero,
       },
     ]);

--- a/test/integration/IndividualClaims/submitClaim.js
+++ b/test/integration/IndividualClaims/submitClaim.js
@@ -70,7 +70,7 @@ describe('submitClaim', function () {
       {
         amount: stakingAmount,
         trancheId: firstTrancheId,
-        tokenId: 1, // new position
+        tokenId: 0, // new position
         destination: AddressZero,
       },
     ]);

--- a/test/integration/YieldTokenIncidents/submitClaim.js
+++ b/test/integration/YieldTokenIncidents/submitClaim.js
@@ -41,7 +41,7 @@ describe('submitClaim', function () {
       {
         amount: stakingAmount,
         trancheId: firstTrancheId,
-        tokenId: 1, // new position
+        tokenId: 0, // new position
         destination: AddressZero,
       },
     ]);

--- a/test/unit/StakingPool/setProducts.js
+++ b/test/unit/StakingPool/setProducts.js
@@ -490,7 +490,7 @@ describe('setProducts unit tests', function () {
     await stakingPool.connect(staker).depositTo([request]);
 
     const ratio = await cover.getPriceAndCapacityRatios([0]);
-    const { totalCapacity } = await stakingPool.getTotalCapacitiesForActiveTranches(
+    const { totalCapacity } = await stakingPool.getActiveTrancheCapacities(
       0,
       ratio._globalCapacityRatio,
       ratio._capacityReductionRatios[0],


### PR DESCRIPTION
Fixes #448

## Context

Previously we weren't reading the capacities and allocations for all the tranches when allocating stake for a particular cover which could result in situations where the allocations could happen above the target weight.

## Changes proposed in this pull request

This PR ensures that we read all active tranches (capacity and allocations) in order to calculate the actual weight of the product.

## Test plan

Currently there are no tests and there's another issue that will modify the allocateStake function. The tests for the next PR should cover this one as well.

## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [ ] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
