### PR TITLE
Fix: re-add legacy claim contracts to deploy script

### DIFF
--- a/contracts/mocks/Testnet/TestnetClaimProofs.sol
+++ b/contracts/mocks/Testnet/TestnetClaimProofs.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity ^0.8.16;
+
+import "../../modules/legacy/LegacyClaimProofs.sol";
+
+contract TestnetClaimProofs is LegacyClaimProofs {
+
+  function addMockProof(uint _coverId, address member, string calldata _ipfsHash) external {
+    emit ProofAdded(_coverId, member, _ipfsHash);
+  }
+
+}

--- a/contracts/mocks/Testnet/TestnetClaimsData.sol
+++ b/contracts/mocks/Testnet/TestnetClaimsData.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity ^0.5.0;
+
+import "../../modules/legacy/LegacyClaimsData.sol";
+
+contract TestnetClaimsData is LegacyClaimsData {
+
+  function addMockClaim(
+    uint claimId,
+    uint coverId,
+    address coverOwner,
+    uint timestamp
+  ) external {
+    allClaims.push(Claim(coverId, timestamp));
+    allClaimsByAddress[coverOwner].push(claimId);
+  }
+
+}

--- a/scripts/deploy/deploy.js
+++ b/scripts/deploy/deploy.js
@@ -218,6 +218,10 @@ async function main() {
   const assessment = await deployProxy('DisposableAssessment', []);
   const coverMigrator = await deployProxy('CoverMigrator', [qd.address, productsV1.address]);
 
+  console.log('Deploying legacy claims data and claim proofs contract');
+  await deployImmutable('TestnetClaimProofs');
+  await deployImmutable('TestnetClaimsData');
+
   console.log('Deploying SwapOperator');
   const cowVaultRelayer = await deployImmutable('SOMockVaultRelayer');
   const cowSettlement = await deployImmutable('SOMockSettlement', [cowVaultRelayer.address]);


### PR DESCRIPTION
## Context

ClaimsData and ClaimProofs were removed from the deploy script but they're by frontend for displaying legacy claims.

## Changes proposed in this pull request

Created mocks for adding new claims and new proofs.

## Test plan

If it breaks - scream.

## Checklist

- [x] Rebased the base branch
- [ ] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
