### PR TITLE
Fix: 5.1.3 Premium never sent to Pool

### DIFF
--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -414,11 +414,10 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
 
       uint remainder = msg.value - premiumWithCommission;
 
-      if (remainder > 0) {
-        // solhint-disable-next-line avoid-low-level-calls
-        (bool ok, /* data */) = address(msg.sender).call{value: remainder}("");
-        require(ok, "Cover: Returning ETH remainder to sender failed.");
-      }
+      // send premium in eth to the pool
+      // solhint-disable-next-line avoid-low-level-calls
+      (bool ok, /* data */) = address(_pool).call{value: premiumInPaymentAsset}("");
+      require(ok, "Cover: Sending ETH to pool failed.");
 
       // send commission
       if (commission > 0) {
@@ -426,11 +425,10 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
         require(ok, "Cover: Sending ETH to commission destination failed.");
       }
 
-      // send premium in eth to the pool
-      if (premiumInPaymentAsset > 0) {
+      if (remainder > 0) {
         // solhint-disable-next-line avoid-low-level-calls
-        (bool ok, /* data */) = address(_pool).call{value: premiumInPaymentAsset}("");
-        require(ok, "Cover: Sending ETH to pool failed.");
+        (bool ok, /* data */) = address(msg.sender).call{value: remainder}("");
+        require(ok, "Cover: Returning ETH remainder to sender failed.");
       }
 
       return;

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -426,7 +426,12 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
         require(ok, "Cover: Sending ETH to commission destination failed.");
       }
 
-      // TODO: send eth to pool
+      // send premium in eth to the pool
+      if (premiumInPaymentAsset > 0) {
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool ok, /* data */) = address(_pool).call{value: premiumInPaymentAsset}("");
+        require(ok, "Cover: Sending ETH to pool failed.");
+      }
 
       return;
     }

--- a/test/unit/Cover/buyCover.js
+++ b/test/unit/Cover/buyCover.js
@@ -191,9 +191,8 @@ describe('buyCover', function () {
       },
     );
 
-    expect(await ethers.provider.getBalance(pool.address)).to.equal(
-      expectedPremium.mul(period).div(daysToSeconds(365)).sub(1), // Contract is rounding up by 1 wei
-    );
+    const expectedPremiumPerPool = expectedPremium.div(2).mul(period).div(daysToSeconds(365));
+    expect(await ethers.provider.getBalance(pool.address)).to.equal(expectedPremiumPerPool.mul(2));
 
     const coverId = (await cover.coverDataCount()).sub(1);
     await assertCoverFields(cover, coverId, {


### PR DESCRIPTION

## Context
closes #560 


## Changes proposed in this pull request
This PR addresses a bug where the ETH premium wasn't being sent to the capital pool when buying a cover with ETH as payment asset.


## Test plan

Added checks that ETH is transferred in already existing unit tests `unit/buyCover.js`


## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [x] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
