### PR TITLE
Fix: updateTranches not expiring tranches

### DIFF
--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -215,17 +215,18 @@ contract StakingPool is IStakingPool, ERC721 {
   // updateUntilCurrentTimestamp forces rewards update until current timestamp not just until
   // bucket/tranche expiry timestamps. Must be true when changing shares or reward per second.
   function updateTranches(bool updateUntilCurrentTimestamp) public {
+
+    uint _firstActiveBucketId = firstActiveBucketId;
+    uint _firstActiveTrancheId = firstActiveTrancheId;
+
     uint currentBucketId = block.timestamp / BUCKET_DURATION;
     uint currentTrancheId = block.timestamp / TRANCHE_DURATION;
 
     // if the pool is new
-    if (firstActiveBucketId == 0) {
-      firstActiveBucketId = currentBucketId;
-      firstActiveTrancheId = currentTrancheId;
+    if (_firstActiveBucketId == 0) {
+      _firstActiveBucketId = currentBucketId;
+      _firstActiveTrancheId = currentTrancheId;
     }
-
-    uint _firstActiveBucketId = firstActiveBucketId;
-    uint _firstActiveTrancheId = firstActiveTrancheId;
 
     // if a force update was not requested
     if (!updateUntilCurrentTimestamp) {
@@ -357,6 +358,17 @@ contract StakingPool is IStakingPool, ERC721 {
       );
     }
 
+    uint _firstActiveTrancheId = block.timestamp / TRANCHE_DURATION;
+    uint maxTranche = _firstActiveTrancheId + MAX_ACTIVE_TRANCHES - 1;
+
+    // if the pool has no previous deposits
+    if (firstActiveTrancheId == 0) {
+      uint currentBucketId = block.timestamp / BUCKET_DURATION;
+
+      firstActiveBucketId = currentBucketId;
+      firstActiveTrancheId = _firstActiveTrancheId;
+    }
+
     updateTranches(true);
 
     // storage reads
@@ -364,9 +376,6 @@ contract StakingPool is IStakingPool, ERC721 {
     uint _stakeSharesSupply = stakeSharesSupply;
     uint _rewardsSharesSupply = rewardsSharesSupply;
     uint _accNxmPerRewardsShare = accNxmPerRewardsShare;
-
-    uint _firstActiveTrancheId = block.timestamp / TRANCHE_DURATION;
-    uint maxTranche = _firstActiveTrancheId + MAX_ACTIVE_TRANCHES - 1;
 
     uint totalAmount;
     tokenIds = new uint[](requests.length);

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -314,7 +314,9 @@ contract StakingPool is IStakingPool, ERC721 {
         delete tranches[_firstActiveTrancheId];
 
         // the tranche is expired now so we decrease the stake and the shares supply
-        uint expiredStake = _activeStake * expiringTranche.stakeShares / _stakeSharesSupply;
+        uint expiredStake = _stakeSharesSupply != 0
+          ? (_activeStake * expiringTranche.stakeShares) / _stakeSharesSupply
+          : 0;
         _activeStake -= expiredStake;
         _stakeSharesSupply -= expiringTranche.stakeShares;
         _rewardsSharesSupply -= expiringTranche.rewardsShares;

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -215,18 +215,17 @@ contract StakingPool is IStakingPool, ERC721 {
   // updateUntilCurrentTimestamp forces rewards update until current timestamp not just until
   // bucket/tranche expiry timestamps. Must be true when changing shares or reward per second.
   function updateTranches(bool updateUntilCurrentTimestamp) public {
-
-    uint _firstActiveBucketId = firstActiveBucketId;
-    uint _firstActiveTrancheId = firstActiveTrancheId;
-
     uint currentBucketId = block.timestamp / BUCKET_DURATION;
     uint currentTrancheId = block.timestamp / TRANCHE_DURATION;
 
     // if the pool is new
-    if (_firstActiveBucketId == 0) {
-      _firstActiveBucketId = currentBucketId;
-      _firstActiveTrancheId = currentTrancheId;
+    if (firstActiveBucketId == 0) {
+      firstActiveBucketId = currentBucketId;
+      firstActiveTrancheId = currentTrancheId;
     }
+
+    uint _firstActiveBucketId = firstActiveBucketId;
+    uint _firstActiveTrancheId = firstActiveTrancheId;
 
     // if a force update was not requested
     if (!updateUntilCurrentTimestamp) {

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -363,10 +363,8 @@ contract StakingPool is IStakingPool, ERC721 {
 
     // if the pool has no previous deposits
     if (firstActiveTrancheId == 0) {
-      uint currentBucketId = block.timestamp / BUCKET_DURATION;
-
-      firstActiveBucketId = currentBucketId;
       firstActiveTrancheId = _firstActiveTrancheId;
+      firstActiveBucketId = block.timestamp / BUCKET_DURATION;
       lastAccNxmUpdate = block.timestamp;
     } else {
       updateTranches(true);

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -367,9 +367,10 @@ contract StakingPool is IStakingPool, ERC721 {
 
       firstActiveBucketId = currentBucketId;
       firstActiveTrancheId = _firstActiveTrancheId;
+      lastAccNxmUpdate = block.timestamp;
+    } else {
+      updateTranches(true);
     }
-
-    updateTranches(true);
 
     // storage reads
     uint _activeStake = activeStake;

--- a/test/unit/StakingPool/depositTo.js
+++ b/test/unit/StakingPool/depositTo.js
@@ -28,7 +28,7 @@ describe('depositTo', function () {
     depositNftId: 1,
   };
 
-  before(async function () {
+  beforeEach(async function () {
     const { stakingPool, cover } = this;
     const { defaultSender: manager } = this.accounts;
 

--- a/test/unit/StakingPool/index.js
+++ b/test/unit/StakingPool/index.js
@@ -22,4 +22,5 @@ describe('StakingPool unit tests', function () {
   require('./calculateNewRewardShares');
   require('./setProducts');
   require('./depositTo');
+  require('./updateTranches');
 });

--- a/test/unit/StakingPool/updateTranches.js
+++ b/test/unit/StakingPool/updateTranches.js
@@ -1,0 +1,101 @@
+const { ethers } = require('hardhat');
+const { expect } = require('chai');
+const { getTranches, TRANCHE_DURATION } = require('./helpers');
+const { setEtherBalance, increaseTime } = require('../../utils/evm');
+
+const { AddressZero } = ethers.constants;
+const { parseEther } = ethers.utils;
+
+describe('updateTranches', function () {
+  const depositToFixture = {
+    poolId: 0,
+    initialPoolFee: 5, // 5%
+    maxPoolFee: 5, // 5%
+    productInitializationParams: [
+      {
+        productId: 0,
+        weight: 100,
+        initialPrice: 500,
+        targetPrice: 500,
+      },
+    ],
+    amount: parseEther('100'),
+    trancheId: 0,
+    tokenId: 0,
+    destination: AddressZero,
+    depositNftId: 1,
+  };
+
+  beforeEach(async function () {
+    const { stakingPool, cover } = this;
+    const { defaultSender: manager } = this.accounts;
+
+    const { poolId, initialPoolFee, maxPoolFee, productInitializationParams } = depositToFixture;
+
+    const coverSigner = await ethers.getImpersonatedSigner(cover.address);
+    await setEtherBalance(coverSigner.address, ethers.utils.parseEther('1'));
+    this.coverSigner = coverSigner;
+
+    await stakingPool
+      .connect(coverSigner)
+      .initialize(manager.address, false, initialPoolFee, maxPoolFee, productInitializationParams, poolId);
+  });
+
+  it('expires tranche with no previous updates', async function () {
+    const { stakingPool } = this;
+    const {
+      members: [user],
+    } = this.accounts;
+
+    const { amount, tokenId, destination } = depositToFixture;
+
+    const { firstActiveTrancheId } = await getTranches();
+
+    // Deposit. In this internal call to updateTranches _rewardsSharesSupply is 0
+    // so it only updates lastAccNxmUpdate and return
+    await stakingPool.connect(user).depositTo([
+      {
+        amount,
+        trancheId: firstActiveTrancheId,
+        tokenId,
+        destination,
+      },
+    ]);
+
+    // increase time to expire the first active tranche
+    await increaseTime(TRANCHE_DURATION);
+
+    await expect(stakingPool.updateTranches(true));
+
+    const expiredTranche = await stakingPool.expiredTranches(firstActiveTrancheId);
+    expect(expiredTranche.accNxmPerRewardShareAtExpiry).to.equal(0);
+    expect(expiredTranche.stakeAmountAtExpiry).to.equal(amount);
+    expect(expiredTranche.stakeShareSupplyAtExpiry).to.equal(Math.sqrt(amount));
+  });
+
+  it('does not revert when expires multiple tranches', async function () {
+    const { stakingPool } = this;
+    const {
+      members: [user],
+    } = this.accounts;
+
+    const { amount, tokenId, destination } = depositToFixture;
+
+    const { firstActiveTrancheId } = await getTranches();
+
+    // deposit
+    await stakingPool.connect(user).depositTo([
+      {
+        amount,
+        trancheId: firstActiveTrancheId,
+        tokenId,
+        destination,
+      },
+    ]);
+
+    // increase time to expire a couple of tranches
+    await increaseTime(TRANCHE_DURATION * 2);
+
+    await expect(stakingPool.updateTranches(true)).to.not.reverted;
+  });
+});


### PR DESCRIPTION
## Context

This PR fixes two issues related to expiring tranches from the `updateTranches` method.

1. Expired tranche is not being expired: In a new pool, if a tranche has a deposit and then no other activity until after the tranche end time passes, when calling `updateTranches` that tranche was not being expired. The reason is that `firstActiveBucketId` is `0` so the first active bucket and tranche were being assigned to the `currentBucketId` and `currentTrancheId`, so then the `while` condition was `false` and the tranche was not expired.
2. Division by zero error: If multiple expired tranches are being expired in a `updateTranches` call, if all stakeShares were burned before the last expiring tranche, a division by zero error was being thrown.
https://github.com/NexusMutual/smart-contracts/blob/882cc4236c912cdf6180701fbc70e5fa34a557c5/contracts/modules/staking/StakingPool.sol#L318

## Changes proposed in this pull request

The following changes were applied:
1. Assign the global variables `firstActiveBucketId` and `firstActiveTrancheId` to the current bucket/tranche if they are not set. In the scenario described this will make the internal call to `updateTranches` in `depositTo` to store those variables, so next time when `updateTranches` is called, they will be correctly compared to the current tranche and enter the `while` block.
2. Validate that `_stakeSharesSupply` is not `0`, return `0` otherwise.
4. Minor fix to `depositTo` unit test setup. Moved the logic from `before` to `beforeEach` as it was not being reverted by the snapshot, affecting tests on other files.


## Test plan

New tests were added in `test/unit/StakingPool/updateTranches.js`. You can validate that previously it was not working by removing the changes applied, making the tests fail.


## Checklist

- [x] Rebased the base branch
- [ ] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
