### PR TITLE
Fix:  Use correct coverId for request allocation in buyCover

### DIFF
--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -272,6 +272,8 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
       _coverSegments[coverId][segmentId - 1].period = (block.timestamp - lastSegment.start).toUint32();
     }
 
+    allocationRequest.coverId = coverId;
+
     (uint coverAmountInCoverAsset, uint amountDueInNXM) = requestAllocation(
       allocationRequest,
       poolAllocationRequests,


### PR DESCRIPTION
## Context

The variable `coverSegmentAllocations` is storing the allocation to the incorrect `coverId`.  The struct `AllocationRequest` initializes the coverId to `0` and then is not updated so all allocation ended up being stored for that coverId.


## Changes proposed in this pull request

Updates the `allocationRequest.coverId` so it uses the correct `coverId`.


## Test plan

A new test was added in `test/unit/Cover/buyCover.js`. The test fails without the fix.


## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
