### PR TITLE
Chore: rename next price to bumped price

### DIFF
--- a/contracts/interfaces/IStakingPool.sol
+++ b/contracts/interfaces/IStakingPool.sol
@@ -66,8 +66,8 @@ interface IStakingPool {
     uint16 lastEffectiveWeight;
     uint8 targetWeight;
     uint96 targetPrice;
-    uint96 nextPrice;
-    uint32 nextPriceUpdateTime;
+    uint96 bumpedPrice;
+    uint32 bumpedPriceUpdateTime;
   }
 
   struct RewardBucket {

--- a/test/unit/StakingPool/helpers.js
+++ b/test/unit/StakingPool/helpers.js
@@ -38,13 +38,13 @@ function interpolatePrice(lastPriceRatio, targetPriceRatio, lastPriceUpdate, cur
     return targetPriceRatio;
   }
 
-  const nextPrice = lastPriceRatio.sub(priceChange);
+  const bumpedPrice = lastPriceRatio.sub(priceChange);
 
-  if (nextPrice.lt(targetPriceRatio)) {
+  if (bumpedPrice.lt(targetPriceRatio)) {
     return targetPriceRatio;
   }
 
-  return nextPrice;
+  return bumpedPrice;
 }
 
 function calculatePrice(amount, basePriceRatio, activeCover, capacity) {

--- a/test/unit/StakingPool/initialize.js
+++ b/test/unit/StakingPool/initialize.js
@@ -329,12 +329,12 @@ describe('initialize', function () {
       );
 
     for (const [index, product] of validProducts.entries()) {
-      const [lastEffectiveWeight, targetWeight, targetPrice, nextPrice, nextPriceUpdateTime] =
+      const [lastEffectiveWeight, targetWeight, targetPrice, bumpedPrice, bumpedPriceUpdateTime] =
         await stakingPool.products(index);
       expect(targetWeight).to.be.eq(product.weight);
       expect(targetPrice.toString()).to.be.eq(product.targetPrice);
-      expect(nextPrice.toString()).to.be.eq(product.initialPrice);
-      expect(nextPriceUpdateTime).to.not.be.eq(0);
+      expect(bumpedPrice.toString()).to.be.eq(product.initialPrice);
+      expect(bumpedPriceUpdateTime).to.not.be.eq(0);
       expect(lastEffectiveWeight).to.be.eq(0);
     }
   });


### PR DESCRIPTION
## Context

Given "next price" (formerly "last price") is not actually the price that will be used for the next cover buy it was a source of confusion.

## Changes proposed in this pull request

Renamed to `nextPrice` and `nextPriceUpdateTime` to `bumpedPrice` and `bumpedPriceUpdateTime`

## Test plan

Functionality is not affected. A search and replace was performed on tests and everything should pass.

## Checklist

- [x] Rebased the base branch
- [ ] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [x] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
