### PR TITLE
Feature: staking pool depositTo/withdraw/extend without arrays

### DIFF
--- a/contracts/interfaces/IStakingPool.sol
+++ b/contracts/interfaces/IStakingPool.sol
@@ -21,20 +21,6 @@ struct AllocationRequest {
   uint globalMinPrice;
 }
 
-struct WithdrawRequest {
-  uint tokenId;
-  bool withdrawStake;
-  bool withdrawRewards;
-  uint[] trancheIds;
-}
-
-struct DepositRequest {
-  uint amount;
-  uint trancheId;
-  uint tokenId;
-  address destination;
-}
-
 struct StakedProductParam {
   uint productId;
   bool recalculateEffectiveWeight;
@@ -111,11 +97,19 @@ interface IStakingPool {
 
   function burnStake(uint amount) external;
 
-  function depositTo(DepositRequest[] memory requests) external returns (uint[] memory tokenIds);
+  function depositTo(
+    uint amount,
+    uint trancheId,
+    uint requestTokenId,
+    address destination
+  ) external returns (uint tokenId);
 
   function withdraw(
-    WithdrawRequest[] memory params
-  ) external returns (uint stakeToWithdraw, uint rewardsToWithdraw);
+    uint tokenId,
+    bool withdrawStake,
+    bool withdrawRewards,
+    uint[] memory trancheIds
+  ) external returns (uint withdrawnStake, uint withdrawnRewards);
 
   function setPoolFee(uint newFee) external;
 

--- a/contracts/interfaces/IStakingPool.sol
+++ b/contracts/interfaces/IStakingPool.sol
@@ -85,6 +85,8 @@ interface IStakingPool {
     string memory ipfsDescriptionHash
   ) external;
 
+  function multicall(bytes[] calldata data) external returns (bytes[] memory results);
+
   function operatorTransfer(address from, address to, uint[] calldata tokenIds) external;
 
   function processExpirations(bool updateUntilCurrentTimestamp) external;

--- a/contracts/mocks/Cover/CoverMockStakingPool.sol
+++ b/contracts/mocks/Cover/CoverMockStakingPool.sol
@@ -151,27 +151,22 @@ contract CoverMockStakingPool is IStakingPool, ERC721Mock {
     burnStakeCalledWith = amount;
   }
 
-  function depositTo(DepositRequest[] memory /* requests */) external returns (uint[] memory /* tokenIds */) {
+  function depositTo(
+    uint /*amount*/,
+    uint /*trancheId*/,
+    uint /*requestTokenId*/,
+    address /*destination*/
+  ) external returns (uint /* tokenId */) {
     totalSupply = totalSupply;
     revert("CoverMockStakingPool: not callable");
   }
 
-  function withdraw(WithdrawRequest[] memory /* params */) external returns (uint /* stakeToWithdraw */, uint /* rewardsToWithdraw */) {
-    totalSupply = totalSupply;
-    revert("CoverMockStakingPool: not callable");
-  }
-
-  function addProducts(StakedProductParam[] memory /* params */) external {
-    totalSupply = totalSupply;
-    revert("CoverMockStakingPool: not callable");
-  }
-
-  function removeProducts(uint[] memory /* productIds */) external {
-    totalSupply = totalSupply;
-    revert("CoverMockStakingPool: not callable");
-  }
-
-  function setProductDetails(StakedProductParam[] memory /* params */) external {
+  function withdraw(
+    uint /*tokenId*/,
+    bool /*withdrawStake*/,
+    bool /*withdrawRewards*/,
+    uint[] memory /*trancheIds*/
+  ) public returns (uint /*withdrawnStake*/, uint /*withdrawnRewards*/) {
     totalSupply = totalSupply;
     revert("CoverMockStakingPool: not callable");
   }

--- a/contracts/mocks/Cover/CoverMockStakingPool.sol
+++ b/contracts/mocks/Cover/CoverMockStakingPool.sol
@@ -201,4 +201,9 @@ contract CoverMockStakingPool is IStakingPool, ERC721Mock {
     revert("CoverMockStakingPool: not callable");
   }
 
+  function multicall(bytes[] calldata) external returns (bytes[] memory) {
+    totalSupply = totalSupply;
+    revert("CoverMockStakingPool: not callable");
+  }
+
 }

--- a/contracts/modules/cover/CoverUtilsLib.sol
+++ b/contracts/modules/cover/CoverUtilsLib.sol
@@ -171,9 +171,7 @@ library CoverUtilsLib {
 
     // will create nft with a position in the desired tranche id
     if (depositAmount > 0) {
-      DepositRequest[] memory requests = new DepositRequest[](1);
-      requests[0] = DepositRequest(depositAmount, trancheId, 0, poolInitParams.manager);
-      newStakingPool.depositTo(requests);
+      newStakingPool.depositTo(depositAmount, trancheId, 0, poolInitParams.manager);
     }
   }
 

--- a/contracts/modules/legacy/LegacyPooledStaking.sol
+++ b/contracts/modules/legacy/LegacyPooledStaking.sol
@@ -1484,8 +1484,6 @@ contract LegacyPooledStaking is IPooledStaking, MasterAwareV2 {
     uint deposit = stakers[msg.sender].deposit;
     stakers[msg.sender].deposit = 0;
     token().approve(address(tokenController()), deposit);
-    DepositRequest[] memory requests = new DepositRequest[](1);
-    requests[0] = DepositRequest(deposit, trancheId, 0, msg.sender);
-    stakingPool.depositTo(requests);
+    stakingPool.depositTo(deposit, trancheId, 0, msg.sender);
   }
 }

--- a/test/integration/Cover/createStakingPool.js
+++ b/test/integration/Cover/createStakingPool.js
@@ -62,14 +62,7 @@ describe('createStakingPool', function () {
     const managerStakingPoolNFTBalanceBefore = await stakingPool.balanceOf(manager.address);
     assert.equal(managerStakingPoolNFTBalanceBefore.toNumber(), 2);
 
-    await stakingPool.connect(manager).depositTo([
-      {
-        amount: deposit,
-        trancheId,
-        tokenId: 0,
-        destination: AddressZero,
-      },
-    ]);
+    await stakingPool.connect(manager).depositTo(deposit, trancheId, 0, AddressZero);
 
     const managerNXMBalanceAfterDeposit = await tk.balanceOf(manager.address);
     const tokenControllerBalanceAfterDeposit = await tk.balanceOf(tc.address);
@@ -79,16 +72,9 @@ describe('createStakingPool', function () {
     expect(tokenControllerBalanceAfterDeposit).to.be.equal(tokenControllerBalanceAfterCreation.add(deposit));
     expect(managerStakingPoolNFTBalanceAfter).to.be.equal(managerStakingPoolNFTBalanceBefore.add(1));
 
-    await expect(
-      stakingPool.connect(staker).depositTo([
-        {
-          amount: deposit,
-          trancheId,
-          tokenId: 0,
-          destination: AddressZero,
-        },
-      ]),
-    ).to.be.revertedWith('StakingPool: The pool is private');
+    await expect(stakingPool.connect(staker).depositTo(deposit, trancheId, 0, AddressZero)).to.be.revertedWith(
+      'StakingPool: The pool is private',
+    );
   });
 
   it('should create a public staking pool with an initial deposit', async function () {
@@ -129,14 +115,7 @@ describe('createStakingPool', function () {
     const managerStakingPoolNFTBalanceBefore = await stakingPool.balanceOf(manager.address);
     expect(managerStakingPoolNFTBalanceBefore).to.be.equal(2);
 
-    await stakingPool.connect(manager).depositTo([
-      {
-        amount: deposit,
-        trancheId,
-        tokenId: 0,
-        destination: AddressZero,
-      },
-    ]);
+    await stakingPool.connect(manager).depositTo(deposit, trancheId, 0, AddressZero);
 
     const managerNXMBalanceAfterDeposit = await tk.balanceOf(manager.address);
     const tokenControllerBalanceAfterManagerDeposit = await tk.balanceOf(tc.address);
@@ -147,14 +126,7 @@ describe('createStakingPool', function () {
     expect(managerStakingPoolNFTBalanceAfter).to.be.equal(managerStakingPoolNFTBalanceBefore.add(1));
 
     const stakerNXMBalanceBefore = await tk.balanceOf(staker.address);
-    await stakingPool.connect(staker).depositTo([
-      {
-        amount: deposit,
-        trancheId,
-        tokenId: 0,
-        destination: AddressZero,
-      },
-    ]);
+    await stakingPool.connect(staker).depositTo(deposit, trancheId, 0, AddressZero);
 
     const stakerNXMBalanceAfter = await tk.balanceOf(staker.address);
     const tokenControllerBalanceAfterStakerDeposit = await tk.balanceOf(tc.address);

--- a/test/integration/Cover/expireCover.js
+++ b/test/integration/Cover/expireCover.js
@@ -46,14 +46,12 @@ describe.skip('expireCover', function () {
     const firstTrancheId = calculateFirstTrancheId(lastBlock, period, gracePeriod);
 
     // Stake to open up capacity
-    await stakingPool.connect(staker).depositTo([
-      {
-        amount: stakingAmount,
-        trancheId: firstTrancheId,
-        tokenId: 0, // new position
-        destination: AddressZero,
-      },
-    ]);
+    await stakingPool.connect(staker).depositTo(
+      stakingAmount,
+      firstTrancheId,
+      0, // new position
+      AddressZero,
+    );
     await stakingPool.setTargetWeight(productId, 10);
   }
 

--- a/test/integration/IndividualClaims/submitClaim.js
+++ b/test/integration/IndividualClaims/submitClaim.js
@@ -32,7 +32,6 @@ describe('submitClaim', function () {
   async function acceptClaim({ staker, assessmentStakingAmount, as }) {
     const { payoutCooldownInDays } = await as.config();
     await as.connect(staker).stake(assessmentStakingAmount);
-
     await as.connect(staker).castVotes([0], [true], ['Assessment data hash'], 0);
 
     const { poll } = await as.assessments(0);
@@ -46,9 +45,7 @@ describe('submitClaim', function () {
     const assessmentStakingAmountForRejection = parseEther('2000');
     const { payoutCooldownInDays } = await as.config();
     await as.connect(approvingStaker).stake(assessmentStakingAmountForApproval);
-
     await as.connect(approvingStaker).castVotes([0], [true], ['Assessment data hash'], 0);
-
     await as.connect(rejectingStaker).stake(assessmentStakingAmountForRejection);
     await as.connect(rejectingStaker).castVotes([0], [false], ['Assessment data hash'], 0);
 
@@ -65,14 +62,12 @@ describe('submitClaim', function () {
     const firstTrancheId = calculateFirstTrancheId(lastBlock, period, gracePeriod);
 
     // Stake to open up capacity
-    await stakingPool.connect(staker).depositTo([
-      {
-        amount: stakingAmount,
-        trancheId: firstTrancheId,
-        tokenId: 0, // new position
-        destination: AddressZero,
-      },
-    ]);
+    await stakingPool.connect(staker).depositTo(
+      stakingAmount,
+      firstTrancheId,
+      0, // new position
+      AddressZero,
+    );
 
     const stakingProductParams = {
       productId,

--- a/test/integration/YieldTokenIncidents/submitClaim.js
+++ b/test/integration/YieldTokenIncidents/submitClaim.js
@@ -44,14 +44,12 @@ describe('submitClaim', function () {
     const firstTrancheId = calculateFirstTrancheId(lastBlock, period, gracePeriod);
 
     // Stake to open up capacity
-    await stakingPool.connect(staker).depositTo([
-      {
-        amount: stakingAmount,
-        trancheId: firstTrancheId,
-        tokenId: 0, // new position
-        destination: AddressZero,
-      },
-    ]);
+    await stakingPool.connect(staker).depositTo(
+      stakingAmount,
+      firstTrancheId,
+      0, // new position
+      AddressZero,
+    );
 
     const stakingProductParams = {
       productId,

--- a/test/unit/StakingPool/extendDeposit.js
+++ b/test/unit/StakingPool/extendDeposit.js
@@ -26,10 +26,8 @@ describe('extendDeposit', function () {
 
   beforeEach(async function () {
     const { stakingPool, cover } = this;
-    const {
-      defaultSender: manager,
-      members: [user],
-    } = this.accounts;
+    const manager = this.accounts.defaultSender;
+    const [user] = this.accounts.members;
 
     const { poolId, initialPoolFee, maxPoolFee, productInitializationParams, amount, ipfsDescriptionHash } =
       depositToFixture;
@@ -57,14 +55,7 @@ describe('extendDeposit', function () {
       expect(totalSupply).to.equal(1);
     }
 
-    await stakingPool.connect(user).depositTo([
-      {
-        amount,
-        trancheId: firstActiveTrancheId,
-        tokenId: 0,
-        destination: AddressZero,
-      },
-    ]);
+    await stakingPool.connect(user).depositTo(amount, firstActiveTrancheId, 0, AddressZero);
   });
 
   it('reverts if token id is 0', async function () {
@@ -81,10 +72,7 @@ describe('extendDeposit', function () {
 
   it('reverts if new tranche ends before the initial tranche', async function () {
     const { stakingPool } = this;
-    const {
-      members: [user],
-    } = this.accounts;
-
+    const [user] = this.accounts.members;
     const { depositNftId } = depositToFixture;
 
     const { firstActiveTrancheId, maxTranche } = await getTranches();
@@ -96,10 +84,7 @@ describe('extendDeposit', function () {
 
   it('reverts if new tranche is not yet available', async function () {
     const { stakingPool } = this;
-    const {
-      members: [user],
-    } = this.accounts;
-
+    const [user] = this.accounts.members;
     const { depositNftId } = depositToFixture;
 
     const { firstActiveTrancheId, maxTranche } = await getTranches();
@@ -111,10 +96,7 @@ describe('extendDeposit', function () {
 
   it('reverts if the new tranche already expired', async function () {
     const { stakingPool } = this;
-    const {
-      members: [user],
-    } = this.accounts;
-
+    const [user] = this.accounts.members;
     const { depositNftId } = depositToFixture;
 
     const { firstActiveTrancheId } = await getTranches();
@@ -141,10 +123,7 @@ describe('extendDeposit', function () {
 
   it('withdraws and make a new deposit if initial tranche is expired', async function () {
     const { stakingPool } = this;
-    const {
-      members: [user],
-    } = this.accounts;
-
+    const [user] = this.accounts.members;
     const { depositNftId } = depositToFixture;
 
     const { firstActiveTrancheId, maxTranche } = await getTranches();
@@ -160,10 +139,7 @@ describe('extendDeposit', function () {
 
   it('updates tranches including accNxmPerRewardsShare and lastAccNxmUpdate', async function () {
     const { stakingPool } = this;
-    const {
-      members: [user],
-    } = this.accounts;
-
+    const [user] = this.accounts.members;
     const { depositNftId } = depositToFixture;
 
     const { firstActiveTrancheId, maxTranche } = await getTranches();
@@ -190,10 +166,7 @@ describe('extendDeposit', function () {
 
   it('removes the initial tranche deposit and stores the new tranche deposit', async function () {
     const { stakingPool } = this;
-    const {
-      members: [user],
-    } = this.accounts;
-
+    const [user] = this.accounts.members;
     const { depositNftId } = depositToFixture;
 
     const { firstActiveTrancheId, maxTranche } = await getTranches();
@@ -236,10 +209,7 @@ describe('extendDeposit', function () {
 
   it('allows to increase the deposit', async function () {
     const { stakingPool } = this;
-    const {
-      members: [user],
-    } = this.accounts;
-
+    const [user] = this.accounts.members;
     const { depositNftId } = depositToFixture;
 
     const { firstActiveTrancheId, maxTranche } = await getTranches();
@@ -278,10 +248,7 @@ describe('extendDeposit', function () {
 
   it('allows to increase the deposit in expired tranche', async function () {
     const { stakingPool } = this;
-    const {
-      members: [user],
-    } = this.accounts;
-
+    const [user] = this.accounts.members;
     const { depositNftId, amount } = depositToFixture;
 
     const { firstActiveTrancheId, maxTranche } = await getTranches();
@@ -313,10 +280,7 @@ describe('extendDeposit', function () {
 
   it('updates the initial and new tranche stake shares and reward shares', async function () {
     const { stakingPool } = this;
-    const {
-      members: [user],
-    } = this.accounts;
-
+    const [user] = this.accounts.members;
     const { depositNftId } = depositToFixture;
 
     const { firstActiveTrancheId, maxTranche } = await getTranches();
@@ -345,10 +309,7 @@ describe('extendDeposit', function () {
 
   it('updates global stake and reward shares supply', async function () {
     const { stakingPool } = this;
-    const {
-      members: [user],
-    } = this.accounts;
-
+    const [user] = this.accounts.members;
     const { depositNftId } = depositToFixture;
 
     const { firstActiveTrancheId, maxTranche } = await getTranches();
@@ -381,10 +342,7 @@ describe('extendDeposit', function () {
 
   it('transfers increased deposit amount to token controller', async function () {
     const { stakingPool, nxm, tokenController } = this;
-    const {
-      members: [user],
-    } = this.accounts;
-
+    const [user] = this.accounts.members;
     const { depositNftId } = depositToFixture;
 
     const { firstActiveTrancheId, maxTranche } = await getTranches();
@@ -405,23 +363,13 @@ describe('extendDeposit', function () {
 
   it('transfers correctly increased deposit amount if previous deposit exists', async function () {
     const { stakingPool, nxm, tokenController } = this;
-    const {
-      members: [user],
-    } = this.accounts;
-
+    const [user] = this.accounts.members;
     const { depositNftId, amount } = depositToFixture;
 
     const { firstActiveTrancheId, maxTranche } = await getTranches();
 
     // add deposit to new tranche
-    await stakingPool.connect(user).depositTo([
-      {
-        amount,
-        trancheId: maxTranche,
-        tokenId: depositNftId,
-        destination: AddressZero,
-      },
-    ]);
+    await stakingPool.connect(user).depositTo(amount, maxTranche, depositNftId, AddressZero);
 
     await generateRewards(stakingPool, this.coverSigner);
 
@@ -439,10 +387,7 @@ describe('extendDeposit', function () {
 
   it('emits DepositExtended event', async function () {
     const { stakingPool } = this;
-    const {
-      members: [user],
-    } = this.accounts;
-
+    const [user] = this.accounts.members;
     const { depositNftId } = depositToFixture;
 
     const { firstActiveTrancheId, maxTranche } = await getTranches();
@@ -455,9 +400,7 @@ describe('extendDeposit', function () {
 
   it('does not emit DepositExtended if initial tranche is expired', async function () {
     const { stakingPool } = this;
-    const {
-      members: [user],
-    } = this.accounts;
+    const [user] = this.accounts.members;
 
     const { depositNftId } = depositToFixture;
 
@@ -473,10 +416,8 @@ describe('extendDeposit', function () {
 
   it('reverts if pool is private', async function () {
     const { stakingPool } = this;
-    const {
-      members: [user],
-      defaultSender: manager,
-    } = this.accounts;
+    const [user] = this.accounts.members;
+    const manager = this.accounts.defaultSender;
 
     const { depositNftId } = depositToFixture;
 
@@ -492,10 +433,8 @@ describe('extendDeposit', function () {
 
   it('reverts if pool is private and tranche expired', async function () {
     const { stakingPool } = this;
-    const {
-      members: [user],
-      defaultSender: manager,
-    } = this.accounts;
+    const [user] = this.accounts.members;
+    const manager = this.accounts.defaultSender;
 
     const { depositNftId } = depositToFixture;
 

--- a/test/unit/StakingPool/processExpirations.js
+++ b/test/unit/StakingPool/processExpirations.js
@@ -53,24 +53,14 @@ describe('processExpirations', function () {
 
   it('expires tranche with no previous updates', async function () {
     const { stakingPool } = this;
-    const {
-      members: [user],
-    } = this.accounts;
-
+    const [user] = this.accounts.members;
     const { amount, tokenId, destination } = depositToFixture;
 
     const { firstActiveTrancheId } = await getTranches(daysToSeconds(0), daysToSeconds(0));
 
     // Deposit. In this internal call to processExpirations _rewardsSharesSupply is 0
     // so it only updates lastAccNxmUpdate and return
-    await stakingPool.connect(user).depositTo([
-      {
-        amount,
-        trancheId: firstActiveTrancheId,
-        tokenId,
-        destination,
-      },
-    ]);
+    await stakingPool.connect(user).depositTo(amount, firstActiveTrancheId, tokenId, destination);
 
     // increase time to expire the first active tranche
     await increaseTime(TRANCHE_DURATION);
@@ -85,23 +75,13 @@ describe('processExpirations', function () {
 
   it('does not revert when expires multiple tranches', async function () {
     const { stakingPool } = this;
-    const {
-      members: [user],
-    } = this.accounts;
-
+    const [user] = this.accounts.members;
     const { amount, tokenId, destination } = depositToFixture;
 
     const { firstActiveTrancheId } = await getTranches(daysToSeconds('0'), daysToSeconds('0'));
 
     // deposit
-    await stakingPool.connect(user).depositTo([
-      {
-        amount,
-        trancheId: firstActiveTrancheId,
-        tokenId,
-        destination,
-      },
-    ]);
+    await stakingPool.connect(user).depositTo(amount, firstActiveTrancheId, tokenId, destination);
 
     // increase time to expire a couple of tranches
     await increaseTime(TRANCHE_DURATION * 2);

--- a/test/unit/StakingPool/setPoolFee.js
+++ b/test/unit/StakingPool/setPoolFee.js
@@ -126,8 +126,7 @@ describe('setPoolFee', function () {
     const { initialPoolFee } = initializeParams;
     const newPoolFee = initialPoolFee - 2;
 
-    const depositRequest = { amount: depositAmount, trancheId, tokenId, destination: AddressZero };
-    await stakingPool.connect(user).depositTo([depositRequest]);
+    await stakingPool.connect(user).depositTo(depositAmount, trancheId, tokenId, AddressZero);
 
     // Generate rewards
     const coverAmount = parseEther('1');

--- a/test/unit/StakingPool/setProducts.js
+++ b/test/unit/StakingPool/setProducts.js
@@ -51,13 +51,6 @@ const buyCoverParamsTemplate = {
   ipfsData: 'ipfs data',
 };
 
-const depositRequestTemplate = {
-  tokenId: 0,
-  destination: AddressZero, // needs to be set
-  trancheId: 0, // needs to be set
-  amount: parseEther('100'),
-};
-
 describe('setProducts unit tests', function () {
   // Create a default deposit request to the staking pool
   const getCurrentTrancheId = async () => {
@@ -458,13 +451,8 @@ describe('setProducts unit tests', function () {
 
     // Get capacity in staking pool
     await nxm.connect(staker).approve(tokenController.address, amount);
-    const request = {
-      ...depositRequestTemplate,
-      amount,
-      destination: staker.address,
-      trancheId: (await getCurrentTrancheId()) + 2,
-    };
-    await stakingPool.connect(staker).depositTo([request]);
+    const trancheId = (await getCurrentTrancheId()) + 2;
+    await stakingPool.connect(staker).depositTo(amount, trancheId, /* token id: */ 0, staker.address);
 
     let i = 0;
     const coverId = 1;
@@ -534,13 +522,8 @@ describe('setProducts unit tests', function () {
 
     // Get capacity in staking pool
     await nxm.connect(staker).approve(tokenController.address, amount);
-    const request = {
-      ...depositRequestTemplate,
-      amount,
-      destination: manager.address,
-      trancheId: (await getCurrentTrancheId()) + 2,
-    };
-    await stakingPool.connect(staker).depositTo([request]);
+    const trancheId = (await getCurrentTrancheId()) + 2;
+    await stakingPool.connect(staker).depositTo(amount, trancheId, /* token id: */ 0, manager.address);
 
     const ratio = await cover.getPriceAndCapacityRatios([0]);
     const { totalCapacity } = await stakingPool.getActiveTrancheCapacities(
@@ -608,13 +591,8 @@ describe('setProducts unit tests', function () {
 
     // Get capacity in staking pool
     await nxm.connect(staker).approve(tokenController.address, amount);
-    const request = {
-      ...depositRequestTemplate,
-      amount,
-      destination: manager.address,
-      trancheId: (await getCurrentTrancheId()) + 2,
-    };
-    await stakingPool.connect(staker).depositTo([request]);
+    const trancheId = (await getCurrentTrancheId()) + 2;
+    await stakingPool.connect(staker).depositTo(amount, trancheId, /* token id: */ 0, manager.address);
 
     // Initialize Products and CoverBuy requests
     const coverBuyParams = Array(20)


### PR DESCRIPTION
## Context

The array parameters unnecessary complicate the logic, increasee the code size and if the functions will be mostly used for a single deposit - they'll consume more gas.
Issue: #557 

## Changes proposed in this pull request

This PR simplifies this logic and makes the function act on a single deposit. There's also the new `multicall` function which adds support for performing multiple operations in a single tx if there's a need for that at any point.

## Test plan

Fixed all the tests that started to fail because of it. There's a single test that used 2 deposit in a single tx and I've used multicall for that. 

## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
