### PR TITLE
Feature: Allow managers to lower targetWeights even if effectiveWeight is exceeded

### DIFF
--- a/contracts/interfaces/IStakingPool.sol
+++ b/contracts/interfaces/IStakingPool.sol
@@ -73,7 +73,7 @@ interface IStakingPool {
   }
 
   struct StakedProduct {
-    uint8 lastEffectiveWeight;
+    uint16 lastEffectiveWeight;
     uint8 targetWeight;
     uint96 targetPrice;
     uint96 nextPrice;

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -1315,8 +1315,8 @@ contract StakingPool is IStakingPool, ERC721 {
   function recalculateEffectiveWeights(uint[] calldata productIds) external {
     (
     uint globalCapacityRatio,
-    uint globalMinPriceRatio,
-    uint[] memory initialPriceRatios,
+    /* globalMinPriceRatio */,
+    /* initialPriceRatios */,
     uint[] memory capacityReductionRatios
     ) = ICover(coverContract).getPriceAndCapacityRatios(productIds);
 

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -1645,7 +1645,7 @@ function setProducts(StakedProductParam[] memory params) external onlyManager {
       : 0;
 
     effectiveWeight = actualWeight > type(uint16).max
-      ? uint16(WEIGHT_DENOMINATOR)
-      : (Math.max(targetWeight, actualWeight)).toUint16();
+      ? uint16(type(uint16).max)
+      : Math.max(targetWeight, actualWeight).toUint16();
   }
 }

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -1326,7 +1326,7 @@ contract StakingPool is IStakingPool, ERC721 {
       uint productId = productIds[i];
       StakedProduct memory _product = products[productId];
 
-      uint8 previousEffectiveWeight = _product.lastEffectiveWeight;
+      uint16 previousEffectiveWeight = _product.lastEffectiveWeight;
       _product.lastEffectiveWeight = _getEffectiveWeight(
         productId,
         _product.targetWeight,
@@ -1393,7 +1393,7 @@ function setProducts(StakedProductParam[] memory params) external onlyManager {
           _product.targetWeight = _param.targetWeight;
         }
 
-        uint8 previousEffectiveWeight = _product.lastEffectiveWeight;
+        uint16 previousEffectiveWeight = _product.lastEffectiveWeight;
         _product.lastEffectiveWeight = _getEffectiveWeight(
           _param.productId,
           _product.targetWeight,
@@ -1405,8 +1405,8 @@ function setProducts(StakedProductParam[] memory params) external onlyManager {
       products[_param.productId] = _product;
     }
 
-    if (_totalEffectiveWeight > MAX_TOTAL_WEIGHT) {
-      require(!targetWeightIncreased, "StakingPool: Total max effective weight exceeded");
+    if (targetWeightIncreased) {
+      require(_totalEffectiveWeight <= MAX_TOTAL_WEIGHT, "StakingPool: Total max effective weight exceeded");
     }
     totalTargetWeight = _totalTargetWeight.toUint32();
     totalEffectiveWeight = _totalEffectiveWeight.toUint32();
@@ -1623,7 +1623,7 @@ function setProducts(StakedProductParam[] memory params) external onlyManager {
     uint targetWeight,
     uint globalCapacityRatio,
     uint capacityReductionRatio
-  ) internal view returns (uint8 effectiveWeight) {
+  ) internal view returns (uint16 effectiveWeight) {
     uint firstTrancheIdToUse = block.timestamp / TRANCHE_DURATION;
 
     (, , uint totalAllocation) = getAllocations(
@@ -1640,7 +1640,12 @@ function setProducts(StakedProductParam[] memory params) external onlyManager {
       capacityReductionRatio
     );
 
-    uint actualWeight = totalCapacity > 0 ? (totalAllocation * WEIGHT_DENOMINATOR / totalCapacity) : 0;
-    effectiveWeight = (Math.max(targetWeight, actualWeight)).toUint8();
+    uint actualWeight = totalCapacity > 0
+      ? (totalAllocation * WEIGHT_DENOMINATOR / totalCapacity)
+      : 0;
+
+    effectiveWeight = actualWeight > type(uint16).max
+      ? uint16(WEIGHT_DENOMINATOR)
+      : (Math.max(targetWeight, actualWeight)).toUint16();
   }
 }

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -1312,9 +1312,36 @@ contract StakingPool is IStakingPool, ERC721 {
 
   /* pool management */
 
-  function setProducts(StakedProductParam[] memory params) external onlyManager {
-    uint[] memory productIds = new uint[](params.length);
+  function recalculateEffectiveWeights(uint[] calldata productIds) external {
+    (
+    uint globalCapacityRatio,
+    uint globalMinPriceRatio,
+    uint[] memory initialPriceRatios,
+    uint[] memory capacityReductionRatios
+    ) = ICover(coverContract).getPriceAndCapacityRatios(productIds);
+
+    uint _totalEffectiveWeight = totalEffectiveWeight;
+
+    for (uint i = 0; i < productIds.length; i++) {
+      uint productId = productIds[i];
+      StakedProduct memory _product = products[productId];
+
+      uint8 previousEffectiveWeight = _product.lastEffectiveWeight;
+      _product.lastEffectiveWeight = _getEffectiveWeight(
+        productId,
+        _product.targetWeight,
+        globalCapacityRatio,
+        capacityReductionRatios[i]
+      );
+      _totalEffectiveWeight = _totalEffectiveWeight - previousEffectiveWeight + _product.lastEffectiveWeight;
+      products[productId] = _product;
+    }
+    totalEffectiveWeight = _totalEffectiveWeight.toUint32();
+  }
+
+function setProducts(StakedProductParam[] memory params) external onlyManager {
     uint numProducts = params.length;
+    uint[] memory productIds = new uint[](numProducts);
 
     for (uint i = 0; i < numProducts; i++) {
       productIds[i] = params[i].productId;
@@ -1329,6 +1356,7 @@ contract StakingPool is IStakingPool, ERC721 {
 
     uint _totalTargetWeight = totalTargetWeight;
     uint _totalEffectiveWeight = totalEffectiveWeight;
+    bool targetWeightIncreased;
 
     for (uint i = 0; i < numProducts; i++) {
       StakedProductParam memory _param = params[i];
@@ -1356,6 +1384,11 @@ contract StakingPool is IStakingPool, ERC721 {
 
         if (_param.setTargetWeight) {
           require(_param.targetWeight <= WEIGHT_DENOMINATOR, "StakingPool: Cannot set weight beyond 1");
+
+          // totalEffectiveWeight cannot be above the max unless target  weight is not increased
+          if (!targetWeightIncreased) {
+            targetWeightIncreased = _param.targetWeight > _product.targetWeight;
+          }
           _totalTargetWeight = _totalTargetWeight - _product.targetWeight + _param.targetWeight;
           _product.targetWeight = _param.targetWeight;
         }
@@ -1372,7 +1405,9 @@ contract StakingPool is IStakingPool, ERC721 {
       products[_param.productId] = _product;
     }
 
-    require(_totalEffectiveWeight <= MAX_TOTAL_WEIGHT, "StakingPool: Total max effective weight exceeded");
+    if (_totalEffectiveWeight > MAX_TOTAL_WEIGHT) {
+      require(!targetWeightIncreased, "StakingPool: Total max effective weight exceeded");
+    }
     totalTargetWeight = _totalTargetWeight.toUint32();
     totalEffectiveWeight = _totalEffectiveWeight.toUint32();
   }

--- a/test/unit/StakingPool/setProducts.js
+++ b/test/unit/StakingPool/setProducts.js
@@ -525,6 +525,7 @@ describe('setProducts unit tests', function () {
     const { stakingPool, cover, nxm, tokenController } = this;
     const {
       members: [manager, staker, coverBuyer],
+      nonMembers: [anybody],
     } = this.accounts;
     const amount = parseEther('1');
 
@@ -547,7 +548,6 @@ describe('setProducts unit tests', function () {
         return cover.connect(coverBuyer).allocateCapacity(cb, coverId, stakingPool.address);
       }),
     );
-    // TODO: test effective weight after a burn
-    await stakingPool.recalculateEffectiveWeights(initialProducts.map(p => p.productId));
+    await stakingPool.connect(anybody).recalculateEffectiveWeights(initialProducts.map(p => p.productId));
   });
 });

--- a/test/unit/StakingPool/setProducts.js
+++ b/test/unit/StakingPool/setProducts.js
@@ -520,4 +520,34 @@ describe('setProducts unit tests', function () {
       'StakingPool: Total max effective weight exceeded',
     );
   });
+
+  it('any address should be able to recalculate effective weight', async function () {
+    const { stakingPool, cover, nxm, tokenController } = this;
+    const {
+      members: [manager, staker, coverBuyer],
+    } = this.accounts;
+    const amount = parseEther('1');
+
+    let i = 0;
+    const initialProducts = Array.from({ length: 20 }, () => getInitialProduct(50, 100, 500, i++));
+    await initializePool(cover, stakingPool, manager.address, 0, initialProducts);
+
+    // Get capacity in staking pool
+    await nxm.connect(staker).approve(tokenController.address, amount);
+    const request = await depositRequest(stakingPool, amount, 0, manager.address);
+    await stakingPool.connect(staker).depositTo([request]);
+
+    // Initialize Products and CoverBuy requests
+    const coverId = 1;
+    const coverBuy = Array.from({ length: 20 }, () => {
+      return buyCoverParams(coverBuyer.address, --i, daysToSeconds('150'), parseEther('1'));
+    });
+    await Promise.all(
+      coverBuy.map(cb => {
+        return cover.connect(coverBuyer).allocateCapacity(cb, coverId, stakingPool.address);
+      }),
+    );
+    // TODO: test effective weight after a burn
+    await stakingPool.recalculateEffectiveWeights(initialProducts.map(p => p.productId));
+  });
 });

--- a/test/unit/StakingPool/setProducts.js
+++ b/test/unit/StakingPool/setProducts.js
@@ -47,18 +47,18 @@ const buyCoverParamsTemplate = {
   ipfsData: 'ipfs data',
 };
 
+const depositRequestTemplate = {
+  tokenId: 0,
+  destination: AddressZero, // needs to be set
+  trancheId: 0, // needs to be set
+  amount: parseEther('100'),
+};
+
 describe('setProducts unit tests', function () {
   // Create a default deposit request to the staking pool
-  const depositRequest = async (stakingPool, amount, destination) => {
-    const tokenId = 0;
-    const block = await ethers.provider.getBlock('latest');
-    const currentTrancheId = Math.floor(block.timestamp / daysToSeconds(91));
-    return {
-      amount,
-      trancheId: currentTrancheId + 2,
-      tokenId,
-      destination,
-    };
+  const getCurrentTrancheId = async () => {
+    const { timestamp } = await ethers.provider.getBlock('latest');
+    return Math.floor(timestamp / daysToSeconds(91));
   };
 
   const verifyProduct = (product, productParam) => {
@@ -424,7 +424,12 @@ describe('setProducts unit tests', function () {
 
     // Get capacity in staking pool
     await nxm.connect(staker).approve(tokenController.address, amount);
-    const request = await depositRequest(stakingPool, amount, staker.address);
+    const request = {
+      ...depositRequestTemplate,
+      amount,
+      destination: staker.address,
+      trancheId: (await getCurrentTrancheId()) + 2,
+    };
     await stakingPool.connect(staker).depositTo([request]);
 
     let i = 0;
@@ -486,7 +491,12 @@ describe('setProducts unit tests', function () {
 
     // Get capacity in staking pool
     await nxm.connect(staker).approve(tokenController.address, amount);
-    const request = await depositRequest(stakingPool, amount, manager.address);
+    const request = {
+      ...depositRequestTemplate,
+      amount,
+      destination: manager.address,
+      trancheId: (await getCurrentTrancheId()) + 2,
+    };
     await stakingPool.connect(staker).depositTo([request]);
 
     const ratio = await cover.getPriceAndCapacityRatios([0]);
@@ -530,24 +540,48 @@ describe('setProducts unit tests', function () {
     const amount = parseEther('1');
 
     let i = 0;
-    const initialProducts = Array.from({ length: 20 }, () => getInitialProduct(50, 100, 500, i++));
-    await initializePool(cover, stakingPool, manager.address, 0, initialProducts);
+    const initialProducts = Array(20)
+      .fill('')
+      .map(() => ({ ...initialProductTemplate, productId: i++ }));
+
+    // Add products to cover contract
+    await Promise.all(
+      initialProducts.map(({ productId, initialPrice: initialPriceRatio }) => [
+        cover.setProduct({ ...coverProductTemplate, initialPriceRatio }, productId),
+        cover.setProductType(ProductTypeFixture, productId),
+      ]),
+    );
+
+    await cover.initializeStaking(stakingPool.address, manager.address, false, 5, 5, initialProducts, 0);
 
     // Get capacity in staking pool
     await nxm.connect(staker).approve(tokenController.address, amount);
-    const request = await depositRequest(stakingPool, amount, 0, manager.address);
+    const request = {
+      ...depositRequestTemplate,
+      amount,
+      destination: manager.address,
+      trancheId: (await getCurrentTrancheId()) + 2,
+    };
     await stakingPool.connect(staker).depositTo([request]);
 
     // Initialize Products and CoverBuy requests
+    const coverBuyParams = Array(20)
+      .fill('')
+      .map((_, productId) => ({
+        ...buyCoverParamsTemplate,
+        owner: coverBuyer.address,
+        productId,
+        period: daysToSeconds('150'),
+        amount: parseEther('1'),
+      }));
+
     const coverId = 1;
-    const coverBuy = Array.from({ length: 20 }, () => {
-      return buyCoverParams(coverBuyer.address, --i, daysToSeconds('150'), parseEther('1'));
-    });
     await Promise.all(
-      coverBuy.map(cb => {
+      coverBuyParams.map(cb => {
         return cover.connect(coverBuyer).allocateCapacity(cb, coverId, stakingPool.address);
       }),
     );
+
     await stakingPool.connect(anybody).recalculateEffectiveWeights(initialProducts.map(p => p.productId));
   });
 });


### PR DESCRIPTION

## Context

Closes #454  


## Changes proposed in this pull request

This PR changes the `stakingPool.setProducts()` function so the target weight of a product can be lowered, even if the pool has exceeded it's max effective weight. 

A function is also added, so that any user can recalculate the effective weights of the pool.


## Test plan
There isn't much to test until the burn functionality is implemented. Will add more on that PR.


## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [x] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
