### PR TITLE
Feature: Add flag to PoolAllocationRequest to skip pool during edit cover

### DIFF
--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -36,6 +36,7 @@ enum CoverUintParams {
 
 struct PoolAllocationRequest {
   uint40 poolId;
+  bool skip;
   uint coverAmountInAsset;
 }
 

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -287,6 +287,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
         // check if this request should be skipped, keeping the previous allocation
         if (poolAllocationRequests[i].skip) {
           coverSegmentAllocations[allocationRequest.coverId][segmentId].push(previousPoolAllocation);
+          totalCoverAmountInNXM += previousPoolAllocation.coverAmountInNXM;
           continue;
         }
 
@@ -295,15 +296,20 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
           previousPoolAllocation.premiumInNXM
           * (allocationRequest.previousExpiration - block.timestamp) // remaining period
           / (allocationRequest.previousExpiration - allocationRequest.previousStart); // previous period
+
+        // get stored allocation id
         allocationRequest.allocationId = previousPoolAllocation.allocationId;
       } else {
+        // request new allocation id
         allocationRequest.allocationId = type(uint).max;
       }
+
       // converting asset amount to nxm and rounding up to the nearest NXM_PER_ALLOCATION_UNIT
       uint coverAmountInNXM = Math.roundUp(
         Math.divCeil(poolAllocationRequests[i].coverAmountInAsset * ONE_NXM, nxmPriceInCoverAsset),
         NXM_PER_ALLOCATION_UNIT
       );
+
       (uint premiumInNXM, uint allocationId) = stakingPool(poolAllocationRequests[i].poolId).requestAllocation(
         coverAmountInNXM,
         vars.previousPremiumInNXM,
@@ -325,6 +331,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
       totalAmountDueInNXM += (vars.refund >= premiumInNXM ? 0 : premiumInNXM - vars.refund);
       totalCoverAmountInNXM += coverAmountInNXM;
     }
+
     totalCoverAmountInCoverAsset = totalCoverAmountInNXM * nxmPriceInCoverAsset / ONE_NXM;
 
     return (totalCoverAmountInCoverAsset, totalAmountDueInNXM);

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -67,7 +67,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
   // this constant is used for calculating the normalized yearly percentage cost of cover
   uint private constant ONE_YEAR = 365 days;
 
-  uint private constant MAX_COMMISSION_RATIO = 3000; // 30%
+  uint public constant MAX_COMMISSION_RATIO = 3000; // 30%
 
   uint public constant GLOBAL_MIN_PRICE_RATIO = 100; // 1%
 

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -271,7 +271,6 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
 
     for (uint i = 0; i < poolAllocationRequests.length; i++) {
 
-      // TODO: add a flag in PoolAllocationRequest to skip certain pools to avoid repricing
       // TODO: poolAllocationRequests might have repeated pools, is this gameable?
 
       // if there is a previous segment and this index is present on it
@@ -283,6 +282,12 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
         // poolAllocationRequests must match the pools in the previous segment
         if (previousPoolAllocation.poolId != poolAllocationRequests[i].poolId) {
           revert UnexpectedPoolId();
+        }
+
+        // check if this request should be skipped, keeping the previous allocation
+        if (poolAllocationRequests[i].skip) {
+          coverSegmentAllocations[allocationRequest.coverId][segmentId].push(previousPoolAllocation);
+          continue;
         }
 
         vars.previousPremiumInNXM = previousPoolAllocation.premiumInNXM;

--- a/test/unit/Cover/editCover.js
+++ b/test/unit/Cover/editCover.js
@@ -332,7 +332,7 @@ describe('editCover', function () {
         [{ poolId: '0', skip: true, coverAmountInAsset: increasedAmount }],
         { value: extraPremium.add(10) },
       ),
-    ).to.be.revertedWith('Cover: Expired covers cannot be edited');
+    ).to.be.revertedWithCustomError(cover, 'ExpiredCoversCannotBeEdited');
   });
 
   it('should revert when period is too long', async function () {

--- a/test/unit/Cover/editCover.js
+++ b/test/unit/Cover/editCover.js
@@ -13,7 +13,7 @@ describe('editCover', function () {
   const coverBuyFixture = {
     productId: 0,
     coverAsset: 0, // ETH
-    period: 3600 * 24 * 30, // 30 days
+    period: daysToSeconds(30), // 30 days
 
     amount: parseEther('1000'),
 
@@ -71,8 +71,7 @@ describe('editCover', function () {
       period,
       amount: increasedAmount,
       gracePeriod,
-      segmentId: '1',
-      amountPaidOut: 0,
+      segmentId: 1,
     });
   });
 
@@ -139,8 +138,7 @@ describe('editCover', function () {
       period,
       amount,
       gracePeriod,
-      segmentId: '1',
-      amountPaidOut: 0,
+      segmentId: 1,
     });
   });
 
@@ -162,7 +160,6 @@ describe('editCover', function () {
     const expectedEditPremium = expectedPremium.mul(2);
     const extraPremium = expectedEditPremium.sub(expectedRefund);
     const increasedPeriod = period * 2;
-    const amountPaidOut = 0;
 
     await cover.connect(coverBuyer).buyCover(
       {
@@ -178,7 +175,6 @@ describe('editCover', function () {
         commissionRatio: parseEther('0'),
         commissionDestination: AddressZero,
         ipfsData: '',
-        amountPaidOut,
       },
       [{ poolId: '0', skip: false, coverAmountInAsset: amount.toString() }],
       {
@@ -193,7 +189,6 @@ describe('editCover', function () {
       amount,
       gracePeriod,
       segmentId: 1,
-      amountPaidOut,
     });
   });
 
@@ -218,7 +213,6 @@ describe('editCover', function () {
     const extraPremium = expectedEditPremium.sub(expectedRefund);
     const increasedAmount = amount.mul(2);
     const increasedPeriod = period * 2;
-    const amountPaidOut = 0;
 
     await cover.connect(coverBuyer).buyCover(
       {
@@ -234,7 +228,6 @@ describe('editCover', function () {
         commissionRatio: parseEther('0'),
         commissionDestination: AddressZero,
         ipfsData: '',
-        amountPaidOut,
       },
       [{ poolId: '0', skip: false, coverAmountInAsset: increasedAmount.toString() }],
       {
@@ -249,7 +242,6 @@ describe('editCover', function () {
       amount: increasedAmount,
       gracePeriod,
       segmentId: 1,
-      amountPaidOut,
     });
   });
 
@@ -274,7 +266,6 @@ describe('editCover', function () {
     const extraPremium = expectedEditPremium.sub(expectedRefund);
     const decreasedAmount = amount.div(2);
     const increasedPeriod = period * 2;
-    const amountPaidOut = 0;
 
     await cover.connect(coverBuyer).buyCover(
       {
@@ -290,7 +281,6 @@ describe('editCover', function () {
         commissionRatio: parseEther('0'),
         commissionDestination: AddressZero,
         ipfsData: '',
-        amountPaidOut,
       },
       [{ poolId: '0', skip: false, coverAmountInAsset: decreasedAmount.toString() }],
       {
@@ -305,7 +295,6 @@ describe('editCover', function () {
       amount: decreasedAmount,
       gracePeriod,
       segmentId: '1',
-      amountPaidOut,
     });
   });
 
@@ -320,7 +309,6 @@ describe('editCover', function () {
     const increasedAmount = amount.mul(2);
     const expectedEditPremium = expectedPremium.mul(2);
     const extraPremium = expectedEditPremium;
-    const amountPaidOut = 0;
 
     const now = await ethers.provider.getBlock('latest').then(block => block.timestamp);
     await setNextBlockTime(now + period + 3600);
@@ -340,7 +328,6 @@ describe('editCover', function () {
           commissionRatio: parseEther('0'),
           commissionDestination: AddressZero,
           ipfsData: '',
-          amountPaidOut,
         },
         [{ poolId: '0', skip: true, coverAmountInAsset: increasedAmount }],
         { value: extraPremium.add(10) },
@@ -365,9 +352,8 @@ describe('editCover', function () {
     const increasedAmount = amount.mul(2);
     const expectedEditPremium = expectedPremium.mul(2);
     const extraPremium = expectedEditPremium.sub(expectedRefund);
-    const amountPaidOut = 0;
 
-    const periodTooLong = 366 * 24 * 3600; // 366 days
+    const periodTooLong = daysToSeconds(366);
 
     await expect(
       cover.connect(coverBuyer).buyCover(
@@ -384,7 +370,6 @@ describe('editCover', function () {
           commissionRatio: parseEther('0'),
           commissionDestination: AddressZero,
           ipfsData: '',
-          amountPaidOut,
         },
         [{ poolId: '0', skip: false, coverAmountInAsset: increasedAmount.toString() }],
         {
@@ -414,7 +399,6 @@ describe('editCover', function () {
     const increasedAmount = amount.mul(2);
     const expectedEditPremium = expectedPremium.mul(2);
     const extraPremium = expectedEditPremium.sub(expectedRefund);
-    const amountPaidOut = 0;
 
     await expect(
       cover.connect(coverBuyer).buyCover(
@@ -431,7 +415,6 @@ describe('editCover', function () {
           commissionRatio: MAX_COMMISSION_RATIO.add(1), // too high
           commissionDestination: AddressZero,
           ipfsData: '',
-          amountPaidOut,
         },
         [{ poolId: '0', skip: false, coverAmountInAsset: increasedAmount.toString() }],
         {

--- a/test/unit/Cover/editCover.js
+++ b/test/unit/Cover/editCover.js
@@ -95,13 +95,15 @@ describe('editCover', function () {
 
     const buyerBalanceBefore = await ethers.provider.getBalance(coverBuyer.address);
 
+    const increasedAmount = amount.mul(2);
+
     await cover.connect(coverBuyer).buyCover(
       {
         coverId: expectedCoverId,
         owner: coverBuyer.address,
         productId,
         coverAsset,
-        amount,
+        amount: increasedAmount,
         period,
         maxPremiumInAsset: expectedPremium.add(1),
         paymentAsset: coverAsset,
@@ -134,7 +136,7 @@ describe('editCover', function () {
       productId,
       coverAsset,
       period,
-      amount,
+      amount: increasedAmount,
       gracePeriod,
       segmentId: 1,
     });

--- a/test/unit/Cover/editCover.js
+++ b/test/unit/Cover/editCover.js
@@ -77,9 +77,7 @@ describe('editCover', function () {
 
   it('should edit purchased cover and add coverage from a new staking pool', async function () {
     const { cover } = this;
-
     const [coverBuyer, manager] = this.accounts.members;
-
     const { productId, coverAsset, period, amount } = coverBuyFixture;
 
     const { expectedPremium, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);

--- a/test/unit/Cover/editCover.js
+++ b/test/unit/Cover/editCover.js
@@ -9,7 +9,7 @@ const { assertCoverFields, buyCoverOnOnePool, MAX_COVER_PERIOD, createStakingPoo
 
 const gracePeriod = daysToSeconds(120);
 
-describe.skip('editCover', function () {
+describe('editCover', function () {
   const coverBuyFixture = {
     productId: 0,
     coverAsset: 0, // ETH
@@ -36,7 +36,7 @@ describe.skip('editCover', function () {
     const increasedAmount = amount.mul(2);
 
     const expectedRefund = segment.amount
-      .mul(segment.priceRatio)
+      .mul(targetPriceRatio)
       .mul(segment.period)
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
@@ -44,8 +44,7 @@ describe.skip('editCover', function () {
     const expectedEditPremium = expectedPremium.mul(2);
     const extraPremium = expectedEditPremium.sub(expectedRefund);
 
-    await cover.connect(coverBuyer).editCover(
-      expectedCoverId,
+    await cover.connect(coverBuyer).buyCover(
       {
         coverId: expectedCoverId,
         owner: coverBuyer.address,
@@ -99,7 +98,7 @@ describe.skip('editCover', function () {
 
     const buyerBalanceBefore = await ethers.provider.getBalance(coverBuyer.address);
 
-    const tx = await cover.connect(coverBuyer).buyCover(
+    await cover.connect(coverBuyer).buyCover(
       {
         coverId: expectedCoverId,
         owner: coverBuyer.address,
@@ -122,7 +121,6 @@ describe.skip('editCover', function () {
         value: expectedPremium.add(1),
       },
     );
-    await tx.wait();
 
     const buyerBalanceAfter = await ethers.provider.getBalance(coverBuyer.address);
     expect(buyerBalanceAfter).to.be.lt(buyerBalanceBefore.sub(expectedPremium));
@@ -146,7 +144,7 @@ describe.skip('editCover', function () {
     });
   });
 
-  it.skip('should edit purchased cover and increase period', async function () {
+  it('should edit purchased cover and increase period', async function () {
     const { cover } = this;
 
     const [coverBuyer] = this.accounts.members;
@@ -156,7 +154,7 @@ describe.skip('editCover', function () {
     const { expectedPremium, segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
     const expectedRefund = segment.amount
-      .mul(segment.priceRatio)
+      .mul(targetPriceRatio)
       .mul(segment.period)
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
@@ -164,10 +162,11 @@ describe.skip('editCover', function () {
     const expectedEditPremium = expectedPremium.mul(2);
     const extraPremium = expectedEditPremium.sub(expectedRefund);
     const increasedPeriod = period * 2;
+    const amountPaidOut = 0;
 
-    await cover.connect(coverBuyer).editCover(
-      expectedCoverId,
+    await cover.connect(coverBuyer).buyCover(
       {
+        coverId: expectedCoverId,
         owner: coverBuyer.address,
         productId,
         coverAsset,
@@ -179,8 +178,9 @@ describe.skip('editCover', function () {
         commissionRatio: parseEther('0'),
         commissionDestination: AddressZero,
         ipfsData: '',
+        amountPaidOut,
       },
-      [{ poolId: '0', coverAmountInAsset: amount.toString() }],
+      [{ poolId: '0', skip: false, coverAmountInAsset: amount.toString() }],
       {
         value: extraPremium.add(10),
       },
@@ -191,13 +191,13 @@ describe.skip('editCover', function () {
       coverAsset,
       period: increasedPeriod,
       amount,
-      targetPriceRatio,
       gracePeriod,
-      segmentId: '1',
+      segmentId: 1,
+      amountPaidOut,
     });
   });
 
-  it.skip('should edit purchased cover and increase period and amount', async function () {
+  it('should edit purchased cover and increase period and amount', async function () {
     const { cover } = this;
 
     const [coverBuyer] = this.accounts.members;
@@ -209,7 +209,7 @@ describe.skip('editCover', function () {
     const { expectedPremium, segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
     const expectedRefund = segment.amount
-      .mul(segment.priceRatio)
+      .mul(targetPriceRatio)
       .mul(segment.period)
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
@@ -218,10 +218,11 @@ describe.skip('editCover', function () {
     const extraPremium = expectedEditPremium.sub(expectedRefund);
     const increasedAmount = amount.mul(2);
     const increasedPeriod = period * 2;
+    const amountPaidOut = 0;
 
-    await cover.connect(coverBuyer).editCover(
-      expectedCoverId,
+    await cover.connect(coverBuyer).buyCover(
       {
+        coverId: expectedCoverId,
         owner: coverBuyer.address,
         productId,
         coverAsset,
@@ -233,8 +234,9 @@ describe.skip('editCover', function () {
         commissionRatio: parseEther('0'),
         commissionDestination: AddressZero,
         ipfsData: '',
+        amountPaidOut,
       },
-      [{ poolId: '0', coverAmountInAsset: increasedAmount.toString() }],
+      [{ poolId: '0', skip: false, coverAmountInAsset: increasedAmount.toString() }],
       {
         value: extraPremium.add(10),
       },
@@ -245,13 +247,13 @@ describe.skip('editCover', function () {
       coverAsset,
       period: increasedPeriod,
       amount: increasedAmount,
-      targetPriceRatio,
       gracePeriod,
-      segmentId: '1',
+      segmentId: 1,
+      amountPaidOut,
     });
   });
 
-  it.skip('should edit purchased cover and increase period and decrease amount', async function () {
+  it('should edit purchased cover and increase period and decrease amount', async function () {
     const { cover } = this;
 
     const [coverBuyer] = this.accounts.members;
@@ -263,7 +265,7 @@ describe.skip('editCover', function () {
     const { expectedPremium, segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
     const expectedRefund = segment.amount
-      .mul(segment.priceRatio)
+      .mul(targetPriceRatio)
       .mul(segment.period)
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
@@ -272,10 +274,11 @@ describe.skip('editCover', function () {
     const extraPremium = expectedEditPremium.sub(expectedRefund);
     const decreasedAmount = amount.div(2);
     const increasedPeriod = period * 2;
+    const amountPaidOut = 0;
 
-    await cover.connect(coverBuyer).editCover(
-      expectedCoverId,
+    await cover.connect(coverBuyer).buyCover(
       {
+        coverId: expectedCoverId,
         owner: coverBuyer.address,
         productId,
         coverAsset,
@@ -287,8 +290,9 @@ describe.skip('editCover', function () {
         commissionRatio: parseEther('0'),
         commissionDestination: AddressZero,
         ipfsData: '',
+        amountPaidOut,
       },
-      [{ poolId: '0', coverAmountInAsset: decreasedAmount.toString() }],
+      [{ poolId: '0', skip: false, coverAmountInAsset: decreasedAmount.toString() }],
       {
         value: extraPremium,
       },
@@ -299,81 +303,76 @@ describe.skip('editCover', function () {
       coverAsset,
       period: increasedPeriod,
       amount: decreasedAmount,
-      targetPriceRatio,
       gracePeriod,
       segmentId: '1',
+      amountPaidOut,
     });
   });
 
-  it.skip('should allow editing a cover that is expired offering 0 refund', async function () {
+  it('should fail to edit an expired cover', async function () {
     const { cover } = this;
 
     const [coverBuyer] = this.accounts.members;
 
-    const { productId, coverAsset, period, amount, targetPriceRatio } = coverBuyFixture;
+    const { productId, coverAsset, period, amount } = coverBuyFixture;
     const { expectedPremium, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
     const increasedAmount = amount.mul(2);
     const expectedEditPremium = expectedPremium.mul(2);
     const extraPremium = expectedEditPremium;
+    const amountPaidOut = 0;
 
     const now = await ethers.provider.getBlock('latest').then(block => block.timestamp);
     await setNextBlockTime(now + period + 3600);
 
-    await cover.connect(coverBuyer).editCover(
-      expectedCoverId,
-      {
-        owner: coverBuyer.address,
-        productId,
-        coverAsset,
-        amount: increasedAmount,
-        period,
-        maxPremiumInAsset: expectedEditPremium.add(10),
-        paymentAsset: coverAsset,
-        payWitNXM: false,
-        commissionRatio: parseEther('0'),
-        commissionDestination: AddressZero,
-        ipfsData: '',
-      },
-      [{ poolId: '0', coverAmountInAsset: increasedAmount }],
-      { value: extraPremium.add(10) },
-    );
-
-    await assertCoverFields(cover, expectedCoverId, {
-      productId,
-      coverAsset,
-      period,
-      amount: increasedAmount,
-      targetPriceRatio,
-      gracePeriod,
-      segmentId: '1',
-    });
+    await expect(
+      cover.connect(coverBuyer).buyCover(
+        {
+          coverId: expectedCoverId,
+          owner: coverBuyer.address,
+          productId,
+          coverAsset,
+          amount: increasedAmount,
+          period,
+          maxPremiumInAsset: expectedEditPremium.add(10),
+          paymentAsset: coverAsset,
+          payWitNXM: false,
+          commissionRatio: parseEther('0'),
+          commissionDestination: AddressZero,
+          ipfsData: '',
+          amountPaidOut,
+        },
+        [{ poolId: '0', skip: true, coverAmountInAsset: increasedAmount }],
+        { value: extraPremium.add(10) },
+      ),
+    ).to.be.revertedWith('Cover: Expired covers cannot be edited');
   });
 
-  it.skip('should revert when period is too long', async function () {
+  it('should revert when period is too long', async function () {
     const { cover } = this;
 
     const [coverBuyer] = this.accounts.members;
 
-    const { productId, coverAsset, amount, priceDenominator } = coverBuyFixture;
+    const { productId, coverAsset, amount, priceDenominator, targetPriceRatio } = coverBuyFixture;
 
     const { expectedPremium, segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
     const expectedRefund = segment.amount
-      .mul(segment.priceRatio)
+      .mul(targetPriceRatio)
       .mul(segment.period)
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
     const increasedAmount = amount.mul(2);
     const expectedEditPremium = expectedPremium.mul(2);
     const extraPremium = expectedEditPremium.sub(expectedRefund);
+    const amountPaidOut = 0;
 
     const periodTooLong = 366 * 24 * 3600; // 366 days
 
     await expect(
-      cover.connect(coverBuyer).editCover(
-        expectedCoverId,
+      cover.connect(coverBuyer).buyCover(
         {
+          coverId: expectedCoverId,
           owner: coverBuyer.address,
           productId,
           coverAsset,
@@ -385,8 +384,9 @@ describe.skip('editCover', function () {
           commissionRatio: parseEther('0'),
           commissionDestination: AddressZero,
           ipfsData: '',
+          amountPaidOut,
         },
-        [{ poolId: '0', coverAmountInAsset: increasedAmount.toString() }],
+        [{ poolId: '0', skip: false, coverAmountInAsset: increasedAmount.toString() }],
         {
           value: extraPremium,
         },
@@ -394,30 +394,32 @@ describe.skip('editCover', function () {
     ).to.be.revertedWithCustomError(cover, 'CoverPeriodTooLong');
   });
 
-  it.skip('should revert when commission rate too high', async function () {
+  it('should revert when commission rate too high', async function () {
     const { cover } = this;
+    const { MAX_COMMISSION_RATIO } = this.config;
 
     const [coverBuyer] = this.accounts.members;
 
-    const { productId, coverAsset, amount, period, priceDenominator } = coverBuyFixture;
+    const { productId, coverAsset, amount, period, priceDenominator, targetPriceRatio } = coverBuyFixture;
 
     await buyCoverOnOnePool.call(this, coverBuyFixture);
 
     const { expectedPremium, segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
     const expectedRefund = segment.amount
-      .mul(segment.priceRatio)
+      .mul(targetPriceRatio)
       .mul(segment.period)
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
     const increasedAmount = amount.mul(2);
     const expectedEditPremium = expectedPremium.mul(2);
     const extraPremium = expectedEditPremium.sub(expectedRefund);
+    const amountPaidOut = 0;
 
     await expect(
-      cover.connect(coverBuyer).editCover(
-        expectedCoverId,
+      cover.connect(coverBuyer).buyCover(
         {
+          coverId: expectedCoverId,
           owner: coverBuyer.address,
           productId,
           coverAsset,
@@ -426,11 +428,12 @@ describe.skip('editCover', function () {
           maxPremiumInAsset: expectedEditPremium,
           paymentAsset: coverAsset,
           payWitNXM: false,
-          commissionRatio: '2600', // too high
+          commissionRatio: MAX_COMMISSION_RATIO.add(1), // too high
           commissionDestination: AddressZero,
           ipfsData: '',
+          amountPaidOut,
         },
-        [{ poolId: '0', coverAmountInAsset: increasedAmount.toString() }],
+        [{ poolId: '0', skip: false, coverAmountInAsset: increasedAmount.toString() }],
         {
           value: extraPremium,
         },
@@ -438,7 +441,7 @@ describe.skip('editCover', function () {
     ).to.be.revertedWithCustomError(cover, 'CommissionRateTooHigh');
   });
 
-  it.skip('should store new grace period when editing cover', async function () {
+  it('should store new grace period when editing cover', async function () {
     const { cover } = this;
     const [boardMember] = this.accounts.advisoryBoardMembers;
     const [coverBuyer] = this.accounts.members;
@@ -450,18 +453,18 @@ describe.skip('editCover', function () {
 
     // Edit product gracePeriod
     const productTypeBefore = await cover.productTypes(productId);
-    const newGracePeriod = 1000 * 24 * 3600; // 1000 days
+    const newGracePeriod = daysToSeconds(1000);
 
     await cover.connect(boardMember).setProductTypes([[productId, 'ipfs hash', [1, newGracePeriod]]]);
     const productType = await cover.productTypes(productId);
     expect(newGracePeriod).to.be.equal(productType.gracePeriod);
 
     const now = await ethers.provider.getBlock('latest').then(block => block.timestamp);
-    await setNextBlockTime(now + period + 3600);
+    await setNextBlockTime(now + daysToSeconds(1));
 
-    await cover.connect(coverBuyer).editCover(
-      expectedCoverId,
+    await cover.connect(coverBuyer).buyCover(
       {
+        coverId: expectedCoverId,
         owner: coverBuyer.address,
         productId,
         coverAsset,

--- a/test/unit/Cover/setup.js
+++ b/test/unit/Cover/setup.js
@@ -204,6 +204,7 @@ async function setup() {
   ]);
 
   const GLOBAL_MIN_PRICE_RATIO = await cover.GLOBAL_MIN_PRICE_RATIO();
+  const MAX_COMMISSION_RATIO = await cover.MAX_COMMISSION_RATIO();
 
   this.master = master;
   this.pool = pool;
@@ -219,7 +220,7 @@ async function setup() {
   this.capacityFactor = capacityFactor;
   this.stakingPoolImplementation = stakingPoolImplementation;
   this.stakingPoolFactory = stakingPoolFactory;
-  this.config = { GLOBAL_MIN_PRICE_RATIO };
+  this.config = { GLOBAL_MIN_PRICE_RATIO, MAX_COMMISSION_RATIO };
 }
 
 module.exports = setup;


### PR DESCRIPTION
## Context

Closes #559 


## Changes proposed in this pull request
This PR adds a flag to the struct `PoolAllocationRequest` to be able to add a staking pool to the cover allocations. The flag signals that repricing/deallocating should be skipped, and the previous allocation on the staking pool should be carried over.


## Test plan
The unit tests at `test/unit/Cover/editCover.js` are updated and re-enabled.


## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [x] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
