### PR TITLE
Test: Add active cover amount tracking unit tests

### DIFF
--- a/test/unit/Cover/commitActiveCoverAmounts.js
+++ b/test/unit/Cover/commitActiveCoverAmounts.js
@@ -1,0 +1,41 @@
+const { expect } = require('chai');
+
+describe('commitActiveCoverAmounts', function () {
+  it('sets active cover amount commited to true', async function () {
+    const { cover } = this;
+
+    const { emergencyAdmin } = this.accounts;
+
+    {
+      const activeCoverAmountCommitted = await cover.activeCoverAmountCommitted();
+      expect(activeCoverAmountCommitted).to.be.equal(false);
+    }
+
+    await cover.connect(emergencyAdmin).commitActiveCoverAmounts();
+
+    {
+      const activeCoverAmountCommitted = await cover.activeCoverAmountCommitted();
+      expect(activeCoverAmountCommitted).to.be.equal(true);
+    }
+  });
+
+  it('reverts if caller is not emergency admin', async function () {
+    const { cover } = this;
+    const {
+      members: [member],
+    } = this.accounts;
+
+    await expect(cover.connect(member).commitActiveCoverAmounts()).to.be.revertedWith('Caller is not emergency admin');
+  });
+
+  it('reverts if active cover amounts already committed', async function () {
+    const { cover } = this;
+    const { emergencyAdmin } = this.accounts;
+
+    await cover.connect(emergencyAdmin).commitActiveCoverAmounts();
+
+    await expect(cover.connect(emergencyAdmin).commitActiveCoverAmounts()).to.be.revertedWith(
+      'Cover: activeCoverAmountCommitted is already true',
+    );
+  });
+});

--- a/test/unit/Cover/enableActiveCoverAmountTracking.js
+++ b/test/unit/Cover/enableActiveCoverAmountTracking.js
@@ -1,0 +1,123 @@
+const { expect } = require('chai');
+
+describe('enableActiveCoverAmountTracking', function () {
+  it('enables cover amount tracking', async function () {
+    const { cover } = this;
+
+    const { emergencyAdmin } = this.accounts;
+
+    {
+      const coverAmountTrackingEnabled = await cover.coverAmountTrackingEnabled();
+      expect(coverAmountTrackingEnabled).to.be.equal(false);
+    }
+
+    await cover.connect(emergencyAdmin).enableActiveCoverAmountTracking([], []);
+
+    {
+      const coverAmountTrackingEnabled = await cover.coverAmountTrackingEnabled();
+      expect(coverAmountTrackingEnabled).to.be.equal(true);
+    }
+  });
+
+  it('sets total active cover for each asset', async function () {
+    const { cover } = this;
+
+    const { emergencyAdmin } = this.accounts;
+
+    {
+      const totalAsset0 = await cover.totalActiveCoverInAsset(0);
+      const totalAsset1 = await cover.totalActiveCoverInAsset(1);
+      expect(totalAsset0).to.be.equal(0);
+      expect(totalAsset1).to.be.equal(0);
+    }
+
+    await cover.connect(emergencyAdmin).enableActiveCoverAmountTracking([0, 1], [100, 200]);
+
+    {
+      const totalAsset0 = await cover.totalActiveCoverInAsset(0);
+      const totalAsset1 = await cover.totalActiveCoverInAsset(1);
+      expect(totalAsset0).to.be.equal(100);
+      expect(totalAsset1).to.be.equal(200);
+    }
+  });
+
+  it('can be called multiple times', async function () {
+    const { cover } = this;
+
+    const { emergencyAdmin } = this.accounts;
+
+    {
+      const totalAsset = await cover.totalActiveCoverInAsset(0);
+      expect(totalAsset).to.be.equal(0);
+    }
+
+    await cover.connect(emergencyAdmin).enableActiveCoverAmountTracking([0], [100]);
+
+    {
+      const totalAsset = await cover.totalActiveCoverInAsset(0);
+      expect(totalAsset).to.be.equal(100);
+    }
+
+    await cover.connect(emergencyAdmin).enableActiveCoverAmountTracking([0], [200]);
+
+    {
+      const totalAsset = await cover.totalActiveCoverInAsset(0);
+      expect(totalAsset).to.be.equal(200);
+    }
+
+    await cover.connect(emergencyAdmin).enableActiveCoverAmountTracking([0], [100]);
+
+    {
+      const totalAsset = await cover.totalActiveCoverInAsset(0);
+      expect(totalAsset).to.be.equal(100);
+    }
+  });
+
+  it('reverts if caller is not emergency admin', async function () {
+    const { cover } = this;
+    const {
+      members: [member],
+    } = this.accounts;
+
+    await expect(cover.connect(member).enableActiveCoverAmountTracking([], [])).to.be.revertedWith(
+      'Caller is not emergency admin',
+    );
+  });
+
+  it('reverts if not valid array inputs lengths', async function () {
+    const { cover } = this;
+    const { emergencyAdmin } = this.accounts;
+
+    await expect(cover.connect(emergencyAdmin).enableActiveCoverAmountTracking([0], [1, 1])).to.be.revertedWith(
+      'Cover: Array lengths must not be different',
+    );
+  });
+
+  it('reverts if active cover amounts already committed', async function () {
+    const { cover } = this;
+    const { emergencyAdmin } = this.accounts;
+
+    await cover.connect(emergencyAdmin).enableActiveCoverAmountTracking([], []);
+    await cover.connect(emergencyAdmin).commitActiveCoverAmounts();
+
+    await expect(cover.connect(emergencyAdmin).enableActiveCoverAmountTracking([], [])).to.be.revertedWith(
+      'Cover: activeCoverAmountCommitted is already true',
+    );
+  });
+
+  it('reverts if active cover amounts already committed, even if cover tracking was never enabled', async function () {
+    const { cover } = this;
+    const { emergencyAdmin } = this.accounts;
+
+    await cover.connect(emergencyAdmin).commitActiveCoverAmounts();
+
+    {
+      const coverAmountTrackingEnabled = await cover.coverAmountTrackingEnabled();
+      expect(coverAmountTrackingEnabled).to.be.equal(false);
+    }
+
+    await expect(cover.connect(emergencyAdmin).enableActiveCoverAmountTracking([], [])).to.be.revertedWith(
+      'Cover: activeCoverAmountCommitted is already true',
+    );
+  });
+});

--- a/test/unit/Cover/expireCover.js
+++ b/test/unit/Cover/expireCover.js
@@ -1,11 +1,10 @@
-const { assert, expect } = require('chai');
+const { expect } = require('chai');
 const {
   ethers: {
     utils: { parseEther },
   },
 } = require('hardhat');
 const { buyCoverOnOnePool } = require('./helpers');
-const { bnEqual } = require('../utils').helpers;
 const { time } = require('@openzeppelin/test-helpers');
 
 describe('expireCover', function () {
@@ -40,14 +39,44 @@ describe('expireCover', function () {
 
     const coverId = 0;
 
-    await cover.expireCover(0);
+    await cover.expireCover(coverId);
 
     const activeCoverAmountAfterExpiry = await cover.totalActiveCoverInAsset(coverAsset);
-    bnEqual(activeCoverAmountAfterExpiry, parseEther('0'));
+    expect(activeCoverAmountAfterExpiry).to.be.equal(0);
 
     const segmentId = '0';
     const segment = await cover.coverSegments(coverId, segmentId);
-    assert(segment.expired, true);
+    expect(segment.expired).to.be.equal(true);
+  });
+
+  it('allows anyone to call this method', async function () {
+    const { cover } = this;
+
+    const {
+      generalPurpose: [anyone],
+      emergencyAdmin,
+    } = this.accounts;
+
+    const { coverAsset } = ethCoverBuyFixture;
+
+    await cover.connect(emergencyAdmin).enableActiveCoverAmountTracking([], []);
+
+    await cover.connect(emergencyAdmin).commitActiveCoverAmounts();
+
+    await buyCoverOnOnePool.call(this, ethCoverBuyFixture);
+
+    await time.increase(ethCoverBuyFixture.period + 1);
+
+    const coverId = 0;
+
+    await cover.connect(anyone).expireCover(coverId);
+
+    const activeCoverAmountAfterExpiry = await cover.totalActiveCoverInAsset(coverAsset);
+    expect(activeCoverAmountAfterExpiry).to.be.equal(0);
+
+    const segmentId = '0';
+    const segment = await cover.coverSegments(coverId, segmentId);
+    expect(segment.expired).to.be.equal(true);
   });
 
   it('reverts when attempting to expire twice', async function () {
@@ -92,5 +121,36 @@ describe('expireCover', function () {
     await time.increase(ethCoverBuyFixture.period - 3600);
 
     await expect(cover.expireCover(0)).to.be.revertedWith('Cover: Cover is not due to expire yet');
+  });
+
+  it('reverts if invalid cover id', async function () {
+    const { cover } = this;
+
+    const { emergencyAdmin } = this.accounts;
+
+    await cover.connect(emergencyAdmin).enableActiveCoverAmountTracking([], []);
+    await cover.connect(emergencyAdmin).commitActiveCoverAmounts();
+
+    const coverId = 150;
+
+    // Reverts when trying to get last cover segment index
+    // panic code 0x11 (Arithmetic operation underflowed or overflowed outside of an unchecked block)
+    await expect(cover.expireCover(coverId)).to.be.revertedWithPanic('0x11');
+  });
+
+  it('emits CoverExpired event', async function () {
+    const { cover } = this;
+
+    const { emergencyAdmin } = this.accounts;
+
+    await cover.connect(emergencyAdmin).enableActiveCoverAmountTracking([], []);
+    await cover.connect(emergencyAdmin).commitActiveCoverAmounts();
+
+    await buyCoverOnOnePool.call(this, ethCoverBuyFixture);
+    await time.increase(ethCoverBuyFixture.period + 1);
+
+    const coverId = 0;
+
+    await expect(cover.expireCover(coverId)).to.emit(cover, 'CoverExpired').withArgs(coverId, 0);
   });
 });

--- a/test/unit/Cover/index.js
+++ b/test/unit/Cover/index.js
@@ -23,4 +23,6 @@ describe('Cover unit tests', function () {
   require('./editProducts');
   require('./addProducts');
   require('./editProductTypes');
+  require('./enableActiveCoverAmountTracking');
+  require('./commitActiveCoverAmounts');
 });


### PR DESCRIPTION
## Context

Relates to #278 


## Changes proposed in this pull request

Adds new unit tests for `enableActiveCoverAmountTracking`, `commitActiveCoverAmounts`, and `expireCover`. Implemented the list of test cases from the issue, except for the following ones that are going to be submitted in another PR as integration tests:
- `Should expire a cover that had a claim paid out fully`
- `Should expire a cover that had partial claim paid out`
- `Should expire a cover that had rejected claim`

## Test plan

New tests were added in `test/unit/Cover/enableActiveCoverAmountTracking.js`, `test/unit/Cover/commitActiveCoverAmounts.js` and `test/unit/Cover/expireCover.js`


## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
