### PR TITLE
Feat: Index user and coverId params of ClaimSubmitted event for filtering

### DIFF
--- a/contracts/interfaces/IIndividualClaims.sol
+++ b/contracts/interfaces/IIndividualClaims.sol
@@ -122,7 +122,7 @@ interface IIndividualClaims {
 
   /* ========== EVENTS ========== */
 
-  event ClaimSubmitted(address user, uint claimId, uint coverId, uint productId);
+  event ClaimSubmitted(address indexed user, uint claimId, uint indexed coverId, uint productId);
   event MetadataSubmitted(uint indexed claimId, string ipfsMetadata);
   event ClaimPayoutRedeemed(address indexed user, uint amount, uint claimId, uint coverId);
 


### PR DESCRIPTION
## Context

We need to be able to filter the `ClaimSubmitted` events by user and cover. The params need to be indexed for the event to be filterable (see error: `Cannot filter non-indexed parameters; must be null`)

Closes #514 


## Changes proposed in this pull request

- indexed `user` and `coverId` params


## Test plan

N/A

## Checklist

- [ ] Rebased the base branch - N/A
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation - N/A
- [x] Didn't generate new warnings
- [ ] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works - N/A


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
