### PR TITLE
Fix: Replace onlyAdvisoryBoard with onlyGovernance for submitIncident()

### DIFF
--- a/contracts/modules/assessment/YieldTokenIncidents.sol
+++ b/contracts/modules/assessment/YieldTokenIncidents.sol
@@ -154,7 +154,7 @@ contract YieldTokenIncidents is IYieldTokenIncidents, MasterAwareV2 {
     uint32 date,
     uint expectedPayoutInNXM,
     string calldata ipfsMetadata
-  ) external override onlyAdvisoryBoard whenNotPaused {
+  ) external override onlyGovernance whenNotPaused {
     ICover coverContract = cover();
     Product memory product = coverContract.products(productId);
     ProductType memory productType = coverContract.productTypes(product.productType);

--- a/test/integration/Cover/expireCover.js
+++ b/test/integration/Cover/expireCover.js
@@ -95,12 +95,14 @@ describe.skip('expireCover', function () {
     );
   }
 
-  async function submitIncident({ yc, productId, period, signer }) {
-    // submit incident
+  async function submitIncident({ yc, productId, period }) {
     const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
 
     await yc
-      .connect(signer)
+      .connect(governance)
       .submitIncident(productId, parseEther('1.1'), currentTime + period / 2, parseEther('100'), '');
   }
 
@@ -133,7 +135,7 @@ describe.skip('expireCover', function () {
     });
 
     // submit incident
-    await submitIncident({ yc, productId, period, signer: this.accounts.defaultSender });
+    await submitIncident({ yc, productId, period });
 
     // accept incident
     await as.connect(staker1).castVotes([assessmentId], [true], ['Assessment data hash'], parseEther('100'));
@@ -207,7 +209,7 @@ describe.skip('expireCover', function () {
     }
 
     // submit incident
-    await submitIncident({ yc, productId, period, signer: this.accounts.defaultSender });
+    await submitIncident({ yc, productId, period });
 
     // accept incident
     await as.connect(staker1).castVotes([assessmentId], [true], ['Assessment data hash'], parseEther('100'));
@@ -277,7 +279,7 @@ describe.skip('expireCover', function () {
     });
 
     // submit incident
-    await submitIncident({ yc, productId, period, signer: this.accounts.defaultSender });
+    await submitIncident({ yc, productId, period });
 
     // accept incident
     await as.connect(staker1).castVotes([assessmentId], [true], ['Assessment data hash'], parseEther('100'));
@@ -352,7 +354,7 @@ describe.skip('expireCover', function () {
     }
 
     // submit incident
-    await submitIncident({ yc, productId, period, signer: this.accounts.defaultSender });
+    await submitIncident({ yc, productId, period });
 
     // accept incident
     await as.connect(staker1).castVotes([assessmentId], [true], ['Assessment data hash'], parseEther('100'));
@@ -421,7 +423,7 @@ describe.skip('expireCover', function () {
     });
 
     // submit incident
-    await submitIncident({ yc, productId, period, signer: this.accounts.defaultSender });
+    await submitIncident({ yc, productId, period });
 
     // accept incident
     await as.connect(staker1).castVotes([assessmentId], [true], ['Assessment data hash'], parseEther('100'));
@@ -500,7 +502,7 @@ describe.skip('expireCover', function () {
     });
 
     // submit incident
-    await submitIncident({ yc, productId, period, signer: this.accounts.defaultSender });
+    await submitIncident({ yc, productId, period });
 
     // reject incident (requires at least 1 positive vote)
     await as.connect(staker1).castVotes([assessmentId], [true], ['Assessment data hash'], parseEther('100'));
@@ -576,7 +578,7 @@ describe.skip('expireCover', function () {
     }
 
     // submit incident
-    await submitIncident({ yc, productId, period, signer: this.accounts.defaultSender });
+    await submitIncident({ yc, productId, period });
 
     // reject incident (requires at least 1 positive vote)
     await as.connect(staker1).castVotes([assessmentId], [true], ['Assessment data hash'], parseEther('100'));

--- a/test/integration/Cover/expireCover.js
+++ b/test/integration/Cover/expireCover.js
@@ -97,9 +97,7 @@ describe.skip('expireCover', function () {
 
   async function submitIncident({ yc, productId, period }) {
     const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
 
     await yc
       .connect(governance)

--- a/test/integration/Cover/expireCover.js
+++ b/test/integration/Cover/expireCover.js
@@ -1,7 +1,7 @@
 const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { daysToSeconds } = require('../../../lib/helpers');
-const { mineNextBlock, setNextBlockTime } = require('../../utils/evm');
+const { mineNextBlock, setNextBlockTime, setEtherBalance } = require('../../utils/evm');
 
 const { parseEther } = ethers.utils;
 const { AddressZero } = ethers.constants;
@@ -97,10 +97,13 @@ describe.skip('expireCover', function () {
 
   async function submitIncident({ yc, productId, period }) {
     const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
-    const [governance] = this.accounts.governanceContracts;
+
+    const { gv } = this.contracts;
+    const gvSigner = await ethers.getImpersonatedSigner(gv.address);
+    await setEtherBalance(gvSigner.address, ethers.utils.parseEther('1'));
 
     await yc
-      .connect(governance)
+      .connect(gvSigner)
       .submitIncident(productId, parseEther('1.1'), currentTime + period / 2, parseEther('100'), '');
   }
 

--- a/test/integration/YieldTokenIncidents/submitClaim.js
+++ b/test/integration/YieldTokenIncidents/submitClaim.js
@@ -17,7 +17,7 @@ const priceDenominator = '10000';
 
 describe('submitClaim', function () {
   beforeEach(async function () {
-    const { tk, gv } = this.contracts;
+    const { tk } = this.contracts;
 
     const members = this.accounts.members.slice(0, 5);
     const amount = parseEther('10000');

--- a/test/unit/Assessment/startAssessment.js
+++ b/test/unit/Assessment/startAssessment.js
@@ -9,9 +9,8 @@ describe('startAssessment', function () {
   it('returns the index of the newly created assessment', async function () {
     const { individualClaims, yieldTokenIncidents } = this.contracts;
     const [member] = this.accounts.members;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
+
     const { timestamp } = await ethers.provider.getBlock('latest');
 
     {
@@ -48,9 +47,7 @@ describe('startAssessment', function () {
   it('stores assessmentDepositInETH and totalRewardInNXM', async function () {
     const { individualClaims, yieldTokenIncidents, assessment } = this.contracts;
     const [member] = this.accounts.members;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
     const { timestamp } = await ethers.provider.getBlock('latest');
 
     {
@@ -80,9 +77,7 @@ describe('startAssessment', function () {
   it('stores assessmentDepositInETH and totalRewardInNXM', async function () {
     const { individualClaims, yieldTokenIncidents, assessment } = this.contracts;
     const [member] = this.accounts.members;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
     const { timestamp } = await ethers.provider.getBlock('latest');
 
     {
@@ -111,9 +106,7 @@ describe('startAssessment', function () {
   it('stores a poll that starts at the block timestamp and ends after minVotingPeriodInDays', async function () {
     const { individualClaims, yieldTokenIncidents, assessment } = this.contracts;
     const [member] = this.accounts.members;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
 
     {
       await individualClaims.connect(member).submitClaim(0, 0, parseEther('100'), '');

--- a/test/unit/Assessment/startAssessment.js
+++ b/test/unit/Assessment/startAssessment.js
@@ -8,36 +8,38 @@ const daysToSeconds = days => days * 24 * 60 * 60;
 describe('startAssessment', function () {
   it('returns the index of the newly created assessment', async function () {
     const { individualClaims, yieldTokenIncidents } = this.contracts;
-    const [user] = this.accounts.members;
-    const [AB] = this.accounts.advisoryBoardMembers;
+    const [member] = this.accounts.members;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
     const { timestamp } = await ethers.provider.getBlock('latest');
 
     {
-      await individualClaims.connect(user).submitClaim(0, 0, parseEther('100'), '');
+      await individualClaims.connect(member).submitClaim(0, 0, parseEther('100'), '');
       const { assessmentId } = await individualClaims.claims(0);
       expect(assessmentId).to.be.equal(0);
     }
 
     {
-      await yieldTokenIncidents.connect(AB).submitIncident(0, parseEther('1'), timestamp, parseEther('1000'));
+      await yieldTokenIncidents.connect(governance).submitIncident(0, parseEther('1'), timestamp, parseEther('1000'));
       const { assessmentId } = await yieldTokenIncidents.incidents(0);
       expect(assessmentId).to.be.equal(1);
     }
 
     {
-      await individualClaims.connect(user).submitClaim(2, 0, parseEther('100'), '');
+      await individualClaims.connect(member).submitClaim(2, 0, parseEther('100'), '');
       const { assessmentId } = await individualClaims.claims(1);
       expect(assessmentId).to.be.equal(2);
     }
 
     {
-      await individualClaims.connect(user).submitClaim(3, 0, parseEther('100'), '');
+      await individualClaims.connect(member).submitClaim(3, 0, parseEther('100'), '');
       const { assessmentId } = await individualClaims.claims(2);
       expect(assessmentId).to.be.equal(3);
     }
 
     {
-      await yieldTokenIncidents.connect(AB).submitIncident(0, parseEther('1'), timestamp, parseEther('1000'));
+      await yieldTokenIncidents.connect(governance).submitIncident(0, parseEther('1'), timestamp, parseEther('1000'));
       const { assessmentId } = await yieldTokenIncidents.incidents(1);
       expect(assessmentId).to.be.equal(4);
     }
@@ -45,12 +47,14 @@ describe('startAssessment', function () {
 
   it('stores assessmentDepositInETH and totalRewardInNXM', async function () {
     const { individualClaims, yieldTokenIncidents, assessment } = this.contracts;
-    const [user] = this.accounts.members;
-    const [AB] = this.accounts.advisoryBoardMembers;
+    const [member] = this.accounts.members;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
     const { timestamp } = await ethers.provider.getBlock('latest');
 
     {
-      await individualClaims.connect(user).submitClaim(0, 0, parseEther('100'), '');
+      await individualClaims.connect(member).submitClaim(0, 0, parseEther('100'), '');
       const { assessmentDepositInETH, totalRewardInNXM } = await assessment.assessments(0);
       const { rewardRatio } = await individualClaims.config();
       expect(assessmentDepositInETH).to.be.equal(0);
@@ -59,7 +63,9 @@ describe('startAssessment', function () {
 
     {
       const activeCoverAmountInNXM = parseEther('1000');
-      await yieldTokenIncidents.connect(AB).submitIncident(0, parseEther('1'), timestamp, activeCoverAmountInNXM);
+      await yieldTokenIncidents
+        .connect(governance)
+        .submitIncident(0, parseEther('1'), timestamp, activeCoverAmountInNXM);
       const { assessmentDepositInETH, totalRewardInNXM } = await assessment.assessments(1);
       const { rewardRatio, expectedPayoutRatio } = await yieldTokenIncidents.config();
 
@@ -73,12 +79,14 @@ describe('startAssessment', function () {
 
   it('stores assessmentDepositInETH and totalRewardInNXM', async function () {
     const { individualClaims, yieldTokenIncidents, assessment } = this.contracts;
-    const [user] = this.accounts.members;
-    const [AB] = this.accounts.advisoryBoardMembers;
+    const [member] = this.accounts.members;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
     const { timestamp } = await ethers.provider.getBlock('latest');
 
     {
-      await individualClaims.connect(user).submitClaim(0, 0, parseEther('100'), '');
+      await individualClaims.connect(member).submitClaim(0, 0, parseEther('100'), '');
       const { assessmentDepositInETH, totalRewardInNXM } = await assessment.assessments(0);
       const { rewardRatio } = await individualClaims.config();
       expect(assessmentDepositInETH).to.be.equal(0);
@@ -87,7 +95,9 @@ describe('startAssessment', function () {
 
     {
       const activeCoverAmountInNXM = parseEther('1000');
-      await yieldTokenIncidents.connect(AB).submitIncident(0, parseEther('1'), timestamp, activeCoverAmountInNXM);
+      await yieldTokenIncidents
+        .connect(governance)
+        .submitIncident(0, parseEther('1'), timestamp, activeCoverAmountInNXM);
       const { assessmentDepositInETH, totalRewardInNXM } = await assessment.assessments(1);
       const { rewardRatio, expectedPayoutRatio } = await yieldTokenIncidents.config();
       // For now AB doesn't require a deposit to submit yieldTokenIncidents
@@ -100,11 +110,13 @@ describe('startAssessment', function () {
 
   it('stores a poll that starts at the block timestamp and ends after minVotingPeriodInDays', async function () {
     const { individualClaims, yieldTokenIncidents, assessment } = this.contracts;
-    const [user] = this.accounts.members;
-    const [AB] = this.accounts.advisoryBoardMembers;
+    const [member] = this.accounts.members;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
 
     {
-      await individualClaims.connect(user).submitClaim(0, 0, parseEther('100'), '');
+      await individualClaims.connect(member).submitClaim(0, 0, parseEther('100'), '');
       const { timestamp } = await ethers.provider.getBlock('latest');
       const { poll } = await assessment.assessments(0);
       const { minVotingPeriodInDays } = await assessment.config();
@@ -116,7 +128,7 @@ describe('startAssessment', function () {
 
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
-      await yieldTokenIncidents.connect(AB).submitIncident(0, parseEther('1'), timestamp, Zero);
+      await yieldTokenIncidents.connect(governance).submitIncident(0, parseEther('1'), timestamp, Zero);
       const { poll } = await assessment.assessments(0);
       const { minVotingPeriodInDays } = await assessment.config();
       expect(poll.start).to.be.equal(timestamp);
@@ -128,9 +140,9 @@ describe('startAssessment', function () {
 
   it('reverts if caller is not an internal contract', async function () {
     const { assessment } = this.contracts;
-    const admin = this.accounts.emergencyAdmin;
+    const [member] = this.accounts.members;
 
-    await expect(assessment.connect(admin).startAssessment(parseEther('100'), parseEther('10'))).to.be.revertedWith(
+    await expect(assessment.connect(member).startAssessment(parseEther('100'), parseEther('10'))).to.be.revertedWith(
       'Caller is not an internal contract',
     );
   });

--- a/test/unit/Assessment/updateUintParameters.js
+++ b/test/unit/Assessment/updateUintParameters.js
@@ -22,9 +22,7 @@ describe('updateUintParameters', function () {
 
   it('sets each parameter to the given new values', async function () {
     const { assessment } = this.contracts;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
     const newValues = {
       minVotingPeriodInDays: 111,
       stakeLockupPeriodInDays: 222,
@@ -61,9 +59,7 @@ describe('updateUintParameters', function () {
 
   it('sets only the given parameters to the new values', async function () {
     const { assessment } = this.contracts;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
     const newValues = {
       minVotingPeriodInDays: 11,
       stakeLockupPeriodInDays: 22,
@@ -127,9 +123,7 @@ describe('updateUintParameters', function () {
 
   it('allows parameters to be given in any order', async function () {
     const { assessment } = this.contracts;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
 
     {
       const newValues = {

--- a/test/unit/IndividualClaims/updateUintParameters.js
+++ b/test/unit/IndividualClaims/updateUintParameters.js
@@ -24,9 +24,7 @@ describe('updateUintParameters', function () {
 
   it('sets each parameter to the given new values', async function () {
     const { individualClaims } = this.contracts;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
     const newValues = {
       payoutRedemptionPeriodInDays: 111,
       minAssessmentDepositRatio: 2222,
@@ -63,9 +61,7 @@ describe('updateUintParameters', function () {
 
   it('sets only the given parameters to the new values', async function () {
     const { individualClaims } = this.contracts;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
     const newValues = {
       payoutRedemptionPeriodInDays: 111,
       minAssessmentDepositRatio: 2222,
@@ -114,9 +110,7 @@ describe('updateUintParameters', function () {
 
   it('allows parameters to be given in any order', async function () {
     const { individualClaims } = this.contracts;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
 
     {
       const newValues = {

--- a/test/unit/YieldTokenIncidents/getIncidentsCount.js
+++ b/test/unit/YieldTokenIncidents/getIncidentsCount.js
@@ -6,9 +6,7 @@ const { parseEther } = ethers.utils;
 describe('getIncidentsCount', function () {
   it('returns the total number of incidents', async function () {
     const { yieldTokenIncidents } = this.contracts;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
 
     {
       const count = await yieldTokenIncidents.getIncidentsCount();

--- a/test/unit/YieldTokenIncidents/getIncidentsCount.js
+++ b/test/unit/YieldTokenIncidents/getIncidentsCount.js
@@ -6,7 +6,9 @@ const { parseEther } = ethers.utils;
 describe('getIncidentsCount', function () {
   it('returns the total number of incidents', async function () {
     const { yieldTokenIncidents } = this.contracts;
-    const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
 
     {
       const count = await yieldTokenIncidents.getIncidentsCount();
@@ -16,7 +18,7 @@ describe('getIncidentsCount', function () {
     const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
     const productId = 2;
     await yieldTokenIncidents
-      .connect(advisoryBoard)
+      .connect(governance)
       .submitIncident(productId, parseEther('1.1'), currentTime, parseEther('20000'), '');
 
     {
@@ -26,7 +28,7 @@ describe('getIncidentsCount', function () {
 
     for (let i = 0; i < 6; i++) {
       await yieldTokenIncidents
-        .connect(advisoryBoard)
+        .connect(governance)
         .submitIncident(productId, parseEther('1.1'), currentTime, parseEther('20000'), '');
     }
 

--- a/test/unit/YieldTokenIncidents/getIncidentsToDisplay.js
+++ b/test/unit/YieldTokenIncidents/getIncidentsToDisplay.js
@@ -9,9 +9,7 @@ const daysToSeconds = days => days * 24 * 60 * 60;
 describe('getIncidentsToDisplay', function () {
   it('aggregates and displays claims related data in a human-readable form', async function () {
     const { yieldTokenIncidents, assessment } = this.contracts;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
 
     const expectedIncidentIds = ['0', '1', '2', '3', '4'];
     const expectedProductIds = ['2', '3', '2', '2', '3'];

--- a/test/unit/YieldTokenIncidents/getIncidentsToDisplay.js
+++ b/test/unit/YieldTokenIncidents/getIncidentsToDisplay.js
@@ -9,7 +9,9 @@ const daysToSeconds = days => days * 24 * 60 * 60;
 describe('getIncidentsToDisplay', function () {
   it('aggregates and displays claims related data in a human-readable form', async function () {
     const { yieldTokenIncidents, assessment } = this.contracts;
-    const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
 
     const expectedIncidentIds = ['0', '1', '2', '3', '4'];
     const expectedProductIds = ['2', '3', '2', '2', '3'];
@@ -33,7 +35,7 @@ describe('getIncidentsToDisplay', function () {
         const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
         expectedIncidentDates.push(currentTime);
         await yieldTokenIncidents
-          .connect(advisoryBoard)
+          .connect(governance)
           .submitIncident(expectedProductIds[i], expectedPriceBefore[i], currentTime, parseEther('100'), '');
       }
 

--- a/test/unit/YieldTokenIncidents/redeemPayout.js
+++ b/test/unit/YieldTokenIncidents/redeemPayout.js
@@ -32,9 +32,7 @@ describe('redeemPayout', function () {
   it("reverts if the address is not the cover owner's or approved", async function () {
     const { yieldTokenIncidents, assessment, cover, coverNFT } = this.contracts;
     const [coverOwner, nonCoverOwner] = this.accounts.members;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
     const segment = await getCoverSegment();
     segment.amount = parseEther('10000');
 
@@ -85,9 +83,7 @@ describe('redeemPayout', function () {
   it('reverts if the incident is not accepted', async function () {
     const { yieldTokenIncidents, assessment, cover } = this.contracts;
     const [member1, member2] = this.accounts.members;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
     const segment = await getCoverSegment();
     segment.amount = parseEther('10000');
 
@@ -129,9 +125,7 @@ describe('redeemPayout', function () {
   it("reverts if the voting and cooldown period haven't ended", async function () {
     const { yieldTokenIncidents, assessment, cover } = this.contracts;
     const [member1] = this.accounts.members;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
     const segment = await getCoverSegment();
     segment.amount = parseEther('10000');
 
@@ -172,9 +166,7 @@ describe('redeemPayout', function () {
   it('reverts if the redemption period expired', async function () {
     const { yieldTokenIncidents, assessment, cover } = this.contracts;
     const [member1] = this.accounts.members;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
     const { payoutRedemptionPeriodInDays } = await yieldTokenIncidents.config();
     const { payoutCooldownInDays } = await assessment.config();
     const segment = await getCoverSegment();
@@ -204,9 +196,7 @@ describe('redeemPayout', function () {
   it('reverts if the payout exceeds the covered amount', async function () {
     const { yieldTokenIncidents, assessment, cover } = this.contracts;
     const [member1] = this.accounts.members;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
     const { payoutCooldownInDays } = await assessment.config();
     const segment = await getCoverSegment();
     await cover.createMockCover(member1.address, productIdYbEth, ASSET.ETH, [segment]);
@@ -242,9 +232,7 @@ describe('redeemPayout', function () {
   it('reverts if the cover segment ends before the incident occured', async function () {
     const { yieldTokenIncidents, assessment, cover } = this.contracts;
     const [member1] = this.accounts.members;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
     const { payoutCooldownInDays } = await assessment.config();
 
     const segment0 = await getCoverSegment();
@@ -283,9 +271,7 @@ describe('redeemPayout', function () {
   it('reverts if the cover segment starts after or when the incident occured', async function () {
     const { yieldTokenIncidents, assessment, cover } = this.contracts;
     const [member1] = this.accounts.members;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
     const { payoutCooldownInDays } = await assessment.config();
 
     const { timestamp } = await ethers.provider.getBlock('latest');
@@ -328,9 +314,7 @@ describe('redeemPayout', function () {
   it('reverts if the cover segment is outside the grace period', async function () {
     const { yieldTokenIncidents, assessment, cover } = this.contracts;
     const [member1] = this.accounts.members;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
     const { gracePeriodInDays } = await cover.productTypes(2);
     const segment0 = await getCoverSegment();
     segment0.gracePeriodInDays = gracePeriodInDays;
@@ -364,9 +348,7 @@ describe('redeemPayout', function () {
   it('should use coverSegment grace period and not product level grace period', async function () {
     const { yieldTokenIncidents, assessment, cover } = this.contracts;
     const [member1] = this.accounts.members;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
     const { gracePeriodInDays } = await cover.productTypes(2);
     const segment0 = await getCoverSegment();
     const segment1 = await getCoverSegment();
@@ -410,9 +392,7 @@ describe('redeemPayout', function () {
   it("reverts if the cover's productId mismatches the incident's productId", async function () {
     const { yieldTokenIncidents, assessment, cover } = this.contracts;
     const [member1] = this.accounts.members;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
     const validProductId = 2;
     const segment = await getCoverSegment();
     await cover.createMockCover(
@@ -477,9 +457,7 @@ describe('redeemPayout', function () {
     const { yieldTokenIncidents, assessment, cover, ybEth } = this.contracts;
     const [member1] = this.accounts.members;
     const [nonMember1, nonMember2] = this.accounts.nonMembers;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
     const segment = await getCoverSegment();
     segment.amount = parseEther('10000');
 
@@ -558,9 +536,7 @@ describe('redeemPayout', function () {
     const { yieldTokenIncidents, assessment, cover, ybEth, dai } = this.contracts;
     const [member1] = this.accounts.members;
     const [nonMember1, nonMember2] = this.accounts.nonMembers;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
     const segment = await getCoverSegment();
     segment.amount = parseEther('10000');
 
@@ -639,9 +615,7 @@ describe('redeemPayout', function () {
     const { yieldTokenIncidents, assessment, cover, ybPermitDai, dai } = this.contracts;
     const [member1] = this.accounts.members;
     const [nonMember] = this.accounts.nonMembers;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
     const segment = await getCoverSegment();
     segment.amount = parseEther('10000');
     const productId = 4;
@@ -715,9 +689,7 @@ describe('redeemPayout', function () {
   it('emits IncidentPayoutRedeemed event with owner, payout amount, incident and cover ids', async function () {
     const { yieldTokenIncidents, cover, assessment, ybEth, ybDai } = this.contracts;
     const [coverOwner1, coverOwner2, member] = this.accounts.members;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
     const { timestamp } = await ethers.provider.getBlock('latest');
     const segment = await getCoverSegment();
 
@@ -760,9 +732,7 @@ describe('redeemPayout', function () {
   it('reverts if system is paused', async function () {
     const { yieldTokenIncidents, cover, assessment, ybEth, master } = this.contracts;
     const [coverOwner1, member] = this.accounts.members;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
     const { timestamp } = await ethers.provider.getBlock('latest');
     const segment = await getCoverSegment();
     await cover.createMockCover(coverOwner1.address, productIdYbEth, ASSET.ETH, [segment]);
@@ -791,9 +761,7 @@ describe('redeemPayout', function () {
     const { yieldTokenIncidents, cover, assessment, ybEth } = this.contracts;
     const [coverOwner1, member] = this.accounts.members;
     const [nonMember] = this.accounts.nonMembers;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
 
     const { timestamp } = await ethers.provider.getBlock('latest');
     const segment = await getCoverSegment();
@@ -820,9 +788,7 @@ describe('redeemPayout', function () {
   it('should transfer product underlying asset amount to the contract', async function () {
     const { yieldTokenIncidents, assessment, cover, ybEth } = this.contracts;
     const [member1] = this.accounts.members;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
     const segment = await getCoverSegment();
     segment.amount = parseEther('10000');
 
@@ -859,9 +825,7 @@ describe('redeemPayout', function () {
   it('should burn the stake of associated staking pools', async function () {
     const { yieldTokenIncidents, assessment, cover, ybEth } = this.contracts;
     const [member1] = this.accounts.members;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
     const segment = await getCoverSegment();
     segment.amount = parseEther('10000');
 

--- a/test/unit/YieldTokenIncidents/redeemPayout.js
+++ b/test/unit/YieldTokenIncidents/redeemPayout.js
@@ -32,7 +32,9 @@ describe('redeemPayout', function () {
   it("reverts if the address is not the cover owner's or approved", async function () {
     const { yieldTokenIncidents, assessment, cover, coverNFT } = this.contracts;
     const [coverOwner, nonCoverOwner] = this.accounts.members;
-    const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
     const segment = await getCoverSegment();
     segment.amount = parseEther('10000');
 
@@ -43,7 +45,7 @@ describe('redeemPayout', function () {
     {
       const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
       await yieldTokenIncidents
-        .connect(advisoryBoard)
+        .connect(governance)
         .submitIncident(productIdYbEth, priceBefore, currentTime + segment.period / 2, parseEther('100'), '');
     }
 
@@ -83,7 +85,9 @@ describe('redeemPayout', function () {
   it('reverts if the incident is not accepted', async function () {
     const { yieldTokenIncidents, assessment, cover } = this.contracts;
     const [member1, member2] = this.accounts.members;
-    const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
     const segment = await getCoverSegment();
     segment.amount = parseEther('10000');
 
@@ -92,7 +96,7 @@ describe('redeemPayout', function () {
     {
       const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
       await yieldTokenIncidents
-        .connect(advisoryBoard)
+        .connect(governance)
         .submitIncident(productIdYbEth, priceBefore, currentTime, parseEther('100'), '');
     }
 
@@ -125,7 +129,9 @@ describe('redeemPayout', function () {
   it("reverts if the voting and cooldown period haven't ended", async function () {
     const { yieldTokenIncidents, assessment, cover } = this.contracts;
     const [member1] = this.accounts.members;
-    const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
     const segment = await getCoverSegment();
     segment.amount = parseEther('10000');
 
@@ -134,7 +140,7 @@ describe('redeemPayout', function () {
     {
       const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
       await yieldTokenIncidents
-        .connect(advisoryBoard)
+        .connect(governance)
         .submitIncident(productIdYbEth, priceBefore, currentTime, parseEther('100'), '');
     }
 
@@ -166,7 +172,9 @@ describe('redeemPayout', function () {
   it('reverts if the redemption period expired', async function () {
     const { yieldTokenIncidents, assessment, cover } = this.contracts;
     const [member1] = this.accounts.members;
-    const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
     const { payoutRedemptionPeriodInDays } = await yieldTokenIncidents.config();
     const { payoutCooldownInDays } = await assessment.config();
     const segment = await getCoverSegment();
@@ -177,7 +185,7 @@ describe('redeemPayout', function () {
     {
       const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
       await yieldTokenIncidents
-        .connect(advisoryBoard)
+        .connect(governance)
         .submitIncident(productIdYbEth, priceBefore, currentTime, parseEther('100'), '');
     }
 
@@ -196,7 +204,9 @@ describe('redeemPayout', function () {
   it('reverts if the payout exceeds the covered amount', async function () {
     const { yieldTokenIncidents, assessment, cover } = this.contracts;
     const [member1] = this.accounts.members;
-    const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
     const { payoutCooldownInDays } = await assessment.config();
     const segment = await getCoverSegment();
     await cover.createMockCover(member1.address, productIdYbEth, ASSET.ETH, [segment]);
@@ -209,7 +219,7 @@ describe('redeemPayout', function () {
     {
       const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
       await yieldTokenIncidents
-        .connect(advisoryBoard)
+        .connect(governance)
         .submitIncident(productIdYbEth, priceBefore, currentTime, parseEther('100'), '');
     }
 
@@ -232,7 +242,9 @@ describe('redeemPayout', function () {
   it('reverts if the cover segment ends before the incident occured', async function () {
     const { yieldTokenIncidents, assessment, cover } = this.contracts;
     const [member1] = this.accounts.members;
-    const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
     const { payoutCooldownInDays } = await assessment.config();
 
     const segment0 = await getCoverSegment();
@@ -249,7 +261,7 @@ describe('redeemPayout', function () {
     {
       const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
       await yieldTokenIncidents
-        .connect(advisoryBoard)
+        .connect(governance)
         .submitIncident(productIdYbEth, priceBefore, currentTime, parseEther('100'), '');
     }
 
@@ -271,7 +283,9 @@ describe('redeemPayout', function () {
   it('reverts if the cover segment starts after or when the incident occured', async function () {
     const { yieldTokenIncidents, assessment, cover } = this.contracts;
     const [member1] = this.accounts.members;
-    const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
     const { payoutCooldownInDays } = await assessment.config();
 
     const { timestamp } = await ethers.provider.getBlock('latest');
@@ -283,7 +297,7 @@ describe('redeemPayout', function () {
     await cover.createMockCover(member1.address, productIdYbEth, ASSET.ETH, [segment0, segment1]);
 
     await yieldTokenIncidents
-      .connect(advisoryBoard)
+      .connect(governance)
       .submitIncident(productIdYbEth, priceBefore, timestamp + 2, parseEther('100'), '');
 
     {
@@ -314,7 +328,9 @@ describe('redeemPayout', function () {
   it('reverts if the cover segment is outside the grace period', async function () {
     const { yieldTokenIncidents, assessment, cover } = this.contracts;
     const [member1] = this.accounts.members;
-    const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
     const { gracePeriodInDays } = await cover.productTypes(2);
     const segment0 = await getCoverSegment();
     segment0.gracePeriodInDays = gracePeriodInDays;
@@ -326,7 +342,7 @@ describe('redeemPayout', function () {
     const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
     await setTime(currentTime + segment0.period + daysToSeconds(gracePeriodInDays));
     await yieldTokenIncidents
-      .connect(advisoryBoard)
+      .connect(governance)
       .submitIncident(productIdYbEth, priceBefore, currentTime + segment0.period - 1, parseEther('100'), '');
 
     await assessment.connect(member1).castVote(0, true, parseEther('100'));
@@ -348,7 +364,9 @@ describe('redeemPayout', function () {
   it('should use coverSegment grace period and not product level grace period', async function () {
     const { yieldTokenIncidents, assessment, cover } = this.contracts;
     const [member1] = this.accounts.members;
-    const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
     const { gracePeriodInDays } = await cover.productTypes(2);
     const segment0 = await getCoverSegment();
     const segment1 = await getCoverSegment();
@@ -362,7 +380,7 @@ describe('redeemPayout', function () {
 
     // Change product grace period
     const newGracePeriod = gracePeriodInDays * 1000;
-    await cover.connect(advisoryBoard).editProductTypes([2], [newGracePeriod], ['ipfs hash']);
+    await cover.connect(governance).editProductTypes([2], [newGracePeriod], ['ipfs hash']);
     {
       const { gracePeriodInDays } = await cover.productTypes(2);
       expect(gracePeriodInDays).to.equal(newGracePeriod);
@@ -370,7 +388,7 @@ describe('redeemPayout', function () {
     }
 
     await yieldTokenIncidents
-      .connect(advisoryBoard)
+      .connect(governance)
       .submitIncident(productIdYbEth, priceBefore, currentTime + segment0.period - 1, parseEther('100'), '');
 
     await assessment.connect(member1).castVote(0, true, parseEther('100'));
@@ -392,7 +410,9 @@ describe('redeemPayout', function () {
   it("reverts if the cover's productId mismatches the incident's productId", async function () {
     const { yieldTokenIncidents, assessment, cover } = this.contracts;
     const [member1] = this.accounts.members;
-    const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
     const validProductId = 2;
     const segment = await getCoverSegment();
     await cover.createMockCover(
@@ -424,7 +444,7 @@ describe('redeemPayout', function () {
     {
       const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
       await yieldTokenIncidents
-        .connect(advisoryBoard)
+        .connect(governance)
         .submitIncident(validProductId, priceBefore, currentTime + segment.period / 2, parseEther('100'), '');
     }
 
@@ -457,7 +477,9 @@ describe('redeemPayout', function () {
     const { yieldTokenIncidents, assessment, cover, ybEth } = this.contracts;
     const [member1] = this.accounts.members;
     const [nonMember1, nonMember2] = this.accounts.nonMembers;
-    const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
     const segment = await getCoverSegment();
     segment.amount = parseEther('10000');
 
@@ -471,7 +493,7 @@ describe('redeemPayout', function () {
     {
       const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
       await yieldTokenIncidents
-        .connect(advisoryBoard)
+        .connect(governance)
         .submitIncident(productIdYbEth, priceBefore, currentTime + segment.period / 2, parseEther('100'), '');
     }
 
@@ -536,7 +558,9 @@ describe('redeemPayout', function () {
     const { yieldTokenIncidents, assessment, cover, ybEth, dai } = this.contracts;
     const [member1] = this.accounts.members;
     const [nonMember1, nonMember2] = this.accounts.nonMembers;
-    const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
     const segment = await getCoverSegment();
     segment.amount = parseEther('10000');
 
@@ -550,7 +574,7 @@ describe('redeemPayout', function () {
     {
       const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
       await yieldTokenIncidents
-        .connect(advisoryBoard)
+        .connect(governance)
         .submitIncident(productIdYbEth, priceBefore, currentTime + segment.period / 2, parseEther('100'), '');
     }
 
@@ -615,7 +639,9 @@ describe('redeemPayout', function () {
     const { yieldTokenIncidents, assessment, cover, ybPermitDai, dai } = this.contracts;
     const [member1] = this.accounts.members;
     const [nonMember] = this.accounts.nonMembers;
-    const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
     const segment = await getCoverSegment();
     segment.amount = parseEther('10000');
     const productId = 4;
@@ -625,7 +651,7 @@ describe('redeemPayout', function () {
     {
       const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
       await yieldTokenIncidents
-        .connect(advisoryBoard)
+        .connect(governance)
         .submitIncident(productId, priceBefore, currentTime + segment.period / 2, parseEther('100'), '');
     }
 
@@ -688,27 +714,27 @@ describe('redeemPayout', function () {
 
   it('emits IncidentPayoutRedeemed event with owner, payout amount, incident and cover ids', async function () {
     const { yieldTokenIncidents, cover, assessment, ybEth, ybDai } = this.contracts;
-    const [coverOwner1, coverOwner2] = this.accounts.members;
-    const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const [coverOwner1, coverOwner2, member] = this.accounts.members;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
     const { timestamp } = await ethers.provider.getBlock('latest');
     const segment = await getCoverSegment();
 
     await cover.createMockCover(coverOwner1.address, productIdYbEth, ASSET.ETH, [segment]);
-
     await cover.createMockCover(coverOwner1.address, productIdYbEth, ASSET.ETH, [segment]);
-
     await cover.createMockCover(coverOwner2.address, productIdYbDai, ASSET.DAI, [segment]);
 
     await yieldTokenIncidents
-      .connect(advisoryBoard)
+      .connect(governance)
       .submitIncident(productIdYbEth, parseEther('1'), timestamp + 2, parseEther('100'), '');
 
     await yieldTokenIncidents
-      .connect(advisoryBoard)
+      .connect(governance)
       .submitIncident(productIdYbDai, parseEther('1'), timestamp + 2, parseEther('100'), '');
 
-    await assessment.connect(advisoryBoard).castVote(0, true, parseEther('100'));
-    await assessment.connect(advisoryBoard).castVote(1, true, parseEther('100'));
+    await assessment.connect(member).castVote(0, true, parseEther('100'));
+    await assessment.connect(member).castVote(1, true, parseEther('100'));
 
     {
       const { payoutCooldownInDays } = await assessment.config();
@@ -733,17 +759,19 @@ describe('redeemPayout', function () {
 
   it('reverts if system is paused', async function () {
     const { yieldTokenIncidents, cover, assessment, ybEth, master } = this.contracts;
-    const [coverOwner1] = this.accounts.members;
-    const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const [coverOwner1, member] = this.accounts.members;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
     const { timestamp } = await ethers.provider.getBlock('latest');
     const segment = await getCoverSegment();
     await cover.createMockCover(coverOwner1.address, productIdYbEth, ASSET.ETH, [segment]);
 
     await yieldTokenIncidents
-      .connect(advisoryBoard)
+      .connect(governance)
       .submitIncident(productIdYbEth, parseEther('1'), timestamp + 2, parseEther('100'), '');
 
-    await assessment.connect(advisoryBoard).castVote(0, true, parseEther('100'));
+    await assessment.connect(member).castVote(0, true, parseEther('100'));
 
     {
       const { payoutCooldownInDays } = await assessment.config();
@@ -761,19 +789,21 @@ describe('redeemPayout', function () {
 
   it('reverts if caller is not a member', async function () {
     const { yieldTokenIncidents, cover, assessment, ybEth } = this.contracts;
-    const [coverOwner1] = this.accounts.members;
+    const [coverOwner1, member] = this.accounts.members;
     const [nonMember] = this.accounts.nonMembers;
-    const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
 
     const { timestamp } = await ethers.provider.getBlock('latest');
     const segment = await getCoverSegment();
     await cover.createMockCover(coverOwner1.address, productIdYbEth, ASSET.ETH, [segment]);
 
     await yieldTokenIncidents
-      .connect(advisoryBoard)
+      .connect(governance)
       .submitIncident(productIdYbEth, parseEther('1'), timestamp + 2, parseEther('100'), '');
 
-    await assessment.connect(advisoryBoard).castVote(0, true, parseEther('100'));
+    await assessment.connect(member).castVote(0, true, parseEther('100'));
 
     {
       const { payoutCooldownInDays } = await assessment.config();
@@ -790,7 +820,9 @@ describe('redeemPayout', function () {
   it('should transfer product underlying asset amount to the contract', async function () {
     const { yieldTokenIncidents, assessment, cover, ybEth } = this.contracts;
     const [member1] = this.accounts.members;
-    const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
     const segment = await getCoverSegment();
     segment.amount = parseEther('10000');
 
@@ -799,7 +831,7 @@ describe('redeemPayout', function () {
     const depeggedTokensAmount = parseEther('100');
     const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
     await yieldTokenIncidents
-      .connect(advisoryBoard)
+      .connect(governance)
       .submitIncident(productIdYbEth, priceBefore, currentTime + segment.period / 2, depeggedTokensAmount, '');
 
     await assessment.connect(member1).castVote(0, true, depeggedTokensAmount);
@@ -827,7 +859,9 @@ describe('redeemPayout', function () {
   it('should burn the stake of associated staking pools', async function () {
     const { yieldTokenIncidents, assessment, cover, ybEth } = this.contracts;
     const [member1] = this.accounts.members;
-    const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
     const segment = await getCoverSegment();
     segment.amount = parseEther('10000');
 
@@ -841,7 +875,7 @@ describe('redeemPayout', function () {
     const coverAssetDecimals = parseEther('1');
 
     await yieldTokenIncidents
-      .connect(advisoryBoard)
+      .connect(governance)
       .submitIncident(productIdYbEth, priceBefore, currentTime + segment.period / 2, depeggedTokensAmount, '');
 
     await assessment.connect(member1).castVote(0, true, depeggedTokensAmount);

--- a/test/unit/YieldTokenIncidents/submitIncident.js
+++ b/test/unit/YieldTokenIncidents/submitIncident.js
@@ -6,14 +6,16 @@ const { parseEther } = ethers.utils;
 describe('submitIncident', function () {
   it('reverts if the product uses a different claim method', async function () {
     const { yieldTokenIncidents } = this.contracts;
-    const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
 
     {
       const productId = 0;
       const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
       await expect(
         yieldTokenIncidents
-          .connect(advisoryBoard)
+          .connect(governance)
           .submitIncident(productId, parseEther('1.1'), currentTime, parseEther('20000'), ''),
       ).to.be.revertedWith('Invalid claim method for this product type');
     }
@@ -23,7 +25,7 @@ describe('submitIncident', function () {
       const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
       await expect(
         yieldTokenIncidents
-          .connect(advisoryBoard)
+          .connect(governance)
           .submitIncident(productId, parseEther('1.1'), currentTime, parseEther('20000'), ''),
       ).to.be.revertedWith('Invalid claim method for this product type');
     }
@@ -31,13 +33,15 @@ describe('submitIncident', function () {
 
   it('calls startAssessment and stores the returned assessmentId in the incident', async function () {
     const { yieldTokenIncidents } = this.contracts;
-    const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
 
     {
       const productId = 2;
       const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
       await yieldTokenIncidents
-        .connect(advisoryBoard)
+        .connect(governance)
         .submitIncident(productId, parseEther('1.1'), currentTime, parseEther('20000'), '');
       const expectedAssessmentId = 0;
       const { assessmentId } = await yieldTokenIncidents.incidents(0);
@@ -48,7 +52,7 @@ describe('submitIncident', function () {
       const productId = 2;
       const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
       await yieldTokenIncidents
-        .connect(advisoryBoard)
+        .connect(governance)
         .submitIncident(productId, parseEther('1.1'), currentTime, parseEther('20000'), '');
       const expectedAssessmentId = 1;
       const { assessmentId } = await yieldTokenIncidents.incidents(1);
@@ -58,13 +62,15 @@ describe('submitIncident', function () {
 
   it('pushes an incident with productId, date and priceBefore to incidents', async function () {
     const { yieldTokenIncidents } = this.contracts;
-    const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
 
     const expectedProductId = 2;
     const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
     const expectedPriceBefore = parseEther('1.1');
     await yieldTokenIncidents
-      .connect(advisoryBoard)
+      .connect(governance)
       .submitIncident(expectedProductId, expectedPriceBefore, currentTime, parseEther('20000'), '');
     const { productId, date, priceBefore } = await yieldTokenIncidents.incidents(0);
     expect(productId).to.be.equal(expectedProductId);
@@ -74,13 +80,15 @@ describe('submitIncident', function () {
 
   it('calculates the total reward using the expected payout amount parameter provided', async function () {
     const { assessment, yieldTokenIncidents } = this.contracts;
-    const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
 
     const productId = 2;
     const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
     const expectedPayoutAmount = parseEther('100');
     await yieldTokenIncidents
-      .connect(advisoryBoard)
+      .connect(governance)
       .submitIncident(productId, parseEther('1.1'), currentTime, expectedPayoutAmount, '');
     const expectedTotalReward = expectedPayoutAmount.mul(this.config.rewardRatio).div(10000);
     const { totalRewardInNXM } = await assessment.assessments(0);
@@ -89,12 +97,14 @@ describe('submitIncident', function () {
 
   it('calculates the totalRewardInNXM capped at config.maxRewardInNXMWad', async function () {
     const { assessment, yieldTokenIncidents } = this.contracts;
-    const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
     const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
     const productId = 2;
 
     await yieldTokenIncidents
-      .connect(advisoryBoard)
+      .connect(governance)
       .submitIncident(productId, parseEther('1.1'), currentTime, parseEther('100000000'), '');
     const expectedTotalReward = parseEther(this.config.maxRewardInNXMWad.toString());
 
@@ -104,13 +114,15 @@ describe('submitIncident', function () {
 
   it('emits MetadataSubmitted event with the provided ipfsMetadata when it is not empty string', async function () {
     const { yieldTokenIncidents } = this.contracts;
-    const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
     const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
     const productId = 2;
 
     await expect(
       yieldTokenIncidents
-        .connect(advisoryBoard)
+        .connect(governance)
         .submitIncident(productId, parseEther('1.1'), currentTime, parseEther('10000'), 'ipfsMetadata1'),
     )
       .to.emit(yieldTokenIncidents, 'MetadataSubmitted')
@@ -118,7 +130,7 @@ describe('submitIncident', function () {
 
     await expect(
       yieldTokenIncidents
-        .connect(advisoryBoard)
+        .connect(governance)
         .submitIncident(productId, parseEther('1.2'), currentTime, parseEther('20000'), 'ipfsMetadata2'),
     )
       .to.emit(yieldTokenIncidents, 'MetadataSubmitted')
@@ -127,30 +139,34 @@ describe('submitIncident', function () {
 
   it('emits IncidentSubmitted event with sender incident and product ids and payout in NXM', async function () {
     const { yieldTokenIncidents } = this.contracts;
-    const [advisoryBoard1, advisoryBoard2] = this.accounts.advisoryBoardMembers;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
     const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
     const productId = 2;
 
     await expect(
       yieldTokenIncidents
-        .connect(advisoryBoard1)
+        .connect(governance)
         .submitIncident(productId, parseEther('1.1'), currentTime, parseEther('10000'), 'ipfsMetadata1'),
     )
       .to.emit(yieldTokenIncidents, 'IncidentSubmitted')
-      .withArgs(advisoryBoard1.address, 0, productId, parseEther('10000'));
+      .withArgs(governance.address, 0, productId, parseEther('10000'));
 
     await expect(
       yieldTokenIncidents
-        .connect(advisoryBoard2)
+        .connect(governance)
         .submitIncident(productId, parseEther('1.2'), currentTime, parseEther('20000'), 'ipfsMetadata2'),
     )
       .to.emit(yieldTokenIncidents, 'IncidentSubmitted')
-      .withArgs(advisoryBoard2.address, 1, productId, parseEther('20000'));
+      .withArgs(governance.address, 1, productId, parseEther('20000'));
   });
 
   it('reverts if system is paused', async function () {
     const { yieldTokenIncidents, master } = this.contracts;
-    const [advisoryBoard] = this.accounts.advisoryBoardMembers;
+    const {
+      governanceContracts: [governance],
+    } = this.accounts;
 
     await master.pause();
 
@@ -158,21 +174,21 @@ describe('submitIncident', function () {
     const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
     await expect(
       yieldTokenIncidents
-        .connect(advisoryBoard)
+        .connect(governance)
         .submitIncident(productId, parseEther('1.1'), currentTime, parseEther('20000'), ''),
     ).to.be.revertedWith('System is paused');
   });
 
   it('reverts if caller is not advisory board', async function () {
     const { yieldTokenIncidents } = this.contracts;
-    const [nonAdvisoryBoard] = this.accounts.members;
+    const [nonGovernance] = this.accounts.members;
 
     const productId = 2;
     const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
     await expect(
       yieldTokenIncidents
-        .connect(nonAdvisoryBoard)
+        .connect(nonGovernance)
         .submitIncident(productId, parseEther('1.1'), currentTime, parseEther('20000'), ''),
-    ).to.be.revertedWith('Caller is not an advisory board member');
+    ).to.be.revertedWith('Caller is not authorized to govern');
   });
 });

--- a/test/unit/YieldTokenIncidents/submitIncident.js
+++ b/test/unit/YieldTokenIncidents/submitIncident.js
@@ -6,9 +6,7 @@ const { parseEther } = ethers.utils;
 describe('submitIncident', function () {
   it('reverts if the product uses a different claim method', async function () {
     const { yieldTokenIncidents } = this.contracts;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
 
     {
       const productId = 0;
@@ -33,9 +31,7 @@ describe('submitIncident', function () {
 
   it('calls startAssessment and stores the returned assessmentId in the incident', async function () {
     const { yieldTokenIncidents } = this.contracts;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
 
     {
       const productId = 2;
@@ -62,9 +58,7 @@ describe('submitIncident', function () {
 
   it('pushes an incident with productId, date and priceBefore to incidents', async function () {
     const { yieldTokenIncidents } = this.contracts;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
 
     const expectedProductId = 2;
     const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
@@ -80,9 +74,7 @@ describe('submitIncident', function () {
 
   it('calculates the total reward using the expected payout amount parameter provided', async function () {
     const { assessment, yieldTokenIncidents } = this.contracts;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
 
     const productId = 2;
     const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
@@ -97,9 +89,7 @@ describe('submitIncident', function () {
 
   it('calculates the totalRewardInNXM capped at config.maxRewardInNXMWad', async function () {
     const { assessment, yieldTokenIncidents } = this.contracts;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
     const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
     const productId = 2;
 
@@ -114,9 +104,7 @@ describe('submitIncident', function () {
 
   it('emits MetadataSubmitted event with the provided ipfsMetadata when it is not empty string', async function () {
     const { yieldTokenIncidents } = this.contracts;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
     const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
     const productId = 2;
 
@@ -139,9 +127,7 @@ describe('submitIncident', function () {
 
   it('emits IncidentSubmitted event with sender incident and product ids and payout in NXM', async function () {
     const { yieldTokenIncidents } = this.contracts;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
     const { timestamp: currentTime } = await ethers.provider.getBlock('latest');
     const productId = 2;
 
@@ -164,9 +150,7 @@ describe('submitIncident', function () {
 
   it('reverts if system is paused', async function () {
     const { yieldTokenIncidents, master } = this.contracts;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
 
     await master.pause();
 

--- a/test/unit/YieldTokenIncidents/updateUintParameters.js
+++ b/test/unit/YieldTokenIncidents/updateUintParameters.js
@@ -25,9 +25,7 @@ describe('updateUintParameters', function () {
 
   it('sets each parameter to the given new values', async function () {
     const { yieldTokenIncidents } = this.contracts;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
     const newValues = {
       payoutRedemptionPeriodInDays: 111,
       expectedPayoutRatio: 2222,
@@ -73,9 +71,7 @@ describe('updateUintParameters', function () {
 
   it('sets only the given parameters to the new values', async function () {
     const { yieldTokenIncidents } = this.contracts;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
 
     {
       const newValues = {
@@ -141,9 +137,7 @@ describe('updateUintParameters', function () {
 
   it('allows parameters to be given in any order', async function () {
     const { yieldTokenIncidents } = this.contracts;
-    const {
-      governanceContracts: [governance],
-    } = this.accounts;
+    const [governance] = this.accounts.governanceContracts;
 
     {
       const newValues = {


### PR DESCRIPTION
## Context
Closes issue https://github.com/NexusMutual/smart-contracts/issues/446.

## Changes proposed in this pull request
For better security, no one single AB member should be able to have special powers, but we should leverage the governance system with an AB only proposal category for submitIncident(). 

Note that the only other operation that is AB-only is add/edit/remove products and product types. To decrease friction, we should leave it as is, but have an alert setup for these actions.

## Test plan
Updated all existing tests. There already is a test for the modifier.

## Checklist
- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
