### PR TITLE
Feature: assessment data ipfs hash

### DIFF
--- a/contracts/interfaces/IAssessment.sol
+++ b/contracts/interfaces/IAssessment.sol
@@ -149,6 +149,7 @@ interface IAssessment {
   function castVotes(
     uint[] calldata assessmentIds,
     bool[] calldata votes,
+    string[] calldata ipfsAssessmentDataHashes,
     uint96 stakeIncrease
   ) external;
 
@@ -170,7 +171,7 @@ interface IAssessment {
 
   event StakeDeposited(address user, uint104 amount);
   event StakeWithdrawn(address indexed user, address to, uint96 amount);
-  event VoteCast(address indexed user, uint256 assessmentId, uint96 stakedAmount, bool accepted);
+  event VoteCast(address indexed user, uint256 assessmentId, uint96 stakedAmount, bool accepted, string ipfsAssessmentDataHash);
   event RewardWithdrawn(address user, address to, uint256 amount);
   event FraudProcessed(uint assessmentId, address assessor, Poll poll);
   event FraudSubmitted(bytes32 root);

--- a/contracts/modules/assessment/Assessment.sol
+++ b/contracts/modules/assessment/Assessment.sol
@@ -291,11 +291,16 @@ contract Assessment is IAssessment, MasterAwareV2 {
   function castVotes(
     uint[] calldata assessmentIds,
     bool[] calldata votes,
+    string[] calldata ipfsAssessmentDataHashes,
     uint96 stakeIncrease
   ) external override onlyMember whenNotPaused {
     require(
       assessmentIds.length == votes.length,
       "The lengths of the assessment ids and votes arrays mismatch"
+    );
+    require(
+      assessmentIds.length == votes.length,
+      "The lengths of the assessment ids and ipfs assessment data hashes arrays mismatch"
     );
 
     if (stakeIncrease > 0) {
@@ -303,7 +308,7 @@ contract Assessment is IAssessment, MasterAwareV2 {
     }
 
     for (uint i = 0; i < assessmentIds.length; i++) {
-      castVote(assessmentIds[i], votes[i]);
+      castVote(assessmentIds[i], votes[i], ipfsAssessmentDataHashes[i]);
     }
   }
 
@@ -318,7 +323,7 @@ contract Assessment is IAssessment, MasterAwareV2 {
   ///
   /// @param assessmentId  The index of the assessment for which the vote is cast
   /// @param isAcceptVote  True to accept, false to deny
-  function castVote(uint assessmentId, bool isAcceptVote) internal {
+  function castVote(uint assessmentId, bool isAcceptVote, string memory ipfsAssessmentDataHash) internal {
     {
       require(!hasAlreadyVotedOn[msg.sender][assessmentId], "Already voted");
       hasAlreadyVotedOn[msg.sender][assessmentId] = true;
@@ -365,8 +370,7 @@ contract Assessment is IAssessment, MasterAwareV2 {
       uint32(block.timestamp),
       stakeAmount
     ));
-
-    emit VoteCast(msg.sender, assessmentId, stakeAmount, isAcceptVote);
+    emit VoteCast(msg.sender, assessmentId, stakeAmount, isAcceptVote, ipfsAssessmentDataHash);
   }
 
   /// Allows governance to submit a merkle tree root hash representing fraudulent stakers

--- a/contracts/modules/assessment/Assessment.sol
+++ b/contracts/modules/assessment/Assessment.sol
@@ -299,7 +299,7 @@ contract Assessment is IAssessment, MasterAwareV2 {
       "The lengths of the assessment ids and votes arrays mismatch"
     );
     require(
-      assessmentIds.length == votes.length,
+      assessmentIds.length == ipfsAssessmentDataHashes.length,
       "The lengths of the assessment ids and ipfs assessment data hashes arrays mismatch"
     );
 

--- a/test/integration/Cover/expireCover.js
+++ b/test/integration/Cover/expireCover.js
@@ -136,7 +136,7 @@ describe.skip('expireCover', function () {
     await submitIncident({ yc, productId, period, signer: this.accounts.defaultSender });
 
     // accept incident
-    await as.connect(staker1).castVotes([assessmentId], [true], ['ipfsAssessmentDataHash'], parseEther('100'));
+    await as.connect(staker1).castVotes([assessmentId], [true], ['Assessment data hash'], parseEther('100'));
 
     {
       // advance past payout cooldown
@@ -210,7 +210,7 @@ describe.skip('expireCover', function () {
     await submitIncident({ yc, productId, period, signer: this.accounts.defaultSender });
 
     // accept incident
-    await as.connect(staker1).castVotes([assessmentId], [true], ['ipfsAssessmentDataHash'], parseEther('100'));
+    await as.connect(staker1).castVotes([assessmentId], [true], ['Assessment data hash'], parseEther('100'));
 
     {
       // advance past payout cooldown
@@ -280,7 +280,7 @@ describe.skip('expireCover', function () {
     await submitIncident({ yc, productId, period, signer: this.accounts.defaultSender });
 
     // accept incident
-    await as.connect(staker1).castVotes([assessmentId], [true], ['ipfsAssessmentDataHash'], parseEther('100'));
+    await as.connect(staker1).castVotes([assessmentId], [true], ['Assessment data hash'], parseEther('100'));
 
     {
       // advance past payout cooldown
@@ -355,7 +355,7 @@ describe.skip('expireCover', function () {
     await submitIncident({ yc, productId, period, signer: this.accounts.defaultSender });
 
     // accept incident
-    await as.connect(staker1).castVotes([assessmentId], [true], ['ipfsAssessmentDataHash'], parseEther('100'));
+    await as.connect(staker1).castVotes([assessmentId], [true], ['Assessment data hash'], parseEther('100'));
 
     {
       // advance past payout cooldown
@@ -424,7 +424,7 @@ describe.skip('expireCover', function () {
     await submitIncident({ yc, productId, period, signer: this.accounts.defaultSender });
 
     // accept incident
-    await as.connect(staker1).castVotes([assessmentId], [true], ['ipfsAssessmentDataHash'], parseEther('100'));
+    await as.connect(staker1).castVotes([assessmentId], [true], ['Assessment data hash'], parseEther('100'));
 
     {
       // advance past payout cooldown
@@ -503,8 +503,8 @@ describe.skip('expireCover', function () {
     await submitIncident({ yc, productId, period, signer: this.accounts.defaultSender });
 
     // reject incident (requires at least 1 positive vote)
-    await as.connect(staker1).castVotes([assessmentId], [true], ['ipfsAssessmentDataHash'], parseEther('100'));
-    await as.connect(staker2).castVotes([assessmentId], [false], ['ipfsAssessmentDataHash'], parseEther('100'));
+    await as.connect(staker1).castVotes([assessmentId], [true], ['Assessment data hash'], parseEther('100'));
+    await as.connect(staker2).castVotes([assessmentId], [false], ['Assessment data hash'], parseEther('100'));
 
     {
       // advance past payout cooldown
@@ -579,8 +579,8 @@ describe.skip('expireCover', function () {
     await submitIncident({ yc, productId, period, signer: this.accounts.defaultSender });
 
     // reject incident (requires at least 1 positive vote)
-    await as.connect(staker1).castVotes([assessmentId], [true], ['ipfsAssessmentDataHash'], parseEther('100'));
-    await as.connect(staker2).castVotes([assessmentId], [false], ['ipfsAssessmentDataHash'], parseEther('100'));
+    await as.connect(staker1).castVotes([assessmentId], [true], ['Assessment data hash'], parseEther('100'));
+    await as.connect(staker2).castVotes([assessmentId], [false], ['Assessment data hash'], parseEther('100'));
 
     {
       // advance past payout cooldown

--- a/test/integration/Cover/expireCover.js
+++ b/test/integration/Cover/expireCover.js
@@ -136,7 +136,7 @@ describe.skip('expireCover', function () {
     await submitIncident({ yc, productId, period, signer: this.accounts.defaultSender });
 
     // accept incident
-    await as.connect(staker1).castVotes([assessmentId], [true], parseEther('100'));
+    await as.connect(staker1).castVotes([assessmentId], [true], ['ipfsAssessmentDataHash'], parseEther('100'));
 
     {
       // advance past payout cooldown
@@ -210,7 +210,7 @@ describe.skip('expireCover', function () {
     await submitIncident({ yc, productId, period, signer: this.accounts.defaultSender });
 
     // accept incident
-    await as.connect(staker1).castVotes([assessmentId], [true], parseEther('100'));
+    await as.connect(staker1).castVotes([assessmentId], [true], ['ipfsAssessmentDataHash'], parseEther('100'));
 
     {
       // advance past payout cooldown
@@ -280,7 +280,7 @@ describe.skip('expireCover', function () {
     await submitIncident({ yc, productId, period, signer: this.accounts.defaultSender });
 
     // accept incident
-    await as.connect(staker1).castVotes([assessmentId], [true], parseEther('100'));
+    await as.connect(staker1).castVotes([assessmentId], [true], ['ipfsAssessmentDataHash'], parseEther('100'));
 
     {
       // advance past payout cooldown
@@ -355,7 +355,7 @@ describe.skip('expireCover', function () {
     await submitIncident({ yc, productId, period, signer: this.accounts.defaultSender });
 
     // accept incident
-    await as.connect(staker1).castVotes([assessmentId], [true], parseEther('100'));
+    await as.connect(staker1).castVotes([assessmentId], [true], ['ipfsAssessmentDataHash'], parseEther('100'));
 
     {
       // advance past payout cooldown
@@ -424,7 +424,7 @@ describe.skip('expireCover', function () {
     await submitIncident({ yc, productId, period, signer: this.accounts.defaultSender });
 
     // accept incident
-    await as.connect(staker1).castVotes([assessmentId], [true], parseEther('100'));
+    await as.connect(staker1).castVotes([assessmentId], [true], ['ipfsAssessmentDataHash'], parseEther('100'));
 
     {
       // advance past payout cooldown
@@ -503,8 +503,8 @@ describe.skip('expireCover', function () {
     await submitIncident({ yc, productId, period, signer: this.accounts.defaultSender });
 
     // reject incident (requires at least 1 positive vote)
-    await as.connect(staker1).castVotes([assessmentId], [true], parseEther('100'));
-    await as.connect(staker2).castVotes([assessmentId], [false], parseEther('100'));
+    await as.connect(staker1).castVotes([assessmentId], [true], ['ipfsAssessmentDataHash'], parseEther('100'));
+    await as.connect(staker2).castVotes([assessmentId], [false], ['ipfsAssessmentDataHash'], parseEther('100'));
 
     {
       // advance past payout cooldown
@@ -579,8 +579,8 @@ describe.skip('expireCover', function () {
     await submitIncident({ yc, productId, period, signer: this.accounts.defaultSender });
 
     // reject incident (requires at least 1 positive vote)
-    await as.connect(staker1).castVotes([assessmentId], [true], parseEther('100'));
-    await as.connect(staker2).castVotes([assessmentId], [false], parseEther('100'));
+    await as.connect(staker1).castVotes([assessmentId], [true], ['ipfsAssessmentDataHash'], parseEther('100'));
+    await as.connect(staker2).castVotes([assessmentId], [false], ['ipfsAssessmentDataHash'], parseEther('100'));
 
     {
       // advance past payout cooldown

--- a/test/integration/IndividualClaims/submitClaim.js
+++ b/test/integration/IndividualClaims/submitClaim.js
@@ -34,7 +34,7 @@ describe.skip('submitClaim', function () {
     const { payoutCooldownInDays } = await as.config();
     await as.connect(staker).stake(assessmentStakingAmount);
 
-    await as.connect(staker).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await as.connect(staker).castVotes([0], [true], ['Assessment data hash'], 0);
 
     const { poll } = await as.assessments(0);
     const futureTime = poll.end + daysToSeconds(payoutCooldownInDays);
@@ -48,10 +48,10 @@ describe.skip('submitClaim', function () {
     const { payoutCooldownInDays } = await as.config();
     await as.connect(approvingStaker).stake(assessmentStakingAmountForApproval);
 
-    await as.connect(approvingStaker).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await as.connect(approvingStaker).castVotes([0], [true], ['Assessment data hash'], 0);
 
     await as.connect(rejectingStaker).stake(assessmentStakingAmountForRejection);
-    await as.connect(rejectingStaker).castVotes([0], [false], ['ipfsAssessmentDataHash'], 0);
+    await as.connect(rejectingStaker).castVotes([0], [false], ['Assessment data hash'], 0);
 
     const { poll } = await as.assessments(0);
     const futureTime = poll.end + daysToSeconds(payoutCooldownInDays);

--- a/test/integration/IndividualClaims/submitClaim.js
+++ b/test/integration/IndividualClaims/submitClaim.js
@@ -34,7 +34,7 @@ describe.skip('submitClaim', function () {
     const { payoutCooldownInDays } = await as.config();
     await as.connect(staker).stake(assessmentStakingAmount);
 
-    await as.connect(staker).castVotes([0], [true], 0);
+    await as.connect(staker).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
 
     const { poll } = await as.assessments(0);
     const futureTime = poll.end + daysToSeconds(payoutCooldownInDays);
@@ -48,10 +48,10 @@ describe.skip('submitClaim', function () {
     const { payoutCooldownInDays } = await as.config();
     await as.connect(approvingStaker).stake(assessmentStakingAmountForApproval);
 
-    await as.connect(approvingStaker).castVotes([0], [true], 0);
+    await as.connect(approvingStaker).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
 
     await as.connect(rejectingStaker).stake(assessmentStakingAmountForRejection);
-    await as.connect(rejectingStaker).castVotes([0], [false], 0);
+    await as.connect(rejectingStaker).castVotes([0], [false], ['ipfsAssessmentDataHash'], 0);
 
     const { poll } = await as.assessments(0);
     const futureTime = poll.end + daysToSeconds(payoutCooldownInDays);

--- a/test/integration/YieldTokenIncidents/submitClaim.js
+++ b/test/integration/YieldTokenIncidents/submitClaim.js
@@ -98,7 +98,7 @@ describe.skip('submitClaim', function () {
     }
 
     // accept incident
-    await as.connect(staker1).castVotes([0], [true], parseEther('100'));
+    await as.connect(staker1).castVotes([0], [true], ['ipfsAssessmentDataHash'], parseEther('100'));
 
     {
       // advance past payout cooldown
@@ -186,7 +186,7 @@ describe.skip('submitClaim', function () {
     }
 
     // accept incident
-    await as.connect(staker1).castVotes([0], [true], parseEther('100'));
+    await as.connect(staker1).castVotes([0], [true], ['ipfsAssessmentDataHash'], parseEther('100'));
 
     {
       // advance past payout cooldown
@@ -271,8 +271,8 @@ describe.skip('submitClaim', function () {
     }
 
     // reject incident (requires at least 1 positive vote)
-    await as.connect(staker1).castVotes([0], [true], parseEther('100'));
-    await as.connect(staker2).castVotes([0], [false], parseEther('100'));
+    await as.connect(staker1).castVotes([0], [true], ['ipfsAssessmentDataHash'], parseEther('100'));
+    await as.connect(staker2).castVotes([0], [false], ['ipfsAssessmentDataHash'], parseEther('100'));
 
     {
       // advance past payout cooldown

--- a/test/integration/YieldTokenIncidents/submitClaim.js
+++ b/test/integration/YieldTokenIncidents/submitClaim.js
@@ -98,7 +98,7 @@ describe.skip('submitClaim', function () {
     }
 
     // accept incident
-    await as.connect(staker1).castVotes([0], [true], ['ipfsAssessmentDataHash'], parseEther('100'));
+    await as.connect(staker1).castVotes([0], [true], ['Assessment data hash'], parseEther('100'));
 
     {
       // advance past payout cooldown
@@ -186,7 +186,7 @@ describe.skip('submitClaim', function () {
     }
 
     // accept incident
-    await as.connect(staker1).castVotes([0], [true], ['ipfsAssessmentDataHash'], parseEther('100'));
+    await as.connect(staker1).castVotes([0], [true], ['Assessment data hash'], parseEther('100'));
 
     {
       // advance past payout cooldown
@@ -271,8 +271,8 @@ describe.skip('submitClaim', function () {
     }
 
     // reject incident (requires at least 1 positive vote)
-    await as.connect(staker1).castVotes([0], [true], ['ipfsAssessmentDataHash'], parseEther('100'));
-    await as.connect(staker2).castVotes([0], [false], ['ipfsAssessmentDataHash'], parseEther('100'));
+    await as.connect(staker1).castVotes([0], [true], ['Assessment data hash'], parseEther('100'));
+    await as.connect(staker2).castVotes([0], [false], ['Assessment data hash'], parseEther('100'));
 
     {
       // advance past payout cooldown

--- a/test/unit/Assessment/castVotes.js
+++ b/test/unit/Assessment/castVotes.js
@@ -5,17 +5,19 @@ const { setTime } = require('./helpers');
 const { parseEther } = ethers.utils;
 const daysToSeconds = days => days * 24 * 60 * 60;
 
+const ASSESSMENT_DATA_HASH = 'Assessment data ipfs hash';
+
 describe('castVotes', function () {
   it('reverts if the user has already voted on the same assessment', async function () {
     const { assessment, individualClaims } = this.contracts;
     const user = this.accounts.members[0];
     await assessment.connect(user).stake(parseEther('100'));
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
-    await assessment.connect(user).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
-    await expect(assessment.connect(user).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0)).to.be.revertedWith(
+    await assessment.connect(user).castVotes([0], [true], [ASSESSMENT_DATA_HASH], 0);
+    await expect(assessment.connect(user).castVotes([0], [true], [ASSESSMENT_DATA_HASH], 0)).to.be.revertedWith(
       'Already voted',
     );
-    await expect(assessment.connect(user).castVotes([0], [false], ['ipfsAssessmentDataHash'], 0)).to.be.revertedWith(
+    await expect(assessment.connect(user).castVotes([0], [false], [ASSESSMENT_DATA_HASH], 0)).to.be.revertedWith(
       'Already voted',
     );
   });
@@ -24,10 +26,10 @@ describe('castVotes', function () {
     const { assessment, individualClaims } = this.contracts;
     const user = this.accounts.members[0];
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
-    await expect(assessment.connect(user).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0)).to.be.revertedWith(
+    await expect(assessment.connect(user).castVotes([0], [true], [ASSESSMENT_DATA_HASH], 0)).to.be.revertedWith(
       'A stake is required to cast votes',
     );
-    await expect(assessment.connect(user).castVotes([0], [false], ['ipfsAssessmentDataHash'], 0)).to.be.revertedWith(
+    await expect(assessment.connect(user).castVotes([0], [false], [ASSESSMENT_DATA_HASH], 0)).to.be.revertedWith(
       'A stake is required to cast votes',
     );
   });
@@ -42,25 +44,25 @@ describe('castVotes', function () {
       const { poll } = await assessment.assessments(0);
       await setTime(poll.end);
     }
-    await expect(assessment.connect(user1).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0)).to.be.revertedWith(
+    await expect(assessment.connect(user1).castVotes([0], [true], [ASSESSMENT_DATA_HASH], 0)).to.be.revertedWith(
       'Voting is closed',
     );
-    await expect(assessment.connect(user1).castVotes([0], ['ipfsAssessmentDataHash'], [false], 0)).to.be.revertedWith(
+    await expect(assessment.connect(user1).castVotes([0], [ASSESSMENT_DATA_HASH], [false], 0)).to.be.revertedWith(
       'Voting is closed',
     );
 
     await individualClaims.submitClaim(1, 0, parseEther('100'), '');
     const { timestamp } = await ethers.provider.getBlock('latest');
     await setTime(timestamp + daysToSeconds(1));
-    await assessment.connect(user1).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(user1).castVotes([1], [true], [ASSESSMENT_DATA_HASH], 0);
     {
       const { poll } = await assessment.assessments(1);
       await setTime(poll.end);
     }
-    await expect(assessment.connect(user2).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0)).to.be.revertedWith(
+    await expect(assessment.connect(user2).castVotes([1], [true], [ASSESSMENT_DATA_HASH], 0)).to.be.revertedWith(
       'Voting is closed',
     );
-    await expect(assessment.connect(user2).castVotes([1], [false], ['ipfsAssessmentDataHash'], 0)).to.be.revertedWith(
+    await expect(assessment.connect(user2).castVotes([1], [false], [ASSESSMENT_DATA_HASH], 0)).to.be.revertedWith(
       'Voting is closed',
     );
   });
@@ -70,7 +72,7 @@ describe('castVotes', function () {
     const user = this.accounts.members[0];
     await assessment.connect(user).stake(parseEther('100'));
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
-    await expect(assessment.connect(user).castVotes([0], [false], ['ipfsAssessmentDataHash'], 0)).to.be.revertedWith(
+    await expect(assessment.connect(user).castVotes([0], [false], [ASSESSMENT_DATA_HASH], 0)).to.be.revertedWith(
       'At least one accept vote is required to vote deny',
     );
   });
@@ -85,7 +87,7 @@ describe('castVotes', function () {
       await setTime(timestamp + daysToSeconds(1));
     }
 
-    await assessment.connect(user).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(user).castVotes([0], [true], [ASSESSMENT_DATA_HASH], 0);
     let expectedEnd;
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
@@ -110,7 +112,7 @@ describe('castVotes', function () {
     await assessment.connect(user4).stake(parseEther('800'));
     await assessment.connect(user5).stake(parseEther('300'));
 
-    await assessment.connect(user1).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(user1).castVotes([0], [true], [ASSESSMENT_DATA_HASH], 0);
 
     {
       const { poll } = await assessment.assessments(0);
@@ -119,7 +121,7 @@ describe('castVotes', function () {
       await setTime(poll.end - 2);
     }
 
-    await assessment.connect(user2).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(user2).castVotes([0], [true], [ASSESSMENT_DATA_HASH], 0);
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
       const { poll } = await assessment.assessments(0);
@@ -129,7 +131,7 @@ describe('castVotes', function () {
       await setTime(timestamp + daysToSeconds(1) - 1);
     }
 
-    await assessment.connect(user3).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(user3).castVotes([0], [true], [ASSESSMENT_DATA_HASH], 0);
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
       const { poll } = await assessment.assessments(0);
@@ -137,7 +139,7 @@ describe('castVotes', function () {
       await setTime(timestamp + daysToSeconds(1) - 1);
     }
 
-    await assessment.connect(user4).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(user4).castVotes([0], [true], [ASSESSMENT_DATA_HASH], 0);
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
       const { poll } = await assessment.assessments(0);
@@ -145,7 +147,7 @@ describe('castVotes', function () {
       await setTime(timestamp + daysToSeconds(1) - 1);
     }
 
-    await assessment.connect(user5).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(user5).castVotes([0], [true], [ASSESSMENT_DATA_HASH], 0);
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
       const { poll } = await assessment.assessments(0);
@@ -165,19 +167,19 @@ describe('castVotes', function () {
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
 
     {
-      await assessment.connect(user1).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user1).castVotes([0], [true], [ASSESSMENT_DATA_HASH], 0);
       const { poll } = await assessment.assessments(0);
       expect(poll.accepted).to.be.equal(parseEther('100'));
     }
 
     {
-      await assessment.connect(user2).castVotes([0], [false], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user2).castVotes([0], [false], [ASSESSMENT_DATA_HASH], 0);
       const { poll } = await assessment.assessments(0);
       expect(poll.accepted).to.be.equal(parseEther('100'));
     }
 
     {
-      await assessment.connect(user3).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user3).castVotes([0], [true], [ASSESSMENT_DATA_HASH], 0);
       const { poll } = await assessment.assessments(0);
       expect(poll.accepted).to.be.equal(parseEther('200'));
     }
@@ -194,25 +196,25 @@ describe('castVotes', function () {
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
 
     {
-      await assessment.connect(user1).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user1).castVotes([0], [true], [ASSESSMENT_DATA_HASH], 0);
       const { poll } = await assessment.assessments(0);
       expect(poll.denied).to.be.equal(parseEther('0'));
     }
 
     {
-      await assessment.connect(user2).castVotes([0], [false], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user2).castVotes([0], [false], [ASSESSMENT_DATA_HASH], 0);
       const { poll } = await assessment.assessments(0);
       expect(poll.denied).to.be.equal(parseEther('100'));
     }
 
     {
-      await assessment.connect(user3).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user3).castVotes([0], [true], [ASSESSMENT_DATA_HASH], 0);
       const { poll } = await assessment.assessments(0);
       expect(poll.denied).to.be.equal(parseEther('100'));
     }
 
     {
-      await assessment.connect(user4).castVotes([0], [false], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user4).castVotes([0], [false], [ASSESSMENT_DATA_HASH], 0);
       const { poll } = await assessment.assessments(0);
       expect(poll.denied).to.be.equal(parseEther('200'));
     }
@@ -228,7 +230,7 @@ describe('castVotes', function () {
     await individualClaims.submitClaim(1, 0, parseEther('100'), '');
 
     {
-      await assessment.connect(user1).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user1).castVotes([0], [true], [ASSESSMENT_DATA_HASH], 0);
       const { timestamp: timestampAtVoteTime } = await ethers.provider.getBlock('latest');
       const { assessmentId, accepted, timestamp, stakedAmount } = await assessment.votesOf(user1.address, 0);
       expect(assessmentId).to.be.equal(0);
@@ -238,7 +240,7 @@ describe('castVotes', function () {
     }
 
     {
-      await assessment.connect(user1).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user1).castVotes([1], [true], [ASSESSMENT_DATA_HASH], 0);
       const { timestamp: timestampAtVoteTime } = await ethers.provider.getBlock('latest');
       const { assessmentId, accepted, timestamp, stakedAmount } = await assessment.votesOf(user1.address, 1);
       expect(assessmentId).to.be.equal(1);
@@ -248,7 +250,7 @@ describe('castVotes', function () {
     }
 
     {
-      await assessment.connect(user2).castVotes([0], [false], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user2).castVotes([0], [false], [ASSESSMENT_DATA_HASH], 0);
       const { timestamp: timestampAtVoteTime } = await ethers.provider.getBlock('latest');
       const { assessmentId, accepted, timestamp, stakedAmount } = await assessment.votesOf(user2.address, 0);
       expect(assessmentId).to.be.equal(0);
@@ -258,7 +260,7 @@ describe('castVotes', function () {
     }
 
     {
-      await assessment.connect(user2).castVotes([1], [false], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user2).castVotes([1], [false], [ASSESSMENT_DATA_HASH], 0);
       const { timestamp: timestampAtVoteTime } = await ethers.provider.getBlock('latest');
       const { assessmentId, accepted, timestamp, stakedAmount } = await assessment.votesOf(user2.address, 1);
       expect(assessmentId).to.be.equal(1);
@@ -277,7 +279,7 @@ describe('castVotes', function () {
     await individualClaims.submitClaim(1, 0, parseEther('100'), '');
 
     {
-      await assessment.connect(user1).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user1).castVotes([0], [true], [ASSESSMENT_DATA_HASH], 0);
       const { timestamp: timestampAtVoteTime } = await ethers.provider.getBlock('latest');
       const { assessmentId, accepted, timestamp, stakedAmount } = await assessment.votesOf(user1.address, 0);
       expect(assessmentId).to.be.equal(0);
@@ -287,7 +289,7 @@ describe('castVotes', function () {
     }
 
     {
-      await assessment.connect(user1).castVotes([1], [true], ['ipfsAssessmentDataHash'], parseEther('33'));
+      await assessment.connect(user1).castVotes([1], [true], [ASSESSMENT_DATA_HASH], parseEther('33'));
       const { timestamp: timestampAtVoteTime } = await ethers.provider.getBlock('latest');
       const { assessmentId, accepted, timestamp, stakedAmount } = await assessment.votesOf(user1.address, 1);
       expect(assessmentId).to.be.equal(1);
@@ -313,29 +315,25 @@ describe('castVotes', function () {
 
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
     await individualClaims.submitClaim(1, 0, parseEther('100'), '');
-
+    const assessmentDataIpfsHashes = ['1st Assessment data ipfs hash', '2nd Assessment data ipfs hash'];
     {
-      const tx = await assessment
-        .connect(user1)
-        .castVotes([0, 1], [true, true], ['ipfsAssessmentDataHash', 'ipfsAssessmentDataHash'], 0);
+      const tx = await assessment.connect(user1).castVotes([0, 1], [true, true], assessmentDataIpfsHashes, 0);
       await expect(tx)
         .to.emit(assessment, 'VoteCast')
-        .withArgs(user1.address, 0, parseEther('100'), true, 'ipfsAssessmentDataHash');
+        .withArgs(user1.address, 0, parseEther('100'), true, assessmentDataIpfsHashes[0]);
       await expect(tx)
         .to.emit(assessment, 'VoteCast')
-        .withArgs(user1.address, 1, parseEther('100'), true, 'ipfsAssessmentDataHash');
+        .withArgs(user1.address, 1, parseEther('100'), true, assessmentDataIpfsHashes[1]);
     }
 
     {
-      const tx = await assessment
-        .connect(user2)
-        .castVotes([0, 1], [true, false], ['ipfsAssessmentDataHash', 'ipfsAssessmentDataHash'], 0);
+      const tx = await assessment.connect(user2).castVotes([0, 1], [true, false], assessmentDataIpfsHashes, 0);
       await expect(tx)
         .to.emit(assessment, 'VoteCast')
-        .withArgs(user2.address, 0, parseEther('1000'), true, 'ipfsAssessmentDataHash');
+        .withArgs(user2.address, 0, parseEther('1000'), true, assessmentDataIpfsHashes[0]);
       await expect(tx)
         .to.emit(assessment, 'VoteCast')
-        .withArgs(user2.address, 1, parseEther('1000'), false, 'ipfsAssessmentDataHash');
+        .withArgs(user2.address, 1, parseEther('1000'), false, assessmentDataIpfsHashes[1]);
     }
   });
 
@@ -345,7 +343,7 @@ describe('castVotes', function () {
 
     await master.setEmergencyPause(true);
 
-    await expect(assessment.connect(user).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0)).to.revertedWith(
+    await expect(assessment.connect(user).castVotes([0], [true], [ASSESSMENT_DATA_HASH], 0)).to.revertedWith(
       'System is paused',
     );
   });
@@ -354,7 +352,7 @@ describe('castVotes', function () {
     const { assessment } = this.contracts;
     const [nonMember] = this.accounts.nonMembers;
 
-    await expect(assessment.connect(nonMember).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0)).to.revertedWith(
+    await expect(assessment.connect(nonMember).castVotes([0], [true], [ASSESSMENT_DATA_HASH], 0)).to.revertedWith(
       'Caller is not a member',
     );
   });
@@ -364,8 +362,17 @@ describe('castVotes', function () {
     const [user] = this.accounts.members;
 
     await expect(
-      assessment.connect(user).castVotes([0], [true, true], ['ipfsAssessmentDataHash', 'ipfsAssessmentDataHash'], 0),
+      assessment.connect(user).castVotes([0], [true, true], [ASSESSMENT_DATA_HASH, ASSESSMENT_DATA_HASH], 0),
     ).to.revertedWith('The lengths of the assessment ids and votes arrays mismatch');
+  });
+
+  it('reverts if array length of assessments id and ipfsHashes does not match', async function () {
+    const { assessment } = this.contracts;
+    const [user] = this.accounts.members;
+
+    await expect(
+      assessment.connect(user).castVotes([0], [true], [ASSESSMENT_DATA_HASH, ASSESSMENT_DATA_HASH], 0),
+    ).to.revertedWith('The lengths of the assessment ids and ipfs assessment data hashes arrays mismatch');
   });
 
   it('does not revert on empty arrays', async function () {
@@ -404,9 +411,7 @@ describe('castVotes', function () {
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
     await individualClaims.submitClaim(1, 0, parseEther('100'), '');
 
-    await assessment
-      .connect(user)
-      .castVotes([0, 1], [true, true], ['ipfsAssessmentDataHash', 'ipfsAssessmentDataHash'], 0);
+    await assessment.connect(user).castVotes([0, 1], [true, true], [ASSESSMENT_DATA_HASH, ASSESSMENT_DATA_HASH], 0);
     const { timestamp: timestampAtVoteTime } = await ethers.provider.getBlock('latest');
 
     {
@@ -447,7 +452,7 @@ describe('castVotes', function () {
       expect(amount).to.be.equal(0);
     }
 
-    await assessment.connect(user).castVotes([0], [true], ['ipfsAssessmentDataHash'], stakeAmount);
+    await assessment.connect(user).castVotes([0], [true], [ASSESSMENT_DATA_HASH], stakeAmount);
 
     {
       const { amount } = await assessment.stakeOf(user.address);
@@ -487,7 +492,7 @@ describe('castVotes', function () {
     const votes = [true, false, true, false, false, true, true, false, true, true, true];
 
     for (let i = 0; i < voters.length; i++) {
-      await assessment.connect(voters[i]).castVotes([assessmentId], [votes[i]], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(voters[i]).castVotes([assessmentId], [votes[i]], [ASSESSMENT_DATA_HASH], 0);
     }
 
     const { poll } = await assessment.assessments(assessmentId);

--- a/test/unit/Assessment/castVotes.js
+++ b/test/unit/Assessment/castVotes.js
@@ -11,19 +11,23 @@ describe('castVotes', function () {
     const user = this.accounts.members[0];
     await assessment.connect(user).stake(parseEther('100'));
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
-    await assessment.connect(user).castVotes([0], [true], 0);
-    await expect(assessment.connect(user).castVotes([0], [true], 0)).to.be.revertedWith('Already voted');
-    await expect(assessment.connect(user).castVotes([0], [false], 0)).to.be.revertedWith('Already voted');
+    await assessment.connect(user).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await expect(assessment.connect(user).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0)).to.be.revertedWith(
+      'Already voted',
+    );
+    await expect(assessment.connect(user).castVotes([0], [false], ['ipfsAssessmentDataHash'], 0)).to.be.revertedWith(
+      'Already voted',
+    );
   });
 
   it('reverts if the user has no stake', async function () {
     const { assessment, individualClaims } = this.contracts;
     const user = this.accounts.members[0];
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
-    await expect(assessment.connect(user).castVotes([0], [true], 0)).to.be.revertedWith(
+    await expect(assessment.connect(user).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0)).to.be.revertedWith(
       'A stake is required to cast votes',
     );
-    await expect(assessment.connect(user).castVotes([0], [false], 0)).to.be.revertedWith(
+    await expect(assessment.connect(user).castVotes([0], [false], ['ipfsAssessmentDataHash'], 0)).to.be.revertedWith(
       'A stake is required to cast votes',
     );
   });
@@ -38,19 +42,27 @@ describe('castVotes', function () {
       const { poll } = await assessment.assessments(0);
       await setTime(poll.end);
     }
-    await expect(assessment.connect(user1).castVotes([0], [true], 0)).to.be.revertedWith('Voting is closed');
-    await expect(assessment.connect(user1).castVotes([0], [false], 0)).to.be.revertedWith('Voting is closed');
+    await expect(assessment.connect(user1).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0)).to.be.revertedWith(
+      'Voting is closed',
+    );
+    await expect(assessment.connect(user1).castVotes([0], ['ipfsAssessmentDataHash'], [false], 0)).to.be.revertedWith(
+      'Voting is closed',
+    );
 
     await individualClaims.submitClaim(1, 0, parseEther('100'), '');
     const { timestamp } = await ethers.provider.getBlock('latest');
     await setTime(timestamp + daysToSeconds(1));
-    await assessment.connect(user1).castVotes([1], [true], 0);
+    await assessment.connect(user1).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
     {
       const { poll } = await assessment.assessments(1);
       await setTime(poll.end);
     }
-    await expect(assessment.connect(user2).castVotes([1], [true], 0)).to.be.revertedWith('Voting is closed');
-    await expect(assessment.connect(user2).castVotes([1], [false], 0)).to.be.revertedWith('Voting is closed');
+    await expect(assessment.connect(user2).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0)).to.be.revertedWith(
+      'Voting is closed',
+    );
+    await expect(assessment.connect(user2).castVotes([1], [false], ['ipfsAssessmentDataHash'], 0)).to.be.revertedWith(
+      'Voting is closed',
+    );
   });
 
   it('reverts if the first vote is deny', async function () {
@@ -58,7 +70,7 @@ describe('castVotes', function () {
     const user = this.accounts.members[0];
     await assessment.connect(user).stake(parseEther('100'));
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
-    await expect(assessment.connect(user).castVotes([0], [false], 0)).to.be.revertedWith(
+    await expect(assessment.connect(user).castVotes([0], [false], ['ipfsAssessmentDataHash'], 0)).to.be.revertedWith(
       'At least one accept vote is required to vote deny',
     );
   });
@@ -73,7 +85,7 @@ describe('castVotes', function () {
       await setTime(timestamp + daysToSeconds(1));
     }
 
-    await assessment.connect(user).castVotes([0], [true], 0);
+    await assessment.connect(user).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
     let expectedEnd;
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
@@ -98,7 +110,7 @@ describe('castVotes', function () {
     await assessment.connect(user4).stake(parseEther('800'));
     await assessment.connect(user5).stake(parseEther('300'));
 
-    await assessment.connect(user1).castVotes([0], [true], 0);
+    await assessment.connect(user1).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
 
     {
       const { poll } = await assessment.assessments(0);
@@ -107,7 +119,7 @@ describe('castVotes', function () {
       await setTime(poll.end - 2);
     }
 
-    await assessment.connect(user2).castVotes([0], [true], 0);
+    await assessment.connect(user2).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
       const { poll } = await assessment.assessments(0);
@@ -117,7 +129,7 @@ describe('castVotes', function () {
       await setTime(timestamp + daysToSeconds(1) - 1);
     }
 
-    await assessment.connect(user3).castVotes([0], [true], 0);
+    await assessment.connect(user3).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
       const { poll } = await assessment.assessments(0);
@@ -125,7 +137,7 @@ describe('castVotes', function () {
       await setTime(timestamp + daysToSeconds(1) - 1);
     }
 
-    await assessment.connect(user4).castVotes([0], [true], 0);
+    await assessment.connect(user4).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
       const { poll } = await assessment.assessments(0);
@@ -133,7 +145,7 @@ describe('castVotes', function () {
       await setTime(timestamp + daysToSeconds(1) - 1);
     }
 
-    await assessment.connect(user5).castVotes([0], [true], 0);
+    await assessment.connect(user5).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
       const { poll } = await assessment.assessments(0);
@@ -153,19 +165,19 @@ describe('castVotes', function () {
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
 
     {
-      await assessment.connect(user1).castVotes([0], [true], 0);
+      await assessment.connect(user1).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
       const { poll } = await assessment.assessments(0);
       expect(poll.accepted).to.be.equal(parseEther('100'));
     }
 
     {
-      await assessment.connect(user2).castVotes([0], [false], 0);
+      await assessment.connect(user2).castVotes([0], [false], ['ipfsAssessmentDataHash'], 0);
       const { poll } = await assessment.assessments(0);
       expect(poll.accepted).to.be.equal(parseEther('100'));
     }
 
     {
-      await assessment.connect(user3).castVotes([0], [true], 0);
+      await assessment.connect(user3).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
       const { poll } = await assessment.assessments(0);
       expect(poll.accepted).to.be.equal(parseEther('200'));
     }
@@ -182,25 +194,25 @@ describe('castVotes', function () {
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
 
     {
-      await assessment.connect(user1).castVotes([0], [true], 0);
+      await assessment.connect(user1).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
       const { poll } = await assessment.assessments(0);
       expect(poll.denied).to.be.equal(parseEther('0'));
     }
 
     {
-      await assessment.connect(user2).castVotes([0], [false], 0);
+      await assessment.connect(user2).castVotes([0], [false], ['ipfsAssessmentDataHash'], 0);
       const { poll } = await assessment.assessments(0);
       expect(poll.denied).to.be.equal(parseEther('100'));
     }
 
     {
-      await assessment.connect(user3).castVotes([0], [true], 0);
+      await assessment.connect(user3).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
       const { poll } = await assessment.assessments(0);
       expect(poll.denied).to.be.equal(parseEther('100'));
     }
 
     {
-      await assessment.connect(user4).castVotes([0], [false], 0);
+      await assessment.connect(user4).castVotes([0], [false], ['ipfsAssessmentDataHash'], 0);
       const { poll } = await assessment.assessments(0);
       expect(poll.denied).to.be.equal(parseEther('200'));
     }
@@ -216,7 +228,7 @@ describe('castVotes', function () {
     await individualClaims.submitClaim(1, 0, parseEther('100'), '');
 
     {
-      await assessment.connect(user1).castVotes([0], [true], 0);
+      await assessment.connect(user1).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
       const { timestamp: timestampAtVoteTime } = await ethers.provider.getBlock('latest');
       const { assessmentId, accepted, timestamp, stakedAmount } = await assessment.votesOf(user1.address, 0);
       expect(assessmentId).to.be.equal(0);
@@ -226,7 +238,7 @@ describe('castVotes', function () {
     }
 
     {
-      await assessment.connect(user1).castVotes([1], [true], 0);
+      await assessment.connect(user1).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
       const { timestamp: timestampAtVoteTime } = await ethers.provider.getBlock('latest');
       const { assessmentId, accepted, timestamp, stakedAmount } = await assessment.votesOf(user1.address, 1);
       expect(assessmentId).to.be.equal(1);
@@ -236,7 +248,7 @@ describe('castVotes', function () {
     }
 
     {
-      await assessment.connect(user2).castVotes([0], [false], 0);
+      await assessment.connect(user2).castVotes([0], [false], ['ipfsAssessmentDataHash'], 0);
       const { timestamp: timestampAtVoteTime } = await ethers.provider.getBlock('latest');
       const { assessmentId, accepted, timestamp, stakedAmount } = await assessment.votesOf(user2.address, 0);
       expect(assessmentId).to.be.equal(0);
@@ -246,7 +258,7 @@ describe('castVotes', function () {
     }
 
     {
-      await assessment.connect(user2).castVotes([1], [false], 0);
+      await assessment.connect(user2).castVotes([1], [false], ['ipfsAssessmentDataHash'], 0);
       const { timestamp: timestampAtVoteTime } = await ethers.provider.getBlock('latest');
       const { assessmentId, accepted, timestamp, stakedAmount } = await assessment.votesOf(user2.address, 1);
       expect(assessmentId).to.be.equal(1);
@@ -265,7 +277,7 @@ describe('castVotes', function () {
     await individualClaims.submitClaim(1, 0, parseEther('100'), '');
 
     {
-      await assessment.connect(user1).castVotes([0], [true], 0);
+      await assessment.connect(user1).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
       const { timestamp: timestampAtVoteTime } = await ethers.provider.getBlock('latest');
       const { assessmentId, accepted, timestamp, stakedAmount } = await assessment.votesOf(user1.address, 0);
       expect(assessmentId).to.be.equal(0);
@@ -275,7 +287,7 @@ describe('castVotes', function () {
     }
 
     {
-      await assessment.connect(user1).castVotes([1], [true], parseEther('33'));
+      await assessment.connect(user1).castVotes([1], [true], ['ipfsAssessmentDataHash'], parseEther('33'));
       const { timestamp: timestampAtVoteTime } = await ethers.provider.getBlock('latest');
       const { assessmentId, accepted, timestamp, stakedAmount } = await assessment.votesOf(user1.address, 1);
       expect(assessmentId).to.be.equal(1);
@@ -293,7 +305,7 @@ describe('castVotes', function () {
     }
   });
 
-  it('emits VoteCast event with user, assessment id, stake amount and vote', async function () {
+  it('emits VoteCast event with user, assessment id, stake amount, vote and ipfs hashes', async function () {
     const { assessment, individualClaims } = this.contracts;
     const [user1, user2] = this.accounts.members;
     await assessment.connect(user1).stake(parseEther('100'));
@@ -303,15 +315,27 @@ describe('castVotes', function () {
     await individualClaims.submitClaim(1, 0, parseEther('100'), '');
 
     {
-      const tx = await assessment.connect(user1).castVotes([0, 1], [true, true], 0);
-      await expect(tx).to.emit(assessment, 'VoteCast').withArgs(user1.address, 0, parseEther('100'), true);
-      await expect(tx).to.emit(assessment, 'VoteCast').withArgs(user1.address, 1, parseEther('100'), true);
+      const tx = await assessment
+        .connect(user1)
+        .castVotes([0, 1], [true, true], ['ipfsAssessmentDataHash', 'ipfsAssessmentDataHash'], 0);
+      await expect(tx)
+        .to.emit(assessment, 'VoteCast')
+        .withArgs(user1.address, 0, parseEther('100'), true, 'ipfsAssessmentDataHash');
+      await expect(tx)
+        .to.emit(assessment, 'VoteCast')
+        .withArgs(user1.address, 1, parseEther('100'), true, 'ipfsAssessmentDataHash');
     }
 
     {
-      const tx = await assessment.connect(user2).castVotes([0, 1], [true, false], 0);
-      await expect(tx).to.emit(assessment, 'VoteCast').withArgs(user2.address, 0, parseEther('1000'), true);
-      await expect(tx).to.emit(assessment, 'VoteCast').withArgs(user2.address, 1, parseEther('1000'), false);
+      const tx = await assessment
+        .connect(user2)
+        .castVotes([0, 1], [true, false], ['ipfsAssessmentDataHash', 'ipfsAssessmentDataHash'], 0);
+      await expect(tx)
+        .to.emit(assessment, 'VoteCast')
+        .withArgs(user2.address, 0, parseEther('1000'), true, 'ipfsAssessmentDataHash');
+      await expect(tx)
+        .to.emit(assessment, 'VoteCast')
+        .withArgs(user2.address, 1, parseEther('1000'), false, 'ipfsAssessmentDataHash');
     }
   });
 
@@ -321,30 +345,34 @@ describe('castVotes', function () {
 
     await master.setEmergencyPause(true);
 
-    await expect(assessment.connect(user).castVotes([0], [true], 0)).to.revertedWith('System is paused');
+    await expect(assessment.connect(user).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0)).to.revertedWith(
+      'System is paused',
+    );
   });
 
   it('reverts if caller is not a member', async function () {
     const { assessment } = this.contracts;
     const [nonMember] = this.accounts.nonMembers;
 
-    await expect(assessment.connect(nonMember).castVotes([0], [true], 0)).to.revertedWith('Caller is not a member');
+    await expect(assessment.connect(nonMember).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0)).to.revertedWith(
+      'Caller is not a member',
+    );
   });
 
   it('reverts if array length of assessments id and votes does not match', async function () {
     const { assessment } = this.contracts;
     const [user] = this.accounts.members;
 
-    await expect(assessment.connect(user).castVotes([0], [true, true], 0)).to.revertedWith(
-      'The lengths of the assessment ids and votes arrays mismatch',
-    );
+    await expect(
+      assessment.connect(user).castVotes([0], [true, true], ['ipfsAssessmentDataHash', 'ipfsAssessmentDataHash'], 0),
+    ).to.revertedWith('The lengths of the assessment ids and votes arrays mismatch');
   });
 
   it('does not revert on empty arrays', async function () {
     const { assessment } = this.contracts;
     const [user] = this.accounts.members;
 
-    await expect(assessment.connect(user).castVotes([], [], 0)).to.not.be.reverted;
+    await expect(assessment.connect(user).castVotes([], [], [], 0)).to.not.be.reverted;
   });
 
   it('allows to stake without voting', async function () {
@@ -360,7 +388,7 @@ describe('castVotes', function () {
       expect(amount).to.be.equal(0);
     }
 
-    await assessment.connect(user).castVotes([], [], stakeAmount);
+    await assessment.connect(user).castVotes([], [], [], stakeAmount);
 
     {
       const { amount } = await assessment.stakeOf(user.address);
@@ -376,7 +404,9 @@ describe('castVotes', function () {
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
     await individualClaims.submitClaim(1, 0, parseEther('100'), '');
 
-    await assessment.connect(user).castVotes([0, 1], [true, true], 0);
+    await assessment
+      .connect(user)
+      .castVotes([0, 1], [true, true], ['ipfsAssessmentDataHash', 'ipfsAssessmentDataHash'], 0);
     const { timestamp: timestampAtVoteTime } = await ethers.provider.getBlock('latest');
 
     {
@@ -417,7 +447,7 @@ describe('castVotes', function () {
       expect(amount).to.be.equal(0);
     }
 
-    await assessment.connect(user).castVotes([0], [true], stakeAmount);
+    await assessment.connect(user).castVotes([0], [true], ['ipfsAssessmentDataHash'], stakeAmount);
 
     {
       const { amount } = await assessment.stakeOf(user.address);
@@ -457,7 +487,7 @@ describe('castVotes', function () {
     const votes = [true, false, true, false, false, true, true, false, true, true, true];
 
     for (let i = 0; i < voters.length; i++) {
-      await assessment.connect(voters[i]).castVotes([assessmentId], [votes[i]], 0);
+      await assessment.connect(voters[i]).castVotes([assessmentId], [votes[i]], ['ipfsAssessmentDataHash'], 0);
     }
 
     const { poll } = await assessment.assessments(assessmentId);

--- a/test/unit/Assessment/getPoll.js
+++ b/test/unit/Assessment/getPoll.js
@@ -16,7 +16,7 @@ describe('getPoll', function () {
       expect(poll.start).to.be.equal(targetAssessment.poll.start);
       expect(poll.end).to.be.equal(targetAssessment.poll.end);
     }
-    await assessment.connect(user).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(user).castVotes([0], [true], ['Assessment data hash'], 0);
     {
       const targetAssessment = await assessment.assessments(0);
       const poll = await assessment.getPoll(0);

--- a/test/unit/Assessment/getPoll.js
+++ b/test/unit/Assessment/getPoll.js
@@ -16,7 +16,7 @@ describe('getPoll', function () {
       expect(poll.start).to.be.equal(targetAssessment.poll.start);
       expect(poll.end).to.be.equal(targetAssessment.poll.end);
     }
-    await assessment.connect(user).castVotes([0], [true], 0);
+    await assessment.connect(user).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
     {
       const targetAssessment = await assessment.assessments(0);
       const poll = await assessment.getPoll(0);

--- a/test/unit/Assessment/getRewards.js
+++ b/test/unit/Assessment/getRewards.js
@@ -17,12 +17,12 @@ describe('getRewards', function () {
     await individualClaims.submitClaim(1, 0, parseEther('100'), '');
     await individualClaims.submitClaim(2, 0, parseEther('1000'), '');
 
-    await assessment.connect(user1).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
-    await assessment.connect(user2).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
-    await assessment.connect(user1).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
-    await assessment.connect(user2).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
-    await assessment.connect(user1).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
-    await assessment.connect(user2).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(user1).castVotes([0], [true], ['Assessment data hash'], 0);
+    await assessment.connect(user2).castVotes([0], [true], ['Assessment data hash'], 0);
+    await assessment.connect(user1).castVotes([1], [true], ['Assessment data hash'], 0);
+    await assessment.connect(user2).castVotes([1], [true], ['Assessment data hash'], 0);
+    await assessment.connect(user1).castVotes([2], [true], ['Assessment data hash'], 0);
+    await assessment.connect(user2).castVotes([2], [true], ['Assessment data hash'], 0);
 
     let expectedUser1Reward = ethers.constants.Zero;
     let expectedUser2Reward = ethers.constants.Zero;
@@ -92,8 +92,8 @@ describe('getRewards', function () {
     await individualClaims.submitClaim(0, 0, parseEther('10'), '');
     await individualClaims.submitClaim(1, 0, parseEther('100'), '');
 
-    await assessment.connect(user).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
-    await assessment.connect(user).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(user).castVotes([0], [true], ['Assessment data hash'], 0);
+    await assessment.connect(user).castVotes([1], [true], ['Assessment data hash'], 0);
 
     let expectedReward = ethers.constants.Zero;
 
@@ -135,7 +135,7 @@ describe('getRewards', function () {
 
     {
       await individualClaims.submitClaim(0, 0, parseEther('1000'), '');
-      await assessment.connect(user).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user).castVotes([2], [true], ['Assessment data hash'], 0);
       const { withdrawableAmountInNXM } = await assessment.getRewards(user.address);
       expect(withdrawableAmountInNXM).to.be.equal(0);
     }
@@ -158,8 +158,8 @@ describe('getRewards', function () {
     await individualClaims.submitClaim(0, 0, parseEther('10'), '');
     await individualClaims.submitClaim(0, 1, parseEther('100'), '');
 
-    await assessment.connect(user).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
-    await assessment.connect(user).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(user).castVotes([0], [true], ['Assessment data hash'], 0);
+    await assessment.connect(user).castVotes([1], [true], ['Assessment data hash'], 0);
 
     {
       const { withdrawableUntilIndex } = await assessment.getRewards(user.address);
@@ -175,7 +175,7 @@ describe('getRewards', function () {
 
     {
       await individualClaims.submitClaim(0, 0, parseEther('1000'), '');
-      await assessment.connect(user).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user).castVotes([2], [true], ['Assessment data hash'], 0);
       const { withdrawableUntilIndex } = await assessment.getRewards(user.address);
       expect(withdrawableUntilIndex).to.be.equal(2);
     }

--- a/test/unit/Assessment/getRewards.js
+++ b/test/unit/Assessment/getRewards.js
@@ -17,12 +17,12 @@ describe('getRewards', function () {
     await individualClaims.submitClaim(1, 0, parseEther('100'), '');
     await individualClaims.submitClaim(2, 0, parseEther('1000'), '');
 
-    await assessment.connect(user1).castVotes([0], [true], 0);
-    await assessment.connect(user2).castVotes([0], [true], 0);
-    await assessment.connect(user1).castVotes([1], [true], 0);
-    await assessment.connect(user2).castVotes([1], [true], 0);
-    await assessment.connect(user1).castVotes([2], [true], 0);
-    await assessment.connect(user2).castVotes([2], [true], 0);
+    await assessment.connect(user1).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(user2).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(user1).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(user2).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(user1).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(user2).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
 
     let expectedUser1Reward = ethers.constants.Zero;
     let expectedUser2Reward = ethers.constants.Zero;
@@ -92,8 +92,8 @@ describe('getRewards', function () {
     await individualClaims.submitClaim(0, 0, parseEther('10'), '');
     await individualClaims.submitClaim(1, 0, parseEther('100'), '');
 
-    await assessment.connect(user).castVotes([0], [true], 0);
-    await assessment.connect(user).castVotes([1], [true], 0);
+    await assessment.connect(user).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(user).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
 
     let expectedReward = ethers.constants.Zero;
 
@@ -135,7 +135,7 @@ describe('getRewards', function () {
 
     {
       await individualClaims.submitClaim(0, 0, parseEther('1000'), '');
-      await assessment.connect(user).castVotes([2], [true], 0);
+      await assessment.connect(user).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
       const { withdrawableAmountInNXM } = await assessment.getRewards(user.address);
       expect(withdrawableAmountInNXM).to.be.equal(0);
     }
@@ -158,8 +158,8 @@ describe('getRewards', function () {
     await individualClaims.submitClaim(0, 0, parseEther('10'), '');
     await individualClaims.submitClaim(0, 1, parseEther('100'), '');
 
-    await assessment.connect(user).castVotes([0], [true], 0);
-    await assessment.connect(user).castVotes([1], [true], 0);
+    await assessment.connect(user).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(user).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
 
     {
       const { withdrawableUntilIndex } = await assessment.getRewards(user.address);
@@ -175,7 +175,7 @@ describe('getRewards', function () {
 
     {
       await individualClaims.submitClaim(0, 0, parseEther('1000'), '');
-      await assessment.connect(user).castVotes([2], [true], 0);
+      await assessment.connect(user).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
       const { withdrawableUntilIndex } = await assessment.getRewards(user.address);
       expect(withdrawableUntilIndex).to.be.equal(2);
     }

--- a/test/unit/Assessment/getVoteCountOfAssessor.js
+++ b/test/unit/Assessment/getVoteCountOfAssessor.js
@@ -18,15 +18,15 @@ describe('getVoteCountOfAssessor', function () {
       expect(count).to.be.equal(0);
     }
 
-    await assessment.connect(assessor1).castVotes([0], [true], 0);
+    await assessment.connect(assessor1).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
 
     {
       const count = await assessment.getVoteCountOfAssessor(assessor1.address);
       expect(count).to.be.equal(1);
     }
 
-    await assessment.connect(assessor1).castVotes([1], [true], 0);
-    await assessment.connect(assessor1).castVotes([2], [true], 0);
+    await assessment.connect(assessor1).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(assessor1).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
 
     {
       const count = await assessment.getVoteCountOfAssessor(assessor1.address);
@@ -38,8 +38,8 @@ describe('getVoteCountOfAssessor', function () {
       expect(count).to.be.equal(0);
     }
 
-    await assessment.connect(assessor2).castVotes([1], [true], 0);
-    await assessment.connect(assessor2).castVotes([2], [true], 0);
+    await assessment.connect(assessor2).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(assessor2).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
 
     {
       const count = await assessment.getVoteCountOfAssessor(assessor2.address);

--- a/test/unit/Assessment/getVoteCountOfAssessor.js
+++ b/test/unit/Assessment/getVoteCountOfAssessor.js
@@ -18,15 +18,15 @@ describe('getVoteCountOfAssessor', function () {
       expect(count).to.be.equal(0);
     }
 
-    await assessment.connect(assessor1).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(assessor1).castVotes([0], [true], ['Assessment data hash'], 0);
 
     {
       const count = await assessment.getVoteCountOfAssessor(assessor1.address);
       expect(count).to.be.equal(1);
     }
 
-    await assessment.connect(assessor1).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
-    await assessment.connect(assessor1).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(assessor1).castVotes([1], [true], ['Assessment data hash'], 0);
+    await assessment.connect(assessor1).castVotes([2], [true], ['Assessment data hash'], 0);
 
     {
       const count = await assessment.getVoteCountOfAssessor(assessor1.address);
@@ -38,8 +38,8 @@ describe('getVoteCountOfAssessor', function () {
       expect(count).to.be.equal(0);
     }
 
-    await assessment.connect(assessor2).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
-    await assessment.connect(assessor2).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(assessor2).castVotes([1], [true], ['Assessment data hash'], 0);
+    await assessment.connect(assessor2).castVotes([2], [true], ['Assessment data hash'], 0);
 
     {
       const count = await assessment.getVoteCountOfAssessor(assessor2.address);

--- a/test/unit/Assessment/helpers.js
+++ b/test/unit/Assessment/helpers.js
@@ -161,7 +161,7 @@ const generateRewards = async ({ assessment, individualClaims, staker }) => {
   await assessment.connect(staker).stake(parseEther('10'));
 
   await individualClaims.connect(staker).submitClaim(0, 0, parseEther('100'), '');
-  await assessment.connect(staker).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+  await assessment.connect(staker).castVotes([0], [true], ['Assessment data hash'], 0);
 };
 
 module.exports = {

--- a/test/unit/Assessment/helpers.js
+++ b/test/unit/Assessment/helpers.js
@@ -161,7 +161,7 @@ const generateRewards = async ({ assessment, individualClaims, staker }) => {
   await assessment.connect(staker).stake(parseEther('10'));
 
   await individualClaims.connect(staker).submitClaim(0, 0, parseEther('100'), '');
-  await assessment.connect(staker).castVotes([0], [true], 0);
+  await assessment.connect(staker).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
 };
 
 module.exports = {

--- a/test/unit/Assessment/processFraud.js
+++ b/test/unit/Assessment/processFraud.js
@@ -13,7 +13,7 @@ describe('processFraud', function () {
     const [fraudulentMember, honestMember] = this.accounts.members;
     await assessment.connect(fraudulentMember).stake(parseEther('100'));
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
-    await assessment.connect(fraudulentMember).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(fraudulentMember).castVotes([0], [true], ['Assessment data hash'], 0);
     const merkleTree = await submitFraud({
       assessment,
       signer: governance,
@@ -84,10 +84,10 @@ describe('processFraud', function () {
     await assessment.connect(otherMember2).stake(parseEther('10'));
 
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
-    await assessment.connect(fraudulentMember).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(fraudulentMember).castVotes([0], [true], ['Assessment data hash'], 0);
 
     await individualClaims.submitClaim(1, 0, parseEther('100'), '');
-    await assessment.connect(fraudulentMember).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(fraudulentMember).castVotes([1], [true], ['Assessment data hash'], 0);
 
     const { timestamp } = await ethers.provider.getBlock('latest');
     await setTime(timestamp + daysToSeconds(30));
@@ -95,19 +95,19 @@ describe('processFraud', function () {
 
     // Fraudulent claim
     await individualClaims.submitClaim(2, 0, parseEther('100'), '');
-    await assessment.connect(fraudulentMember).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
-    await assessment.connect(otherMember1).castVotes([2], [false], ['ipfsAssessmentDataHash'], 0);
-    await assessment.connect(otherMember2).castVotes([2], [false], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(fraudulentMember).castVotes([2], [true], ['Assessment data hash'], 0);
+    await assessment.connect(otherMember1).castVotes([2], [false], ['Assessment data hash'], 0);
+    await assessment.connect(otherMember2).castVotes([2], [false], ['Assessment data hash'], 0);
 
     await individualClaims.submitClaim(3, 0, parseEther('100'), '');
-    await assessment.connect(otherMember1).castVotes([3], [true], ['ipfsAssessmentDataHash'], 0);
-    await assessment.connect(otherMember2).castVotes([3], [true], ['ipfsAssessmentDataHash'], 0);
-    await assessment.connect(fraudulentMember).castVotes([3], [false], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(otherMember1).castVotes([3], [true], ['Assessment data hash'], 0);
+    await assessment.connect(otherMember2).castVotes([3], [true], ['Assessment data hash'], 0);
+    await assessment.connect(fraudulentMember).castVotes([3], [false], ['Assessment data hash'], 0);
 
     await individualClaims.submitClaim(4, 0, parseEther('100'), '');
-    await assessment.connect(fraudulentMember).castVotes([4], [true], ['ipfsAssessmentDataHash'], 0);
-    await assessment.connect(otherMember1).castVotes([4], [true], ['ipfsAssessmentDataHash'], 0);
-    await assessment.connect(otherMember2).castVotes([4], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(fraudulentMember).castVotes([4], [true], ['Assessment data hash'], 0);
+    await assessment.connect(otherMember1).castVotes([4], [true], ['Assessment data hash'], 0);
+    await assessment.connect(otherMember2).castVotes([4], [true], ['Assessment data hash'], 0);
 
     const stake = await assessment.stakeOf(fraudulentMember.address);
     expect(stake.rewardsWithdrawableFromIndex).to.be.equal(2);
@@ -187,7 +187,7 @@ describe('processFraud', function () {
     await Promise.all(
       Array(10)
         .fill('')
-        .map((_, i) => assessment.connect(fraudulentMember).castVotes([i], [true], ['ipfsAssessmentDataHash'], 0)),
+        .map((_, i) => assessment.connect(fraudulentMember).castVotes([i], [true], ['Assessment data hash'], 0)),
     );
 
     const burnAmount = parseEther('50');
@@ -285,10 +285,10 @@ describe('processFraud', function () {
     await assessment.connect(otherMember2).stake(parseEther('200'));
 
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
-    await assessment.connect(fraudulentMember).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(fraudulentMember).castVotes([0], [true], ['Assessment data hash'], 0);
 
     await individualClaims.submitClaim(1, 0, parseEther('100'), '');
-    await assessment.connect(fraudulentMember).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(fraudulentMember).castVotes([1], [true], ['Assessment data hash'], 0);
 
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
@@ -296,14 +296,14 @@ describe('processFraud', function () {
     }
 
     // Increases the poll end by 1 day
-    await assessment.connect(otherMember1).castVotes([1], [false], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(otherMember1).castVotes([1], [false], ['Assessment data hash'], 0);
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
       await setTime(timestamp + daysToSeconds(1) - 2);
     }
 
     // Increases the poll end by 1 day
-    await assessment.connect(otherMember2).castVotes([1], [false], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(otherMember2).castVotes([1], [false], ['Assessment data hash'], 0);
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
       await setTime(timestamp + daysToSeconds(2) - 2);
@@ -348,7 +348,7 @@ describe('processFraud', function () {
     await assessment.connect(fraudulentMember).stake(parseEther('100'));
 
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
-    await assessment.connect(fraudulentMember).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(fraudulentMember).castVotes([0], [true], ['Assessment data hash'], 0);
 
     {
       const fraudulentAssessment = await assessment.assessments(0);
@@ -391,11 +391,11 @@ describe('processFraud', function () {
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
     await individualClaims.submitClaim(1, 0, parseEther('1000'), '');
 
-    await assessment.connect(fraudulentMember1).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
-    await assessment.connect(fraudulentMember1).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(fraudulentMember1).castVotes([0], [true], ['Assessment data hash'], 0);
+    await assessment.connect(fraudulentMember1).castVotes([1], [true], ['Assessment data hash'], 0);
 
-    await assessment.connect(fraudulentMember2).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
-    await assessment.connect(fraudulentMember2).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(fraudulentMember2).castVotes([0], [true], ['Assessment data hash'], 0);
+    await assessment.connect(fraudulentMember2).castVotes([1], [true], ['Assessment data hash'], 0);
 
     const { poll: poll1 } = await assessment.assessments(0);
     const { poll: poll2 } = await assessment.assessments(1);
@@ -484,7 +484,7 @@ describe('processFraud', function () {
 
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
 
-    await assessment.connect(fraudulentMember).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(fraudulentMember).castVotes([0], [true], ['Assessment data hash'], 0);
 
     const burnAmount = parseEther('33');
     await submitFraud({
@@ -525,7 +525,7 @@ describe('processFraud', function () {
 
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
 
-    await assessment.connect(fraudulentMember).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(fraudulentMember).castVotes([0], [true], ['Assessment data hash'], 0);
 
     await submitFraud({
       assessment,
@@ -574,7 +574,7 @@ describe('processFraud', function () {
     await Promise.all(
       Array(10)
         .fill('')
-        .map((_, i) => assessment.connect(fraudulentMember).castVotes([i], [true], ['ipfsAssessmentDataHash'], 0)),
+        .map((_, i) => assessment.connect(fraudulentMember).castVotes([i], [true], ['Assessment data hash'], 0)),
     );
 
     const burnAmount = parseEther('50');
@@ -666,7 +666,7 @@ describe('processFraud', function () {
     await Promise.all(
       Array(2)
         .fill('')
-        .map((_, i) => assessment.connect(fraudulentMember).castVotes([i], [true], ['ipfsAssessmentDataHash'], 0)),
+        .map((_, i) => assessment.connect(fraudulentMember).castVotes([i], [true], ['Assessment data hash'], 0)),
     );
 
     const burnAmount = parseEther('50');
@@ -729,7 +729,7 @@ describe('processFraud', function () {
     await Promise.all(
       Array(2)
         .fill('')
-        .map((_, i) => assessment.connect(fraudulentMember).castVotes([i], [true], ['ipfsAssessmentDataHash'], 0)),
+        .map((_, i) => assessment.connect(fraudulentMember).castVotes([i], [true], ['Assessment data hash'], 0)),
     );
 
     const burnAmount = parseEther('50');
@@ -810,7 +810,7 @@ describe('processFraud', function () {
 
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
 
-    await assessment.connect(fraudulentMember).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(fraudulentMember).castVotes([0], [true], ['Assessment data hash'], 0);
 
     const burnAmount = parseEther('33');
     await submitFraud({
@@ -863,7 +863,7 @@ describe('processFraud', function () {
 
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
 
-    await assessment.connect(fraudulentMember).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(fraudulentMember).castVotes([0], [true], ['Assessment data hash'], 0);
 
     const burnAmount = parseEther('33');
     await submitFraud({
@@ -941,10 +941,10 @@ describe('processFraud', function () {
     await individualClaims.submitClaim(2, 0, parseEther('100'), '');
     await individualClaims.submitClaim(3, 0, parseEther('100'), '');
 
-    await assessment.connect(fraudulentMember).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
-    await assessment.connect(fraudulentMember).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
-    await assessment.connect(fraudulentMember).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
-    await assessment.connect(fraudulentMember).castVotes([3], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(fraudulentMember).castVotes([0], [true], ['Assessment data hash'], 0);
+    await assessment.connect(fraudulentMember).castVotes([1], [true], ['Assessment data hash'], 0);
+    await assessment.connect(fraudulentMember).castVotes([2], [true], ['Assessment data hash'], 0);
+    await assessment.connect(fraudulentMember).castVotes([3], [true], ['Assessment data hash'], 0);
 
     await finalizePoll(assessment);
 
@@ -955,7 +955,7 @@ describe('processFraud', function () {
 
     // Fraudulent claim
     await individualClaims.submitClaim(4, 0, parseEther('100'), '');
-    await assessment.connect(fraudulentMember).castVotes([4], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(fraudulentMember).castVotes([4], [true], ['Assessment data hash'], 0);
 
     const burnAmount = parseEther('100');
     await submitFraud({

--- a/test/unit/Assessment/processFraud.js
+++ b/test/unit/Assessment/processFraud.js
@@ -13,7 +13,7 @@ describe('processFraud', function () {
     const [fraudulentMember, honestMember] = this.accounts.members;
     await assessment.connect(fraudulentMember).stake(parseEther('100'));
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
-    await assessment.connect(fraudulentMember).castVotes([0], [true], 0);
+    await assessment.connect(fraudulentMember).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
     const merkleTree = await submitFraud({
       assessment,
       signer: governance,
@@ -84,10 +84,10 @@ describe('processFraud', function () {
     await assessment.connect(otherMember2).stake(parseEther('10'));
 
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
-    await assessment.connect(fraudulentMember).castVotes([0], [true], 0);
+    await assessment.connect(fraudulentMember).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
 
     await individualClaims.submitClaim(1, 0, parseEther('100'), '');
-    await assessment.connect(fraudulentMember).castVotes([1], [true], 0);
+    await assessment.connect(fraudulentMember).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
 
     const { timestamp } = await ethers.provider.getBlock('latest');
     await setTime(timestamp + daysToSeconds(30));
@@ -95,19 +95,19 @@ describe('processFraud', function () {
 
     // Fraudulent claim
     await individualClaims.submitClaim(2, 0, parseEther('100'), '');
-    await assessment.connect(fraudulentMember).castVotes([2], [true], 0);
-    await assessment.connect(otherMember1).castVotes([2], [false], 0);
-    await assessment.connect(otherMember2).castVotes([2], [false], 0);
+    await assessment.connect(fraudulentMember).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(otherMember1).castVotes([2], [false], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(otherMember2).castVotes([2], [false], ['ipfsAssessmentDataHash'], 0);
 
     await individualClaims.submitClaim(3, 0, parseEther('100'), '');
-    await assessment.connect(otherMember1).castVotes([3], [true], 0);
-    await assessment.connect(otherMember2).castVotes([3], [true], 0);
-    await assessment.connect(fraudulentMember).castVotes([3], [false], 0);
+    await assessment.connect(otherMember1).castVotes([3], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(otherMember2).castVotes([3], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(fraudulentMember).castVotes([3], [false], ['ipfsAssessmentDataHash'], 0);
 
     await individualClaims.submitClaim(4, 0, parseEther('100'), '');
-    await assessment.connect(fraudulentMember).castVotes([4], [true], 0);
-    await assessment.connect(otherMember1).castVotes([4], [true], 0);
-    await assessment.connect(otherMember2).castVotes([4], [true], 0);
+    await assessment.connect(fraudulentMember).castVotes([4], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(otherMember1).castVotes([4], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(otherMember2).castVotes([4], [true], ['ipfsAssessmentDataHash'], 0);
 
     const stake = await assessment.stakeOf(fraudulentMember.address);
     expect(stake.rewardsWithdrawableFromIndex).to.be.equal(2);
@@ -187,7 +187,7 @@ describe('processFraud', function () {
     await Promise.all(
       Array(10)
         .fill('')
-        .map((_, i) => assessment.connect(fraudulentMember).castVotes([i], [true], 0)),
+        .map((_, i) => assessment.connect(fraudulentMember).castVotes([i], [true], ['ipfsAssessmentDataHash'], 0)),
     );
 
     const burnAmount = parseEther('50');
@@ -285,10 +285,10 @@ describe('processFraud', function () {
     await assessment.connect(otherMember2).stake(parseEther('200'));
 
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
-    await assessment.connect(fraudulentMember).castVotes([0], [true], 0);
+    await assessment.connect(fraudulentMember).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
 
     await individualClaims.submitClaim(1, 0, parseEther('100'), '');
-    await assessment.connect(fraudulentMember).castVotes([1], [true], 0);
+    await assessment.connect(fraudulentMember).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
 
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
@@ -296,14 +296,14 @@ describe('processFraud', function () {
     }
 
     // Increases the poll end by 1 day
-    await assessment.connect(otherMember1).castVotes([1], [false], 0);
+    await assessment.connect(otherMember1).castVotes([1], [false], ['ipfsAssessmentDataHash'], 0);
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
       await setTime(timestamp + daysToSeconds(1) - 2);
     }
 
     // Increases the poll end by 1 day
-    await assessment.connect(otherMember2).castVotes([1], [false], 0);
+    await assessment.connect(otherMember2).castVotes([1], [false], ['ipfsAssessmentDataHash'], 0);
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
       await setTime(timestamp + daysToSeconds(2) - 2);
@@ -348,7 +348,7 @@ describe('processFraud', function () {
     await assessment.connect(fraudulentMember).stake(parseEther('100'));
 
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
-    await assessment.connect(fraudulentMember).castVotes([0], [true], 0);
+    await assessment.connect(fraudulentMember).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
 
     {
       const fraudulentAssessment = await assessment.assessments(0);
@@ -391,11 +391,11 @@ describe('processFraud', function () {
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
     await individualClaims.submitClaim(1, 0, parseEther('1000'), '');
 
-    await assessment.connect(fraudulentMember1).castVotes([0], [true], 0);
-    await assessment.connect(fraudulentMember1).castVotes([1], [true], 0);
+    await assessment.connect(fraudulentMember1).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(fraudulentMember1).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
 
-    await assessment.connect(fraudulentMember2).castVotes([0], [true], 0);
-    await assessment.connect(fraudulentMember2).castVotes([1], [true], 0);
+    await assessment.connect(fraudulentMember2).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(fraudulentMember2).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
 
     const { poll: poll1 } = await assessment.assessments(0);
     const { poll: poll2 } = await assessment.assessments(1);
@@ -484,7 +484,7 @@ describe('processFraud', function () {
 
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
 
-    await assessment.connect(fraudulentMember).castVotes([0], [true], 0);
+    await assessment.connect(fraudulentMember).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
 
     const burnAmount = parseEther('33');
     await submitFraud({
@@ -525,7 +525,7 @@ describe('processFraud', function () {
 
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
 
-    await assessment.connect(fraudulentMember).castVotes([0], [true], 0);
+    await assessment.connect(fraudulentMember).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
 
     await submitFraud({
       assessment,
@@ -574,7 +574,7 @@ describe('processFraud', function () {
     await Promise.all(
       Array(10)
         .fill('')
-        .map((_, i) => assessment.connect(fraudulentMember).castVotes([i], [true], 0)),
+        .map((_, i) => assessment.connect(fraudulentMember).castVotes([i], [true], ['ipfsAssessmentDataHash'], 0)),
     );
 
     const burnAmount = parseEther('50');
@@ -666,7 +666,7 @@ describe('processFraud', function () {
     await Promise.all(
       Array(2)
         .fill('')
-        .map((_, i) => assessment.connect(fraudulentMember).castVotes([i], [true], 0)),
+        .map((_, i) => assessment.connect(fraudulentMember).castVotes([i], [true], ['ipfsAssessmentDataHash'], 0)),
     );
 
     const burnAmount = parseEther('50');
@@ -729,7 +729,7 @@ describe('processFraud', function () {
     await Promise.all(
       Array(2)
         .fill('')
-        .map((_, i) => assessment.connect(fraudulentMember).castVotes([i], [true], 0)),
+        .map((_, i) => assessment.connect(fraudulentMember).castVotes([i], [true], ['ipfsAssessmentDataHash'], 0)),
     );
 
     const burnAmount = parseEther('50');
@@ -810,7 +810,7 @@ describe('processFraud', function () {
 
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
 
-    await assessment.connect(fraudulentMember).castVotes([0], [true], 0);
+    await assessment.connect(fraudulentMember).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
 
     const burnAmount = parseEther('33');
     await submitFraud({
@@ -863,7 +863,7 @@ describe('processFraud', function () {
 
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
 
-    await assessment.connect(fraudulentMember).castVotes([0], [true], 0);
+    await assessment.connect(fraudulentMember).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
 
     const burnAmount = parseEther('33');
     await submitFraud({
@@ -941,10 +941,10 @@ describe('processFraud', function () {
     await individualClaims.submitClaim(2, 0, parseEther('100'), '');
     await individualClaims.submitClaim(3, 0, parseEther('100'), '');
 
-    await assessment.connect(fraudulentMember).castVotes([0], [true], 0);
-    await assessment.connect(fraudulentMember).castVotes([1], [true], 0);
-    await assessment.connect(fraudulentMember).castVotes([2], [true], 0);
-    await assessment.connect(fraudulentMember).castVotes([3], [true], 0);
+    await assessment.connect(fraudulentMember).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(fraudulentMember).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(fraudulentMember).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(fraudulentMember).castVotes([3], [true], ['ipfsAssessmentDataHash'], 0);
 
     await finalizePoll(assessment);
 
@@ -955,7 +955,7 @@ describe('processFraud', function () {
 
     // Fraudulent claim
     await individualClaims.submitClaim(4, 0, parseEther('100'), '');
-    await assessment.connect(fraudulentMember).castVotes([4], [true], 0);
+    await assessment.connect(fraudulentMember).castVotes([4], [true], ['ipfsAssessmentDataHash'], 0);
 
     const burnAmount = parseEther('100');
     await submitFraud({

--- a/test/unit/Assessment/unstake.js
+++ b/test/unit/Assessment/unstake.js
@@ -62,7 +62,7 @@ describe('unstake', function () {
     const user = this.accounts.members[0];
     await assessment.connect(user).stake(parseEther('100'));
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
-    await assessment.connect(user).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(user).castVotes([0], [true], ['Assessment data hash'], 0);
     await expect(assessment.connect(user).unstake(parseEther('100'), user.address)).to.be.revertedWith(
       'Stake is in lockup period',
     );

--- a/test/unit/Assessment/unstake.js
+++ b/test/unit/Assessment/unstake.js
@@ -62,7 +62,7 @@ describe('unstake', function () {
     const user = this.accounts.members[0];
     await assessment.connect(user).stake(parseEther('100'));
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
-    await assessment.connect(user).castVotes([0], [true], 0);
+    await assessment.connect(user).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
     await expect(assessment.connect(user).unstake(parseEther('100'), user.address)).to.be.revertedWith(
       'Stake is in lockup period',
     );

--- a/test/unit/Assessment/withdrawRewards.js
+++ b/test/unit/Assessment/withdrawRewards.js
@@ -42,15 +42,15 @@ describe('withdrawRewards', function () {
     await assessment.connect(user).stake(parseEther('10'));
 
     await individualClaims.connect(user).submitClaim(0, 0, parseEther('100'), '');
-    await assessment.connect(user).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(user).castVotes([0], [true], ['Assessment data hash'], 0);
 
     await finalizePoll(assessment);
 
     await individualClaims.connect(user).submitClaim(1, 0, parseEther('100'), '');
-    await assessment.connect(user).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(user).castVotes([1], [true], ['Assessment data hash'], 0);
 
     await individualClaims.connect(user).submitClaim(2, 0, parseEther('100'), '');
-    await assessment.connect(user).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(user).castVotes([2], [true], ['Assessment data hash'], 0);
 
     const balanceBefore = await nxm.balanceOf(user.address);
 
@@ -73,9 +73,9 @@ describe('withdrawRewards', function () {
       await assessment.connect(user2).stake(parseEther('10'));
       await assessment.connect(user3).stake(parseEther('10'));
 
-      await assessment.connect(user1).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
-      await assessment.connect(user2).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
-      await assessment.connect(user3).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user1).castVotes([0], [true], ['Assessment data hash'], 0);
+      await assessment.connect(user2).castVotes([0], [true], ['Assessment data hash'], 0);
+      await assessment.connect(user3).castVotes([0], [true], ['Assessment data hash'], 0);
       const { totalRewardInNXM } = await assessment.assessments(0);
 
       await finalizePoll(assessment);
@@ -105,8 +105,8 @@ describe('withdrawRewards', function () {
     {
       await individualClaims.connect(user1).submitClaim(1, 0, parseEther('100'), '');
 
-      await assessment.connect(user1).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
-      await assessment.connect(user2).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user1).castVotes([1], [true], ['Assessment data hash'], 0);
+      await assessment.connect(user2).castVotes([1], [true], ['Assessment data hash'], 0);
       const { totalRewardInNXM } = await assessment.assessments(1);
 
       await finalizePoll(assessment);
@@ -132,9 +132,9 @@ describe('withdrawRewards', function () {
       await assessment.connect(user2).stake(parseEther('27'));
       await assessment.connect(user3).stake(parseEther('33'));
 
-      await assessment.connect(user1).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
-      await assessment.connect(user2).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
-      await assessment.connect(user3).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user1).castVotes([2], [true], ['Assessment data hash'], 0);
+      await assessment.connect(user2).castVotes([2], [true], ['Assessment data hash'], 0);
+      await assessment.connect(user3).castVotes([2], [true], ['Assessment data hash'], 0);
       const { totalRewardInNXM } = await assessment.assessments(2);
 
       await finalizePoll(assessment);
@@ -261,7 +261,7 @@ describe('withdrawRewards', function () {
         .castVotes(
           [0, 1, 2],
           [true, true, true],
-          ['ipfsAssessmentDataHash', 'ipfsAssessmentDataHash', 'ipfsAssessmentDataHash'],
+          ['Assessment data hash', 'Assessment data hash', 'Assessment data hash'],
           0,
         );
 
@@ -294,7 +294,7 @@ describe('withdrawRewards', function () {
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
 
     for (const user of voters) {
-      await assessment.connect(user).castVotes([0], [true], ['ipfsAssessmentDataHash'], stakeAmount);
+      await assessment.connect(user).castVotes([0], [true], ['Assessment data hash'], stakeAmount);
     }
 
     const { totalRewardInNXM } = await assessment.assessments(0);

--- a/test/unit/Assessment/withdrawRewards.js
+++ b/test/unit/Assessment/withdrawRewards.js
@@ -42,15 +42,15 @@ describe('withdrawRewards', function () {
     await assessment.connect(user).stake(parseEther('10'));
 
     await individualClaims.connect(user).submitClaim(0, 0, parseEther('100'), '');
-    await assessment.connect(user).castVotes([0], [true], 0);
+    await assessment.connect(user).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
 
     await finalizePoll(assessment);
 
     await individualClaims.connect(user).submitClaim(1, 0, parseEther('100'), '');
-    await assessment.connect(user).castVotes([1], [true], 0);
+    await assessment.connect(user).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
 
     await individualClaims.connect(user).submitClaim(2, 0, parseEther('100'), '');
-    await assessment.connect(user).castVotes([2], [true], 0);
+    await assessment.connect(user).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
 
     const balanceBefore = await nxm.balanceOf(user.address);
 
@@ -73,9 +73,9 @@ describe('withdrawRewards', function () {
       await assessment.connect(user2).stake(parseEther('10'));
       await assessment.connect(user3).stake(parseEther('10'));
 
-      await assessment.connect(user1).castVotes([0], [true], 0);
-      await assessment.connect(user2).castVotes([0], [true], 0);
-      await assessment.connect(user3).castVotes([0], [true], 0);
+      await assessment.connect(user1).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user2).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user3).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
       const { totalRewardInNXM } = await assessment.assessments(0);
 
       await finalizePoll(assessment);
@@ -105,8 +105,8 @@ describe('withdrawRewards', function () {
     {
       await individualClaims.connect(user1).submitClaim(1, 0, parseEther('100'), '');
 
-      await assessment.connect(user1).castVotes([1], [true], 0);
-      await assessment.connect(user2).castVotes([1], [true], 0);
+      await assessment.connect(user1).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user2).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
       const { totalRewardInNXM } = await assessment.assessments(1);
 
       await finalizePoll(assessment);
@@ -132,9 +132,9 @@ describe('withdrawRewards', function () {
       await assessment.connect(user2).stake(parseEther('27'));
       await assessment.connect(user3).stake(parseEther('33'));
 
-      await assessment.connect(user1).castVotes([2], [true], 0);
-      await assessment.connect(user2).castVotes([2], [true], 0);
-      await assessment.connect(user3).castVotes([2], [true], 0);
+      await assessment.connect(user1).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user2).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user3).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
       const { totalRewardInNXM } = await assessment.assessments(2);
 
       await finalizePoll(assessment);
@@ -256,7 +256,14 @@ describe('withdrawRewards', function () {
       await individualClaims.connect(staker).submitClaim(1, 0, parseEther('100'), '');
       await individualClaims.connect(staker).submitClaim(2, 0, parseEther('100'), '');
       await assessment.connect(staker).stake(parseEther('10'));
-      await assessment.connect(staker).castVotes([0, 1, 2], [true, true, true], 0);
+      await assessment
+        .connect(staker)
+        .castVotes(
+          [0, 1, 2],
+          [true, true, true],
+          ['ipfsAssessmentDataHash', 'ipfsAssessmentDataHash', 'ipfsAssessmentDataHash'],
+          0,
+        );
 
       const { totalRewardInNXM } = await assessment.assessments(0);
 
@@ -287,7 +294,7 @@ describe('withdrawRewards', function () {
     await individualClaims.submitClaim(0, 0, parseEther('100'), '');
 
     for (const user of voters) {
-      await assessment.connect(user).castVotes([0], [true], stakeAmount);
+      await assessment.connect(user).castVotes([0], [true], ['ipfsAssessmentDataHash'], stakeAmount);
     }
 
     const { totalRewardInNXM } = await assessment.assessments(0);

--- a/test/unit/Assessment/withdrawRewardsTo.js
+++ b/test/unit/Assessment/withdrawRewardsTo.js
@@ -65,15 +65,15 @@ describe('withdrawRewardsTo', function () {
     await assessment.connect(user).stake(parseEther('10'));
 
     await individualClaims.connect(user).submitClaim(0, 0, parseEther('100'), '');
-    await assessment.connect(user).castVotes([0], [true], 0);
+    await assessment.connect(user).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
 
     await finalizePoll(assessment);
 
     await individualClaims.connect(user).submitClaim(1, 0, parseEther('100'), '');
-    await assessment.connect(user).castVotes([1], [true], 0);
+    await assessment.connect(user).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
 
     await individualClaims.connect(user).submitClaim(2, 0, parseEther('100'), '');
-    await assessment.connect(user).castVotes([2], [true], 0);
+    await assessment.connect(user).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
 
     const balanceBefore = await nxm.balanceOf(user.address);
 
@@ -96,9 +96,9 @@ describe('withdrawRewardsTo', function () {
       await assessment.connect(user2).stake(parseEther('10'));
       await assessment.connect(user3).stake(parseEther('10'));
 
-      await assessment.connect(user1).castVotes([0], [true], 0);
-      await assessment.connect(user2).castVotes([0], [true], 0);
-      await assessment.connect(user3).castVotes([0], [true], 0);
+      await assessment.connect(user1).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user2).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user3).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
       const { totalRewardInNXM } = await assessment.assessments(0);
 
       await finalizePoll(assessment);
@@ -128,8 +128,8 @@ describe('withdrawRewardsTo', function () {
     {
       await individualClaims.connect(user1).submitClaim(1, 0, parseEther('100'), '');
 
-      await assessment.connect(user1).castVotes([1], [true], 0);
-      await assessment.connect(user2).castVotes([1], [true], 0);
+      await assessment.connect(user1).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user2).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
       const { totalRewardInNXM } = await assessment.assessments(1);
 
       await finalizePoll(assessment);
@@ -155,9 +155,9 @@ describe('withdrawRewardsTo', function () {
       await assessment.connect(user2).stake(parseEther('27'));
       await assessment.connect(user3).stake(parseEther('33'));
 
-      await assessment.connect(user1).castVotes([2], [true], 0);
-      await assessment.connect(user2).castVotes([2], [true], 0);
-      await assessment.connect(user3).castVotes([2], [true], 0);
+      await assessment.connect(user1).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user2).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user3).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
       const { totalRewardInNXM } = await assessment.assessments(2);
 
       await finalizePoll(assessment);
@@ -192,7 +192,7 @@ describe('withdrawRewardsTo', function () {
 
     await individualClaims.connect(user1).submitClaim(0, 0, parseEther('100'), '');
     await assessment.connect(user1).stake(parseEther('10'));
-    await assessment.connect(user1).castVotes([0], [true], 0);
+    await assessment.connect(user1).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
 
     await finalizePoll(assessment);
 
@@ -210,7 +210,14 @@ describe('withdrawRewardsTo', function () {
       await individualClaims.connect(user1).submitClaim(1, 0, parseEther('100'), '');
       await individualClaims.connect(user1).submitClaim(2, 0, parseEther('100'), '');
       await assessment.connect(user1).stake(parseEther('10'));
-      await assessment.connect(user1).castVotes([0, 1, 2], [true, true, true], 0);
+      await assessment
+        .connect(user1)
+        .castVotes(
+          [0, 1, 2],
+          [true, true, true],
+          ['ipfsAssessmentDataHash', 'ipfsAssessmentDataHash', 'ipfsAssessmentDataHash'],
+          0,
+        );
 
       const { totalRewardInNXM } = await assessment.assessments(0);
 
@@ -246,7 +253,14 @@ describe('withdrawRewardsTo', function () {
       await individualClaims.connect(user1).submitClaim(1, 0, parseEther('100'), '');
       await individualClaims.connect(user1).submitClaim(2, 0, parseEther('100'), '');
       await assessment.connect(user1).stake(parseEther('10'));
-      await assessment.connect(user1).castVotes([0, 1, 2], [true, true, true], 0);
+      await assessment
+        .connect(user1)
+        .castVotes(
+          [0, 1, 2],
+          [true, true, true],
+          ['ipfsAssessmentDataHash', 'ipfsAssessmentDataHash', 'ipfsAssessmentDataHash'],
+          0,
+        );
 
       const { totalRewardInNXM } = await assessment.assessments(0);
 

--- a/test/unit/Assessment/withdrawRewardsTo.js
+++ b/test/unit/Assessment/withdrawRewardsTo.js
@@ -65,15 +65,15 @@ describe('withdrawRewardsTo', function () {
     await assessment.connect(user).stake(parseEther('10'));
 
     await individualClaims.connect(user).submitClaim(0, 0, parseEther('100'), '');
-    await assessment.connect(user).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(user).castVotes([0], [true], ['Assessment data hash'], 0);
 
     await finalizePoll(assessment);
 
     await individualClaims.connect(user).submitClaim(1, 0, parseEther('100'), '');
-    await assessment.connect(user).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(user).castVotes([1], [true], ['Assessment data hash'], 0);
 
     await individualClaims.connect(user).submitClaim(2, 0, parseEther('100'), '');
-    await assessment.connect(user).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(user).castVotes([2], [true], ['Assessment data hash'], 0);
 
     const balanceBefore = await nxm.balanceOf(user.address);
 
@@ -96,9 +96,9 @@ describe('withdrawRewardsTo', function () {
       await assessment.connect(user2).stake(parseEther('10'));
       await assessment.connect(user3).stake(parseEther('10'));
 
-      await assessment.connect(user1).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
-      await assessment.connect(user2).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
-      await assessment.connect(user3).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user1).castVotes([0], [true], ['Assessment data hash'], 0);
+      await assessment.connect(user2).castVotes([0], [true], ['Assessment data hash'], 0);
+      await assessment.connect(user3).castVotes([0], [true], ['Assessment data hash'], 0);
       const { totalRewardInNXM } = await assessment.assessments(0);
 
       await finalizePoll(assessment);
@@ -128,8 +128,8 @@ describe('withdrawRewardsTo', function () {
     {
       await individualClaims.connect(user1).submitClaim(1, 0, parseEther('100'), '');
 
-      await assessment.connect(user1).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
-      await assessment.connect(user2).castVotes([1], [true], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user1).castVotes([1], [true], ['Assessment data hash'], 0);
+      await assessment.connect(user2).castVotes([1], [true], ['Assessment data hash'], 0);
       const { totalRewardInNXM } = await assessment.assessments(1);
 
       await finalizePoll(assessment);
@@ -155,9 +155,9 @@ describe('withdrawRewardsTo', function () {
       await assessment.connect(user2).stake(parseEther('27'));
       await assessment.connect(user3).stake(parseEther('33'));
 
-      await assessment.connect(user1).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
-      await assessment.connect(user2).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
-      await assessment.connect(user3).castVotes([2], [true], ['ipfsAssessmentDataHash'], 0);
+      await assessment.connect(user1).castVotes([2], [true], ['Assessment data hash'], 0);
+      await assessment.connect(user2).castVotes([2], [true], ['Assessment data hash'], 0);
+      await assessment.connect(user3).castVotes([2], [true], ['Assessment data hash'], 0);
       const { totalRewardInNXM } = await assessment.assessments(2);
 
       await finalizePoll(assessment);
@@ -192,7 +192,7 @@ describe('withdrawRewardsTo', function () {
 
     await individualClaims.connect(user1).submitClaim(0, 0, parseEther('100'), '');
     await assessment.connect(user1).stake(parseEther('10'));
-    await assessment.connect(user1).castVotes([0], [true], ['ipfsAssessmentDataHash'], 0);
+    await assessment.connect(user1).castVotes([0], [true], ['Assessment data hash'], 0);
 
     await finalizePoll(assessment);
 
@@ -215,7 +215,7 @@ describe('withdrawRewardsTo', function () {
         .castVotes(
           [0, 1, 2],
           [true, true, true],
-          ['ipfsAssessmentDataHash', 'ipfsAssessmentDataHash', 'ipfsAssessmentDataHash'],
+          ['Assessment data hash', 'Assessment data hash', 'Assessment data hash'],
           0,
         );
 
@@ -258,7 +258,7 @@ describe('withdrawRewardsTo', function () {
         .castVotes(
           [0, 1, 2],
           [true, true, true],
-          ['ipfsAssessmentDataHash', 'ipfsAssessmentDataHash', 'ipfsAssessmentDataHash'],
+          ['Assessment data hash', 'Assessment data hash', 'Assessment data hash'],
           0,
         );
 


### PR DESCRIPTION
## Context

No data is preserved during claim assessment, every value of the input in the form is lost and can not be used in the future (like showing reasons of the denial)

Closing issue: #494 

## Changes proposed in this pull request

Expanding the `castVote` method on the Assassment.sol with ipfsAssessmentDataHash and emitting the hash in the `VoteCast` event


## Test plan

All existing tests modified with the changes made to the contract.


## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [ ] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
