### PR TITLE
Feature: Block deposits and allocations when 100% of stake is burned

### DIFF
--- a/contracts/interfaces/IStakingPool.sol
+++ b/contracts/interfaces/IStakingPool.sol
@@ -142,6 +142,7 @@ interface IStakingPool {
   error OnlyManager();
   error PrivatePool();
   error SystemPaused();
+  error PoolHalted();
 
   // Fees
   error PoolFeeExceedsMax();

--- a/contracts/mocks/TokenControllerMock.sol
+++ b/contracts/mocks/TokenControllerMock.sol
@@ -85,7 +85,7 @@ contract TokenControllerMock is MasterAwareV2 {
 
   function burnStakedNXM(uint amount, uint poolId) external {
     stakingPoolNXMBalances[poolId].deposits -= uint128(amount);
-    token().burnFrom(address(this), amount);
+    token().burn(amount);
   }
 
   function setContractAddresses(address payable coverAddr, address payable tokenAddr) public {

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -1235,7 +1235,7 @@ contract StakingPool is IStakingPool, Multicall {
     // sstore
     activeStake = (_activeStake - amount).toUint96();
 
-    emit StakeBurned(burnAmount);
+    emit StakeBurned(amount);
   }
 
   /* views */

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -453,7 +453,7 @@ contract StakingPool is IStakingPool, Multicall {
       }
 
       deposit.stakeShares += newStakeShares.toUint128();
-      deposit.rewardsShares += newRewardsShares.toUint96();
+      deposit.rewardsShares += newRewardsShares.toUint128();
       deposit.lastAccNxmPerRewardShare = _accNxmPerRewardsShare.toUint96();
 
       // store
@@ -473,7 +473,7 @@ contract StakingPool is IStakingPool, Multicall {
         uint newRewardPerShare = _accNxmPerRewardsShare.uncheckedSub(feeDeposit.lastAccNxmPerRewardShare);
         feeDeposit.pendingRewards += (newRewardPerShare * feeDeposit.rewardsShares / ONE_NXM).toUint96();
         feeDeposit.lastAccNxmPerRewardShare = _accNxmPerRewardsShare.toUint96();
-        feeDeposit.rewardsShares += newFeeRewardShares.toUint96();
+        feeDeposit.rewardsShares += newFeeRewardShares.toUint128();
       }
 
       deposits[MAX_UINT][trancheId] = feeDeposit;
@@ -1486,7 +1486,7 @@ contract StakingPool is IStakingPool, Multicall {
       feeDeposit.pendingRewards += (newRewardPerRewardsShare * feeDeposit.rewardsShares / ONE_NXM).toUint96();
       feeDeposit.lastAccNxmPerRewardShare = _accNxmPerRewardsShare.toUint96();
       // TODO: would using tranche.rewardsShares give a better precision?
-      feeDeposit.rewardsShares = (uint(feeDeposit.rewardsShares) * newFee / oldFee).toUint96();
+      feeDeposit.rewardsShares = (uint(feeDeposit.rewardsShares) * newFee / oldFee).toUint128();
 
       // sstore
       deposits[MAX_UINT][trancheId] = feeDeposit;

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -63,7 +63,7 @@ contract StakingPool is IStakingPool, Multicall {
   uint8 public poolFee;
   uint8 public maxPoolFee;
 
-  // 40 bytes left in slot 3
+  // 32 bytes left in slot 3
 
   // slot 4
   address public manager;

--- a/test/unit/StakingPool/burnStake.js
+++ b/test/unit/StakingPool/burnStake.js
@@ -1,0 +1,127 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+const { getTranches, setTime } = require('./helpers');
+const { AddressZero, MaxUint256 } = ethers.constants;
+const { parseEther } = ethers.utils;
+const { daysToSeconds } = require('../../../lib/helpers');
+const { setEtherBalance } = require('../utils').evm;
+
+const initialProduct = {
+  productId: 0,
+  weight: 75,
+  initialPrice: 255,
+  targetPrice: 386,
+};
+
+const poolInitParams = {
+  poolId: 0,
+  initialPoolFee: 5, // 5%
+  maxPoolFee: 5, // 5%
+  products: [initialProduct],
+  ipfsDescriptionHash: 'Description Hash',
+};
+
+const productTypeFixture = {
+  claimMethod: 1,
+  gracePeriod: daysToSeconds(7), // 7 days
+};
+
+const coverProductTemplate = {
+  productType: 1,
+  yieldTokenAddress: AddressZero,
+  coverAssets: 1111,
+  initialPriceRatio: 500,
+  capacityReductionRatio: 0,
+  isDeprecated: false,
+  useFixedPrice: false,
+};
+
+const DEFAULT_PERIOD = daysToSeconds(30);
+const DEFAULT_GRACE_PERIOD = daysToSeconds(30);
+const stakedNxmAmount = parseEther('1235');
+
+describe('burnStake', function () {
+  beforeEach(async function () {
+    const { stakingPool, cover, nxm, tokenController } = this;
+    const { defaultSender: manager } = this.accounts;
+    const { TRANCHE_DURATION } = this.config;
+    const { poolId, initialPoolFee, maxPoolFee, products, ipfsDescriptionHash } = poolInitParams;
+
+    this.coverSigner = await ethers.getImpersonatedSigner(cover.address);
+    await setEtherBalance(this.coverSigner.address, parseEther('1'));
+
+    await cover.setProductType(productTypeFixture, initialProduct.productId);
+    await cover.setProduct(coverProductTemplate, initialProduct.productId);
+
+    await stakingPool.connect(this.coverSigner).initialize(
+      manager.address,
+      false, // isPrivatePool
+      initialPoolFee,
+      maxPoolFee,
+      products,
+      poolId,
+      ipfsDescriptionHash,
+    );
+
+    await nxm.mint(manager.address, MaxUint256.div(1e6));
+    await nxm.connect(manager).approve(tokenController.address, MaxUint256);
+
+    // Deposit into pool
+    const { firstActiveTrancheId } = await getTranches(DEFAULT_PERIOD, DEFAULT_GRACE_PERIOD);
+    await stakingPool.connect(manager).depositTo(stakedNxmAmount, firstActiveTrancheId + 1, MaxUint256, AddressZero);
+
+    // Move to the beginning of the next tranche
+    const { firstActiveTrancheId: trancheId } = await getTranches();
+    await setTime(TRANCHE_DURATION.mul(trancheId + 1).toNumber());
+  });
+
+  it('should revert if the caller is not the cover contract', async function () {
+    const { stakingPool } = this;
+    await expect(stakingPool.burnStake(10)).to.be.revertedWithCustomError(stakingPool, 'OnlyCoverContract');
+  });
+
+  it('should block the pool if 100% of the stake is burned', async function () {
+    const { stakingPool } = this;
+    const {
+      members: [member],
+    } = this.accounts;
+
+    // burn all of the active stake
+    const activeStake = await stakingPool.activeStake();
+    await stakingPool.connect(this.coverSigner).burnStake(activeStake);
+    const { firstActiveTrancheId } = await getTranches(DEFAULT_PERIOD, DEFAULT_GRACE_PERIOD);
+
+    // depositTo and extendDeposit should revert
+    await expect(
+      stakingPool.connect(member).depositTo(stakedNxmAmount, firstActiveTrancheId, MaxUint256, AddressZero),
+    ).to.be.revertedWithCustomError(stakingPool, 'PoolHalted');
+    await expect(stakingPool.connect(member).extendDeposit(0, 0, 0, 0)).to.be.revertedWithCustomError(
+      stakingPool,
+      'PoolHalted',
+    );
+  });
+
+  it('should not block pool if 99% of the stake is burned', async function () {
+    const { stakingPool } = this;
+    const {
+      members: [member],
+    } = this.accounts;
+
+    // burn activeStake - 1
+    const activeStake = await stakingPool.activeStake();
+    await stakingPool.connect(this.coverSigner).burnStake(activeStake.sub(1));
+
+    // deposit should work
+    const { firstActiveTrancheId } = await getTranches(DEFAULT_PERIOD, DEFAULT_GRACE_PERIOD);
+    await expect(stakingPool.connect(member).depositTo(stakedNxmAmount, firstActiveTrancheId, MaxUint256, AddressZero))
+      .to.not.be.reverted;
+
+    // Burn all activeStake
+    await stakingPool.connect(this.coverSigner).burnStake(stakedNxmAmount.add(1));
+
+    // deposit should fail
+    await expect(
+      stakingPool.connect(member).depositTo(stakedNxmAmount, firstActiveTrancheId, MaxUint256, AddressZero),
+    ).to.be.revertedWithCustomError(stakingPool, 'PoolHalted');
+  });
+});

--- a/test/unit/StakingPool/index.js
+++ b/test/unit/StakingPool/index.js
@@ -12,6 +12,7 @@ describe('StakingPool unit tests', function () {
     await revertToSnapshot(this.snapshotId);
   });
 
+  require('./burnStake');
   require('./calculateNewRewardShares');
   require('./calculatePremium');
   require('./constructor');

--- a/test/unit/StakingPool/setup.js
+++ b/test/unit/StakingPool/setup.js
@@ -99,6 +99,7 @@ async function setup() {
     TARGET_PRICE_DENOMINATOR: await stakingPool.TARGET_PRICE_DENOMINATOR(),
     POOL_FEE_DENOMINATOR: await stakingPool.POOL_FEE_DENOMINATOR(),
     GLOBAL_CAPACITY_DENOMINATOR: await stakingPool.GLOBAL_CAPACITY_DENOMINATOR(),
+    TRANCHE_DURATION: await stakingPool.TRANCHE_DURATION(),
     GLOBAL_CAPACITY_RATIO: await cover.globalCapacityRatio(),
     GLOBAL_REWARDS_RATIO: await cover.globalRewardsRatio(),
     GLOBAL_MIN_PRICE_RATIO: await cover.GLOBAL_MIN_PRICE_RATIO(),


### PR DESCRIPTION
## Context
Closes #562 


## Changes proposed in this pull request

This PR adds a modifier to the staking pool, to block all deposits and cover buys on a staking pool if 100% of the active stake has been burned.
This is done to avoid division-by-zero issues.


## Test plan

A unit test was added at `StakingPool/burnStake.js`


## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [x] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
