### PR TITLE
Fix: Add the current globalCapacityFactor to store

### DIFF
--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -93,6 +93,7 @@ struct CoverSegment {
   uint32 period; // seconds
   uint32 gracePeriod; // seconds
   uint24 globalRewardsRatio;
+  uint24 globalCapacityRatio;
 }
 
 struct ProductBucket {

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -202,7 +202,8 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
         (block.timestamp + 1).toUint32(), // start
         params.period, // period
         allocationRequest.gracePeriod.toUint32(),
-        globalRewardsRatio
+        globalRewardsRatio,
+        globalCapacityRatio
       )
     );
 
@@ -390,7 +391,8 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
         start.toUint32(),
         period.toUint32(),
         productType.gracePeriod,
-        0 // global rewards ratio
+        0, // global rewards ratio
+        globalCapacityRatio
       )
     );
 
@@ -487,7 +489,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
         * burnAmount
         * GLOBAL_CAPACITY_DENOMINATOR
         / segment.amount
-        / globalCapacityRatio;
+        / segment.globalCapacityRatio;
 
       stakingPool(i).burnStake(burnAmountInNXM);
 

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -392,7 +392,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
         period.toUint32(),
         productType.gracePeriod,
         0, // global rewards ratio
-        globalCapacityRatio
+        1
       )
     );
 

--- a/test/unit/Cover/burnStake.js
+++ b/test/unit/Cover/burnStake.js
@@ -6,6 +6,7 @@ const { MaxUint256 } = ethers.constants;
 const { parseEther } = ethers.utils;
 
 const gracePeriod = 120 * 24 * 3600; // 120 days
+const GLOBAL_CAPACITY_DENOMINATOR = 10000;
 
 describe('burnStake', function () {
   const coverBuyFixture = {
@@ -27,14 +28,16 @@ describe('burnStake', function () {
     const { productId, coverAsset, period, amount, targetPriceRatio } = coverBuyFixture;
     const { segmentId, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
-    const burnAmountDivisor = 2;
-    const burnAmount = amount.div(burnAmountDivisor);
-    const remainingAmount = amount.sub(burnAmount);
+    const payoutAmountInAsset = amount.div(2);
+    const remainingAmount = amount.sub(payoutAmountInAsset);
 
+    const segment = await cover.coverSegments(expectedCoverId, segmentId);
     const segmentAllocation = await cover.coverSegmentAllocations(expectedCoverId, segmentId, '0');
-    const expectedBurnAmount = segmentAllocation.coverAmountInNXM.div(burnAmountDivisor);
 
-    await cover.connect(internal).burnStake(expectedCoverId, segmentId, burnAmount);
+    const payoutAmountInNXM = segmentAllocation.coverAmountInNXM.mul(payoutAmountInAsset).div(segment.amount);
+    const expectedBurnAmount = payoutAmountInNXM.mul(GLOBAL_CAPACITY_DENOMINATOR).div(segment.globalCapacityRatio);
+
+    await cover.connect(internal).burnStake(expectedCoverId, segmentId, payoutAmountInAsset);
     await assertCoverFields(cover, expectedCoverId, {
       productId,
       coverAsset,
@@ -43,7 +46,7 @@ describe('burnStake', function () {
       targetPriceRatio,
       gracePeriod,
       segmentId,
-      amountPaidOut: burnAmount,
+      amountPaidOut: payoutAmountInAsset,
     });
 
     const stakingPool = await ethers.getContractAt('CoverMockStakingPool', await cover.stakingPool(0));
@@ -90,13 +93,13 @@ describe('burnStake', function () {
     const burnAmountDivisor = 2;
     const burnAmount = amount.div(burnAmountDivisor);
     const segmentAllocationBefore = await cover.coverSegmentAllocations(expectedCoverId, segmentId, 0);
-    const expectedBurnAmount = segmentAllocationBefore.coverAmountInNXM.div(burnAmountDivisor);
+    const payoutAmountInNXM = segmentAllocationBefore.coverAmountInNXM.div(burnAmountDivisor);
 
     await cover.connect(internal).burnStake(expectedCoverId, segmentId, burnAmount);
 
     const segmentAllocationAfter = await cover.coverSegmentAllocations(expectedCoverId, segmentId, 0);
     expect(segmentAllocationAfter.coverAmountInNXM).to.be.equal(
-      segmentAllocationBefore.coverAmountInNXM.sub(expectedBurnAmount),
+      segmentAllocationBefore.coverAmountInNXM.sub(payoutAmountInNXM),
     );
   });
 
@@ -130,17 +133,22 @@ describe('burnStake', function () {
     });
 
     const burnAmountDivisor = 2;
-    const burnAmount = amount.div(burnAmountDivisor);
-    const remainingAmount = amount.sub(burnAmount);
+    const payoutAmountInAsset = amount.div(burnAmountDivisor);
+    const remainingAmount = amount.sub(payoutAmountInAsset);
     const segmentAllocationsBefore = [];
+    const expectedBurnAmount = [];
+
+    const segment = await cover.coverSegments(expectedCoverId, segmentId);
 
     for (let i = 0; i < amountOfPools; i++) {
       const segmentAllocationBefore = await cover.coverSegmentAllocations(expectedCoverId, segmentId, i);
       segmentAllocationsBefore.push(segmentAllocationBefore);
+
+      const payoutAmountInNXM = segmentAllocationBefore.coverAmountInNXM.mul(payoutAmountInAsset).div(segment.amount);
+      expectedBurnAmount.push(payoutAmountInNXM.mul(GLOBAL_CAPACITY_DENOMINATOR).div(segment.globalCapacityRatio));
     }
 
-    const expectedBurnAmountPerPool = segmentAllocationsBefore[0].coverAmountInNXM.div(burnAmountDivisor);
-    await cover.connect(internal).burnStake(expectedCoverId, segmentId, burnAmount);
+    await cover.connect(internal).burnStake(expectedCoverId, segmentId, payoutAmountInAsset);
     await assertCoverFields(cover, expectedCoverId, {
       productId,
       coverAsset,
@@ -149,25 +157,26 @@ describe('burnStake', function () {
       targetPriceRatio,
       gracePeriod,
       segmentId,
-      amountPaidOut: burnAmount,
+      amountPaidOut: payoutAmountInAsset,
     });
 
     for (let i = 0; i < amountOfPools; i++) {
       const stakingPool = await ethers.getContractAt('CoverMockStakingPool', await cover.stakingPool(i));
 
       const burnStakeCalledWith = await stakingPool.burnStakeCalledWith();
-      expect(burnStakeCalledWith).to.be.equal(expectedBurnAmountPerPool);
+      expect(burnStakeCalledWith).to.be.equal(expectedBurnAmount[i]);
 
       const segmentAllocationAfter = await cover.coverSegmentAllocations(expectedCoverId, segmentId, i);
+      const payoutAmountInNXM = segmentAllocationsBefore[i].coverAmountInNXM.div(burnAmountDivisor);
 
       expect(segmentAllocationAfter.coverAmountInNXM).to.be.equal(
-        segmentAllocationsBefore[i].coverAmountInNXM.sub(expectedBurnAmountPerPool),
+        segmentAllocationsBefore[i].coverAmountInNXM.sub(payoutAmountInNXM),
       );
     }
   });
 
   it('should perform a burn with globalCapacityRatio when the cover was bought', async function () {
-    const GLOBAL_CAPACITY_RATIO = 3;
+    const GLOBAL_CAPACITY_RATIO = 30000;
     const { cover, accounts } = this;
     const [internal] = this.accounts.internalContracts;
     const { productId, coverAsset, period, amount, targetPriceRatio } = coverBuyFixture;
@@ -175,14 +184,16 @@ describe('burnStake', function () {
 
     await cover.connect(accounts.governanceContracts[0]).updateUintParameters([0], [GLOBAL_CAPACITY_RATIO]);
 
-    const burnAmountDivisor = 2;
-    const burnAmount = amount.div(burnAmountDivisor);
-    const remainingAmount = amount.sub(burnAmount);
+    const payoutAmountInAsset = amount.div(2);
+    const remainingAmount = amount.sub(payoutAmountInAsset);
 
+    const segment = await cover.coverSegments(expectedCoverId, segmentId);
     const segmentAllocation = await cover.coverSegmentAllocations(expectedCoverId, segmentId, '0');
-    const expectedBurnAmount = segmentAllocation.coverAmountInNXM.div(burnAmountDivisor);
 
-    await cover.connect(internal).burnStake(expectedCoverId, segmentId, burnAmount);
+    const payoutAmountInNXM = segmentAllocation.coverAmountInNXM.mul(payoutAmountInAsset).div(segment.amount);
+    const expectedBurnAmount = payoutAmountInNXM.mul(GLOBAL_CAPACITY_DENOMINATOR).div(segment.globalCapacityRatio);
+
+    await cover.connect(internal).burnStake(expectedCoverId, segmentId, payoutAmountInAsset);
     await assertCoverFields(cover, expectedCoverId, {
       productId,
       coverAsset,
@@ -191,7 +202,7 @@ describe('burnStake', function () {
       targetPriceRatio,
       gracePeriod,
       segmentId,
-      amountPaidOut: burnAmount,
+      amountPaidOut: payoutAmountInAsset,
     });
 
     const stakingPool = await ethers.getContractAt('CoverMockStakingPool', await cover.stakingPool(0));

--- a/test/unit/Cover/setup.js
+++ b/test/unit/Cover/setup.js
@@ -153,7 +153,7 @@ async function setup() {
 
   await master.setEmergencyAdmin(accounts.emergencyAdmin.address);
 
-  const capacityFactor = '10000';
+  const capacityFactor = '20000';
   const coverAssetsFallback = 0b111; // ETH, DAI and USDC
 
   await cover

--- a/test/unit/CoverViewer/views.js
+++ b/test/unit/CoverViewer/views.js
@@ -11,6 +11,7 @@ describe('views', function () {
       period: 30 * 24 * 3600, // 30 days
       gracePeriod: 7 * 24 * 3600, // 7 days
       globalRewardsRatio: 5000,
+      globalCapacityRatio: 2000,
     };
     const coverId = 0;
 

--- a/test/unit/IndividualClaims/getClaimsCount.js
+++ b/test/unit/IndividualClaims/getClaimsCount.js
@@ -22,7 +22,18 @@ describe('getClaimsCount', function () {
       coverOwner.address,
       0, // productId
       ASSET.ETH,
-      [[parseEther('100'), timestamp + 1, daysToSeconds(365), 30, 0, false, 0]],
+      [
+        {
+          amount: parseEther('100'),
+          start: timestamp + 1,
+          period: daysToSeconds(365),
+          gracePeriod: 30,
+          priceRatio: 0,
+          expired: false,
+          globalRewardsRatio: 0,
+          globalCapacityRatio: 20000,
+        },
+      ],
     );
 
     {

--- a/test/unit/IndividualClaims/helpers.js
+++ b/test/unit/IndividualClaims/helpers.js
@@ -45,6 +45,7 @@ const coverSegmentFixture = {
   priceRatio: 0,
   expired: false,
   globalRewardsRatio: 0,
+  globalCapacityRatio: 20000,
 };
 
 const getCoverSegment = async () => {

--- a/test/unit/IndividualClaims/redeemClaimPayout.js
+++ b/test/unit/IndividualClaims/redeemClaimPayout.js
@@ -267,7 +267,18 @@ describe('redeemClaimPayout', function () {
         originalOwner.address,
         0, // productId
         ASSET.ETH,
-        [[segment.amount, timestamp + 1, segment.period, 7, 0, false, 0]],
+        [
+          {
+            amount: segment.amount,
+            start: timestamp + 1,
+            period: segment.period,
+            gracePeriod: 7,
+            priceRatio: 0,
+            expired: false,
+            globalRewardsRatio: 0,
+            globalCapacityRatio: 20000,
+          },
+        ],
       );
 
       const coverId = 1;

--- a/test/unit/YieldTokenIncidents/redeemPayout.js
+++ b/test/unit/YieldTokenIncidents/redeemPayout.js
@@ -15,6 +15,7 @@ const coverSegmentFixture = {
   priceRatio: 0,
   expired: false,
   globalRewardsRatio: 0,
+  globalCapacityRatio: 2000,
 };
 
 describe('redeemPayout', function () {
@@ -289,7 +290,16 @@ describe('redeemPayout', function () {
     {
       const { timestamp } = await ethers.provider.getBlock('latest');
       await cover.createMockCover(member1.address, productIdYbEth, ASSET.ETH, [
-        [parseEther('100'), timestamp + 1, daysToSeconds('30'), 7, 0, false, 0],
+        {
+          amount: parseEther('100'),
+          start: timestamp + 1,
+          period: daysToSeconds('30'),
+          gracePeriod: 7,
+          priceRatio: 0,
+          expired: false,
+          globalRewardsRatio: 0,
+          globalCapacityRatio: 20000,
+        },
       ]);
     }
 


### PR DESCRIPTION
## Context

closing #566 


## Changes proposed in this pull request

Adding `globalCapacityFactor` to segments of the Cover to be used when burning stake.

## Test plan

Test expanded with test with change of globalCapacityFactor before burn stake


## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [ ] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
