### PR TITLE
Bug: Ensure the allocated cover amount is >= the requested cover amount

### DIFF
--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -278,6 +278,8 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
       segmentId
     );
 
+    require(coverAmountInCoverAsset >= params.amount, "Cover: Insufficient cover amount allocated");
+
     _coverSegments[coverId].push(
       CoverSegment(
         coverAmountInCoverAsset.toUint96(), // cover amount in cover asset
@@ -370,7 +372,6 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
     }
 
     totalCoverAmountInCoverAsset = totalCoverAmountInNXM * nxmPriceInCoverAsset / ONE_NXM;
-    require(totalCoverAmountInCoverAsset > 0, "Cover: Amount should be greater than 0");
 
     return (totalCoverAmountInCoverAsset, totalAmountDueInNXM);
   }

--- a/test/integration/MemberRoles/switchMembershipAndAssets.js
+++ b/test/integration/MemberRoles/switchMembershipAndAssets.js
@@ -96,7 +96,7 @@ describe('switchMembershipAndAssets', function () {
           owner: member.address,
           productId,
           coverAsset: 0,
-          amount: parseEther('100'),
+          amount: parseEther('1'),
           period,
           maxPremiumInAsset: expectedPremium,
           paymentAsset: coverAsset,

--- a/test/integration/YieldTokenIncidents/submitClaim.js
+++ b/test/integration/YieldTokenIncidents/submitClaim.js
@@ -28,7 +28,7 @@ describe('submitClaim', function () {
     const { tk } = this.contracts;
 
     const members = this.accounts.members.slice(0, 5);
-    const amount = parseEther('10000');
+    const amount = parseEther('30000');
     for (const member of members) {
       await tk.connect(this.accounts.defaultSender).transfer(member.address, amount);
     }

--- a/test/integration/utils/staking.js
+++ b/test/integration/utils/staking.js
@@ -8,7 +8,7 @@ function calculateFirstTrancheId(lastBlock, period, gracePeriod) {
 
 async function stake({ stakingPool, staker, productId, period, gracePeriod }) {
   // Staking inputs
-  const stakingAmount = parseEther('6000');
+  const stakingAmount = parseEther('10000');
   const lastBlock = await ethers.provider.getBlock('latest');
   const firstTrancheId = calculateFirstTrancheId(lastBlock, period, gracePeriod);
 

--- a/test/unit/Cover/buyCover.js
+++ b/test/unit/Cover/buyCover.js
@@ -855,7 +855,7 @@ describe('buyCover', function () {
           value: expectedPremium,
         },
       ),
-    ).to.be.revertedWith('Cover: Amount should be greater than 0');
+    ).to.be.revertedWith('Cover: Insufficient cover amount allocated');
   });
 
   it('reverts if allocationRequest coverAmountInAsset is 0', async function () {
@@ -882,12 +882,12 @@ describe('buyCover', function () {
           commissionDestination: AddressZero,
           ipfsData: '',
         },
-        [{ poolId: '0', coverAmountInAsset: 0 }],
+        [{ poolId: '0', coverAmountInAsset: 1 }],
         {
           value: expectedPremium,
         },
       ),
-    ).to.be.revertedWith('Cover: Amount should be greater than 0');
+    ).to.be.revertedWith('Cover: Insufficient cover amount allocated');
   });
 
   it('retrieves ERC20 payment from caller and transfers it to the Pool', async function () {


### PR DESCRIPTION
## Context
Closes issue https://github.com/NexusMutual/smart-contracts/issues/594

## Changes proposed in this pull request
Check the total allocated cover amount is >= the requested cover amount. Use `>=` and not `==` as suggested in the audit report because the allocated cover amount is converted from asset to NXM and back to asset (using `divCeil` and `roundUp`), making the amount input to `buyCover` function act as a "min amount" in fact.

## Test plan
Updated existing tests.

## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
