### PR TITLE
Fix: Cast small uints to 256 bits before multiplying

### DIFF
--- a/contracts/modules/assessment/Assessment.sol
+++ b/contracts/modules/assessment/Assessment.sol
@@ -331,7 +331,7 @@ contract Assessment is IAssessment, MasterAwareV2 {
 
     if (poll.accepted == 0) {
       // Reset the poll end date on the first accept vote
-      poll.end = uint32(block.timestamp + config.minVotingPeriodInDays * 1 days);
+      poll.end = uint32(block.timestamp + uint(config.minVotingPeriodInDays) * 1 days);
     }
 
     // Check if poll ends in less than 24 hours
@@ -341,7 +341,7 @@ contract Assessment is IAssessment, MasterAwareV2 {
       poll.end += uint32(
         Math.min(
           silentEndingPeriod,
-          silentEndingPeriod * uint(stakeAmount) / (uint(poll.accepted) + uint(poll.denied))
+          silentEndingPeriod * uint(stakeAmount) / (uint(poll.accepted + poll.denied))
         )
       );
     }

--- a/contracts/modules/assessment/Assessment.sol
+++ b/contracts/modules/assessment/Assessment.sol
@@ -112,7 +112,7 @@ contract Assessment is IAssessment, MasterAwareV2 {
       // rewards.
       if (
         !hasReachedUnwithdrawableReward &&
-        assessment.poll.end + config.payoutCooldownInDays * 1 days >= block.timestamp
+        uint(assessment.poll.end) + uint(config.payoutCooldownInDays) * 1 days >= block.timestamp
       ) {
         hasReachedUnwithdrawableReward = true;
         // Store the index of the vote until which rewards can be withdrawn.
@@ -157,7 +157,7 @@ contract Assessment is IAssessment, MasterAwareV2 {
     if (voteCount > 0) {
       Vote memory vote = votesOf[msg.sender][voteCount - 1];
       require(
-        block.timestamp > vote.timestamp + config.stakeLockupPeriodInDays * 1 days,
+        block.timestamp > vote.timestamp + uint(config.stakeLockupPeriodInDays) * 1 days,
         "Stake is in lockup period"
       );
     }
@@ -228,7 +228,7 @@ contract Assessment is IAssessment, MasterAwareV2 {
     for (uint i = rewardsWithdrawableFromIndex; i < withdrawnUntilIndex; i++) {
       vote = votesOf[staker][i];
       assessment = assessments[vote.assessmentId];
-      if (assessment.poll.end + config.payoutCooldownInDays * 1 days >= block.timestamp) {
+      if (uint(assessment.poll.end) + uint(config.payoutCooldownInDays) * 1 days >= block.timestamp) {
         // Poll is not final
         withdrawnUntilIndex = i;
         break;
@@ -264,7 +264,7 @@ contract Assessment is IAssessment, MasterAwareV2 {
         0, // accepted
         0, // denied
         uint32(block.timestamp), // start
-        uint32(block.timestamp + config.minVotingPeriodInDays * 1 days) // end
+        uint32(block.timestamp + uint32(config.minVotingPeriodInDays) * 1 days) // end
       ),
       uint128(totalAssessmentReward),
       uint128(assessmentDepositInETH)
@@ -335,7 +335,7 @@ contract Assessment is IAssessment, MasterAwareV2 {
     }
 
     // Check if poll ends in less than 24 hours
-    uint silentEndingPeriod = config.silentEndingPeriodInDays * 1 days;
+    uint silentEndingPeriod = uint(config.silentEndingPeriodInDays) * 1 days;
     if (poll.end - block.timestamp < silentEndingPeriod) {
       // Extend proportionally to the user's stake but up to 1 day maximum
       poll.end += uint32(
@@ -423,7 +423,7 @@ contract Assessment is IAssessment, MasterAwareV2 {
       IAssessment.Poll memory poll = assessments[vote.assessmentId].poll;
 
       {
-        if (uint32(block.timestamp) >= poll.end + config.payoutCooldownInDays * 1 days) {
+        if (uint32(block.timestamp) >= uint(poll.end) + uint(config.payoutCooldownInDays) * 1 days) {
           // Once the cooldown period ends the poll result is final, thus skip
           continue;
         }

--- a/contracts/modules/assessment/IndividualClaims.sol
+++ b/contracts/modules/assessment/IndividualClaims.sol
@@ -148,8 +148,8 @@ contract IndividualClaims is IIndividualClaims, MasterAwareV2 {
           (,,uint8 payoutCooldownInDays,) = assessment().config();
           if (
             block.timestamp >= poll.end +
-            payoutCooldownInDays * 1 days +
-            config.payoutRedemptionPeriodInDays * 1 days
+            uint(payoutCooldownInDays) * 1 days +
+            uint(config.payoutRedemptionPeriodInDays) * 1 days
           ) {
             payoutStatus = PayoutStatus.UNCLAIMED;
           }
@@ -242,13 +242,13 @@ contract IndividualClaims is IIndividualClaims, MasterAwareV2 {
         uint80 assessmentId = claims[previousSubmission.claimId].assessmentId;
         IAssessment.Poll memory poll = assessment().getPoll(assessmentId);
         (,,uint8 payoutCooldownInDays,) = assessment().config();
-        uint payoutCooldown = payoutCooldownInDays * 1 days;
+        uint payoutCooldown = uint(payoutCooldownInDays) * 1 days;
         if (block.timestamp >= poll.end + payoutCooldown) {
           if (
             poll.accepted > poll.denied &&
-            block.timestamp < poll.end +
-            payoutCooldown+
-            config.payoutRedemptionPeriodInDays * 1 days
+            block.timestamp < uint(poll.end) +
+            payoutCooldown +
+            uint(config.payoutRedemptionPeriodInDays) * 1 days
           ) {
             revert("A payout can still be redeemed");
           }
@@ -274,7 +274,7 @@ contract IndividualClaims is IIndividualClaims, MasterAwareV2 {
       require(requestedAmount <= segment.amount, "Covered amount exceeded");
       require(segment.start <= block.timestamp, "Cover starts in the future");
       require(
-        segment.start + segment.period + segment.gracePeriodInDays * 1 days > block.timestamp,
+        uint(segment.start) + uint(segment.period) + uint(segment.gracePeriodInDays) * 1 days > block.timestamp,
         "Cover is outside the grace period"
       );
 
@@ -347,12 +347,12 @@ contract IndividualClaims is IIndividualClaims, MasterAwareV2 {
     require(poll.accepted > poll.denied, "The claim needs to be accepted");
 
     (,,uint8 payoutCooldownInDays,) = assessment().config();
-    uint payoutCooldown = payoutCooldownInDays * 1 days;
+    uint payoutCooldown = uint(payoutCooldownInDays) * 1 days;
 
     require(block.timestamp >= poll.end + payoutCooldown, "The claim is in cooldown period");
 
     require(
-      block.timestamp < poll.end + payoutCooldown + config.payoutRedemptionPeriodInDays * 1 days,
+      block.timestamp < uint(poll.end) + payoutCooldown + uint(config.payoutRedemptionPeriodInDays) * 1 days,
       "The redemption period has expired"
     );
 

--- a/contracts/modules/assessment/YieldTokenIncidents.sol
+++ b/contracts/modules/assessment/YieldTokenIncidents.sol
@@ -220,7 +220,7 @@ contract YieldTokenIncidents is IYieldTokenIncidents, MasterAwareV2 {
       {
         require(
           coverSegment.start + coverSegment.period +
-          coverSegment.gracePeriodInDays * 1 days >= block.timestamp,
+          uint(coverSegment.gracePeriodInDays) * 1 days >= block.timestamp,
           "Grace period has expired"
         );
       }

--- a/contracts/modules/cover/CoverUtilsLib.sol
+++ b/contracts/modules/cover/CoverUtilsLib.sol
@@ -83,7 +83,7 @@ library CoverUtilsLib {
       uint productId = params.productsV1.getNewProductId(legacyProductId);
       productType = _productTypes[_products[productId].productType];
       require(
-        block.timestamp < validUntil + productType.gracePeriodInDays * 1 days,
+        block.timestamp < validUntil + uint(productType.gracePeriodInDays) * 1 days,
         "Cover outside of the grace period"
       );
 
@@ -101,8 +101,8 @@ library CoverUtilsLib {
     _coverSegments[newCoverId].push(
       CoverSegment(
         SafeUintCast.toUint96(sumAssured * 10 ** 18), // amount
-        SafeUintCast.toUint32(validUntil - coverPeriodInDays * 1 days), // start
-        SafeUintCast.toUint32(coverPeriodInDays * 1 days), // period
+        SafeUintCast.toUint32(validUntil - uint(coverPeriodInDays) * 1 days), // start
+        SafeUintCast.toUint32(uint(coverPeriodInDays) * 1 days), // period
         productType.gracePeriodInDays,
         0 // global rewards ratio //
       )


### PR DESCRIPTION
## Context

Closes #419 

## Changes proposed in this pull request

This PR increases the size of uints, when multiplying two uints that are smaller than 256 bits, to avoid overflows. 


## Test plan
Did not add any further tests


## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
