### PR TITLE
Feature: Use custom errors instead of revert strings in Cover and StakingPool

### DIFF
--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -127,9 +127,9 @@ struct PoolInitializationParams {
   uint globalMinPriceRatio;
 }
 
-error AlreadyInitialized();
 // Auth
 error OnlyMemberRolesCanOperateTransfer();
+error OnlyOwnerOrApproved();
 
 // Cover details
 error CoverPeriodTooShort();
@@ -143,7 +143,7 @@ error ProductDeprecated();
 error ProductDeprecatedOrNotInitialized();
 error InvalidProductType();
 error UnexpectedProductId();
-// Cover assets
+// Cover and payment assets
 error PayoutAssetNotSupported();
 error PaymentAssetDeprecated();
 error UnexpectedCoverAsset();
@@ -154,13 +154,13 @@ error TargetPriceBelowGlobalMinPriceRatio();
 error InitialPriceRatioBelowGlobalMinPriceRatio();
 error InitialPriceRatioAbove100Percent();
 error CommissionRateTooHigh();
-// Sending ETH
+// ETH transfers
 error InsufficientEthSent();
 error SendingEthToPoolFailed();
 error SendingEthToCommissionDestinationFailed();
 error ReturningEthRemainderToSenderFailed();
 // Misc
-error OnlyOwnerOrApproved();
+error AlreadyInitialized();
 error ExpiredCoversCannotBeEdited();
 error InsufficientCoverAmountAllocated();
 error UnexpectedPoolId();

--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -127,45 +127,6 @@ struct PoolInitializationParams {
   uint globalMinPriceRatio;
 }
 
-// Auth
-error OnlyMemberRolesCanOperateTransfer();
-error OnlyOwnerOrApproved();
-
-// Cover details
-error CoverPeriodTooShort();
-error CoverPeriodTooLong();
-error CoverOutsideOfTheGracePeriod();
-error CoverAmountIsZero();
-// Products
-error ProductDoesntExist();
-error ProductTypeNotFound();
-error ProductDeprecated();
-error ProductDeprecatedOrNotInitialized();
-error InvalidProductType();
-error UnexpectedProductId();
-// Cover and payment assets
-error PayoutAssetNotSupported();
-error PaymentAssetDeprecated();
-error UnexpectedCoverAsset();
-error UnsupportedCoverAssets();
-// Price & Commission
-error PriceExceedsMaxPremiumInAsset();
-error TargetPriceBelowGlobalMinPriceRatio();
-error InitialPriceRatioBelowGlobalMinPriceRatio();
-error InitialPriceRatioAbove100Percent();
-error CommissionRateTooHigh();
-// ETH transfers
-error InsufficientEthSent();
-error SendingEthToPoolFailed();
-error SendingEthToCommissionDestinationFailed();
-error ReturningEthRemainderToSenderFailed();
-// Misc
-error AlreadyInitialized();
-error ExpiredCoversCannotBeEdited();
-error InsufficientCoverAmountAllocated();
-error UnexpectedPoolId();
-error CapacityReductionRatioAbove100Percent();
-
 interface ICover {
 
   /* ========== VIEWS ========== */
@@ -253,4 +214,48 @@ interface ICover {
   event ProductSet(uint id, string ipfsMetadata);
   event ProductTypeSet(uint id, string ipfsMetadata);
   event CoverEdited(uint indexed coverId, uint indexed productId, uint indexed segmentId, address buyer, string ipfsMetadata);
+
+  // Auth
+  error OnlyMemberRolesCanOperateTransfer();
+  error OnlyOwnerOrApproved();
+
+  // Cover details
+  error CoverPeriodTooShort();
+  error CoverPeriodTooLong();
+  error CoverOutsideOfTheGracePeriod();
+  error CoverAmountIsZero();
+
+  // Products
+  error ProductDoesntExist();
+  error ProductTypeNotFound();
+  error ProductDeprecated();
+  error ProductDeprecatedOrNotInitialized();
+  error InvalidProductType();
+  error UnexpectedProductId();
+
+  // Cover and payment assets
+  error PayoutAssetNotSupported();
+  error PaymentAssetDeprecated();
+  error UnexpectedCoverAsset();
+  error UnsupportedCoverAssets();
+
+  // Price & Commission
+  error PriceExceedsMaxPremiumInAsset();
+  error TargetPriceBelowGlobalMinPriceRatio();
+  error InitialPriceRatioBelowGlobalMinPriceRatio();
+  error InitialPriceRatioAbove100Percent();
+  error CommissionRateTooHigh();
+
+  // ETH transfers
+  error InsufficientEthSent();
+  error SendingEthToPoolFailed();
+  error SendingEthToCommissionDestinationFailed();
+  error ReturningEthRemainderToSenderFailed();
+
+  // Misc
+  error AlreadyInitialized();
+  error ExpiredCoversCannotBeEdited();
+  error InsufficientCoverAmountAllocated();
+  error UnexpectedPoolId();
+  error CapacityReductionRatioAbove100Percent();
 }

--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -137,7 +137,7 @@ error CoverPeriodTooLong();
 error CoverOutsideOfTheGracePeriod();
 error CoverAmountIsZero();
 // Products
-error ProductNotFound();
+error ProductDoesntExist();
 error ProductTypeNotFound();
 error ProductDeprecated();
 error ProductDeprecatedOrNotInitialized();

--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -127,6 +127,45 @@ struct PoolInitializationParams {
   uint globalMinPriceRatio;
 }
 
+error AlreadyInitialized();
+// Auth
+error OnlyMemberRolesCanOperateTransfer();
+
+// Cover details
+error CoverPeriodTooShort();
+error CoverPeriodTooLong();
+error CoverOutsideOfTheGracePeriod();
+error CoverAmountIsZero();
+// Products
+error ProductNotFound();
+error ProductTypeNotFound();
+error ProductDeprecated();
+error ProductDeprecatedOrNotInitialized();
+error InvalidProductType();
+error UnexpectedProductId();
+// Cover assets
+error PayoutAssetNotSupported();
+error PaymentAssetDeprecated();
+error UnexpectedCoverAsset();
+error UnsupportedCoverAssets();
+// Price & Commission
+error PriceExceedsMaxPremiumInAsset();
+error TargetPriceBelowGlobalMinPriceRatio();
+error InitialPriceRatioBelowGlobalMinPriceRatio();
+error InitialPriceRatioAbove100Percent();
+error CommissionRateTooHigh();
+// Sending ETH
+error InsufficientEthSent();
+error SendingEthToPoolFailed();
+error SendingEthToCommissionDestinationFailed();
+error ReturningEthRemainderToSenderFailed();
+// Misc
+error OnlyOwnerOrApproved();
+error ExpiredCoversCannotBeEdited();
+error InsufficientCoverAmountAllocated();
+error UnexpectedPoolId();
+error CapacityReductionRatioAbove100Percent();
+
 interface ICover {
 
   /* ========== VIEWS ========== */

--- a/contracts/interfaces/IStakingPool.sol
+++ b/contracts/interfaces/IStakingPool.sol
@@ -36,6 +36,39 @@ struct ProductInitializationParams {
   uint96 targetPrice;
 }
 
+// Auth
+error OnlyCoverContract();
+error OnlyManager();
+error PrivatePool();
+error SystemPaused();
+// Fees
+error PoolFeeExceedsMax();
+error MaxPoolFeeAbove100();
+// Voting
+error NxmIsLockedForGovernanceVote();
+error ManagerNxmIsLockedForGovernanceVote();
+// Deposit
+error InsufficientDepositAmount();
+error RewardRatioTooHigh();
+// Staking NFTs
+error InvalidTokenId();
+error NotTokenOwnerOrApproved();
+// Tranche & capacity
+error NewTrancheEndsBeforeInitialTranche();
+error RequestedTrancheIsNotYetActive();
+error RequestedTrancheIsExpired();
+error InsufficientCapacity();
+// Products & weights
+error PoolNotAllowedForThisProduct();
+error MustSetPriceForNewProducts();
+error MustSetWeightForNewProducts();
+error TargetPriceTooHigh();
+error TargetPriceBelowMin();
+error TargetWeightTooHigh();
+error MustRecalculateEffectiveWeight();
+error TotalTargetWeightExceeded();
+error TotalEffectiveWeightExceeded();
+
 interface IStakingPool {
 
   /* structs for storage */

--- a/contracts/interfaces/IStakingPool.sol
+++ b/contracts/interfaces/IStakingPool.sol
@@ -36,39 +36,6 @@ struct ProductInitializationParams {
   uint96 targetPrice;
 }
 
-// Auth
-error OnlyCoverContract();
-error OnlyManager();
-error PrivatePool();
-error SystemPaused();
-// Fees
-error PoolFeeExceedsMax();
-error MaxPoolFeeAbove100();
-// Voting
-error NxmIsLockedForGovernanceVote();
-error ManagerNxmIsLockedForGovernanceVote();
-// Deposit
-error InsufficientDepositAmount();
-error RewardRatioTooHigh();
-// Staking NFTs
-error InvalidTokenId();
-error NotTokenOwnerOrApproved();
-// Tranche & capacity
-error NewTrancheEndsBeforeInitialTranche();
-error RequestedTrancheIsNotYetActive();
-error RequestedTrancheIsExpired();
-error InsufficientCapacity();
-// Products & weights
-error PoolNotAllowedForThisProduct();
-error MustSetPriceForNewProducts();
-error MustSetWeightForNewProducts();
-error TargetPriceTooHigh();
-error TargetPriceBelowMin();
-error TargetWeightTooHigh();
-error MustRecalculateEffectiveWeight();
-error TotalTargetWeightExceeded();
-error TotalEffectiveWeightExceeded();
-
 interface IStakingPool {
 
   /* structs for storage */
@@ -172,4 +139,43 @@ interface IStakingPool {
   event PoolDescriptionSet(uint poolId, string ipfsDescriptionHash);
 
   event Withdraw(address indexed src, uint indexed tokenId, uint tranche, uint amountStakeWithdrawn, uint amountRewardsWithdrawn);
+
+  // Auth
+  error OnlyCoverContract();
+  error OnlyManager();
+  error PrivatePool();
+  error SystemPaused();
+
+  // Fees
+  error PoolFeeExceedsMax();
+  error MaxPoolFeeAbove100();
+
+  // Voting
+  error NxmIsLockedForGovernanceVote();
+  error ManagerNxmIsLockedForGovernanceVote();
+
+  // Deposit
+  error InsufficientDepositAmount();
+  error RewardRatioTooHigh();
+
+  // Staking NFTs
+  error InvalidTokenId();
+  error NotTokenOwnerOrApproved();
+
+  // Tranche & capacity
+  error NewTrancheEndsBeforeInitialTranche();
+  error RequestedTrancheIsNotYetActive();
+  error RequestedTrancheIsExpired();
+  error InsufficientCapacity();
+
+  // Products & weights
+  error PoolNotAllowedForThisProduct();
+  error MustSetPriceForNewProducts();
+  error MustSetWeightForNewProducts();
+  error TargetPriceTooHigh();
+  error TargetPriceBelowMin();
+  error TargetWeightTooHigh();
+  error MustRecalculateEffectiveWeight();
+  error TotalTargetWeightExceeded();
+  error TotalEffectiveWeightExceeded();
 }

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -105,7 +105,9 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
   }
 
   function initialize() external {
-    require(globalCapacityRatio == 0, "Cover: already initialized");
+    if (globalCapacityRatio != 0) {
+      revert AlreadyInitialized();
+    }
     globalCapacityRatio = 20000; // x2
     globalRewardsRatio = 5000; // 50%
     coverAssetsFallback = 3; // 0x11 - DAI and ETH
@@ -118,24 +120,42 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
     PoolAllocationRequest[] memory poolAllocationRequests
   ) external payable onlyMember nonReentrant whenNotPaused returns (uint coverId) {
 
-    require(params.period >= MIN_COVER_PERIOD, "Cover: Cover period is too short");
-    require(params.period <= MAX_COVER_PERIOD, "Cover: Cover period is too long");
-    require(params.commissionRatio <= MAX_COMMISSION_RATIO, "Cover: Commission rate is too high");
-    require(params.amount > 0, "Cover: amount = 0");
+    if (params.period < MIN_COVER_PERIOD) {
+      revert CoverPeriodTooShort();
+    }
+    if (params.period > MAX_COVER_PERIOD) {
+      revert CoverPeriodTooLong();
+    }
+    if (params.commissionRatio > MAX_COMMISSION_RATIO) {
+      revert CommissionRateTooHigh();
+    }
+    if (params.amount == 0) {
+      revert CoverAmountIsZero();
+    }
+
 
     uint segmentId;
 
     AllocationRequest memory allocationRequest;
     {
-      require(_products.length > params.productId, "Cover: Product not found");
+      if (_products.length <= params.productId) {
+        revert ProductNotFound();
+      }
 
       Product memory product = _products[params.productId];
-      require(!product.isDeprecated, "Cover: Product is deprecated");
+
+      if (product.isDeprecated) {
+        revert ProductDeprecated();
+      }
 
       uint32 deprecatedCoverAssets = pool().deprecatedCoverAssetsBitmap();
       uint32 supportedCoverAssets = _getSupportedCoverAssets(deprecatedCoverAssets, product.coverAssets);
-      require(isAssetSupported(supportedCoverAssets, params.coverAsset), "Cover: Payout asset is not supported");
-      require(!_isCoverAssetDeprecated(deprecatedCoverAssets, params.paymentAsset), "Cover: Payment asset deprecated");
+      if (!isAssetSupported(supportedCoverAssets, params.coverAsset)) {
+        revert PayoutAssetNotSupported();
+      }
+      if (_isCoverAssetDeprecated(deprecatedCoverAssets, params.paymentAsset)) {
+        revert PaymentAssetDeprecated();
+      }
 
       allocationRequest = AllocationRequest(
         params.productId,
@@ -165,17 +185,25 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
 
       // existing cover
       coverId = params.coverId;
-      require(coverNFT.isApprovedOrOwner(msg.sender, coverId), "Cover: Only owner or approved can edit");
+      if (!coverNFT.isApprovedOrOwner(msg.sender, coverId)) {
+        revert OnlyOwnerOrApproved();
+      }
 
       CoverData memory cover = _coverData[coverId];
-      require(params.coverAsset == cover.coverAsset, "Cover: Unexpected coverAsset requested");
-      require(params.productId == cover.productId, "Cover: Unexpected productId requested");
+      if (params.coverAsset != cover.coverAsset) {
+        revert UnexpectedCoverAsset();
+      }
+      if (params.productId != cover.productId) {
+        revert UnexpectedProductId();
+      }
 
       segmentId = _coverSegments[coverId].length;
       CoverSegment memory lastSegment = coverSegments(coverId, segmentId - 1);
 
       // require last segment not to be expired
-      require(lastSegment.start + lastSegment.period > block.timestamp, "Cover: Expired covers cannot be edited");
+      if (lastSegment.start + lastSegment.period <= block.timestamp) {
+        revert ExpiredCoversCannotBeEdited();
+      }
 
       allocationRequest.previousStart = lastSegment.start;
       allocationRequest.previousExpiration = lastSegment.start + lastSegment.period;
@@ -194,7 +222,9 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
       segmentId
     );
 
-    require(coverAmountInCoverAsset >= params.amount, "Cover: Insufficient cover amount allocated");
+    if (coverAmountInCoverAsset < params.amount) {
+      revert InsufficientCoverAmountAllocated();
+    }
 
     _coverSegments[coverId].push(
       CoverSegment(
@@ -252,7 +282,9 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
           coverSegmentAllocations[allocationRequest.coverId][segmentId - 1][i];
 
         // poolAllocationRequests must match the pools in the previous segment
-        require(previousPoolAllocation.poolId == poolAllocationRequests[i].poolId, "Cover: Unexpected pool id");
+        if (previousPoolAllocation.poolId != poolAllocationRequests[i].poolId) {
+          revert UnexpectedPoolId();
+        }
 
         vars.previousPremiumInNXM = previousPoolAllocation.premiumInNXM;
         vars.refund =
@@ -304,7 +336,9 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
 
     // NXM payment
     if (paymentAsset == NXM_ASSET_ID) {
-      require(premiumInNxm <= maxPremiumInAsset, "Cover: Price exceeds maxPremiumInAsset");
+      if (premiumInNxm > maxPremiumInAsset) {
+        revert PriceExceedsMaxPremiumInAsset();
+      }
 
       ITokenController _tokenController = tokenController();
       _tokenController.burnFrom(msg.sender, premiumInNxm);
@@ -322,13 +356,17 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
     uint premiumInPaymentAsset = _pool.getTokenPrice(paymentAsset) * premiumInNxm / ONE_NXM;
     uint commission = premiumInPaymentAsset * commissionRatio / COMMISSION_DENOMINATOR;
 
-    require(premiumInPaymentAsset <= maxPremiumInAsset, "Cover: Price exceeds maxPremiumInAsset");
+    if (premiumInPaymentAsset > maxPremiumInAsset) {
+      revert PriceExceedsMaxPremiumInAsset();
+    }
 
     // ETH payment
     if (paymentAsset == ETH_ASSET_ID) {
 
       uint premiumWithCommission = premiumInPaymentAsset + commission;
-      require(msg.value >= premiumWithCommission, "Cover: Insufficient ETH sent");
+      if (msg.value < premiumWithCommission) {
+        revert InsufficientEthSent();
+      }
 
       uint remainder = msg.value - premiumWithCommission;
 
@@ -336,19 +374,25 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
         // send premium in eth to the pool
         // solhint-disable-next-line avoid-low-level-calls
         (bool ok, /* data */) = address(_pool).call{value: premiumInPaymentAsset}("");
-        require(ok, "Cover: Sending ETH to pool failed.");
+        if (!ok) {
+          revert SendingEthToPoolFailed();
+        }
       }
 
       // send commission
       if (commission > 0) {
         (bool ok, /* data */) = address(commissionDestination).call{value: commission}("");
-        require(ok, "Cover: Sending ETH to commission destination failed.");
+        if (!ok) {
+          revert SendingEthToCommissionDestinationFailed();
+        }
       }
 
       if (remainder > 0) {
         // solhint-disable-next-line avoid-low-level-calls
         (bool ok, /* data */) = address(msg.sender).call{value: remainder}("");
-        require(ok, "Cover: Returning ETH remainder to sender failed.");
+        if (!ok) {
+          revert ReturningEthRemainderToSenderFailed();
+        }
       }
 
       return;
@@ -375,10 +419,9 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
     ProductType memory productType = _productTypes[_products[productId].productType];
 
     // uses the current v2 grace period
-    require(
-      block.timestamp < start + period + productType.gracePeriod,
-      "Cover outside of the grace period"
-    );
+    if (block.timestamp >= start + period + productType.gracePeriod) {
+      revert CoverOutsideOfTheGracePeriod();
+    }
 
     _coverData.push(
       CoverData(productId.toUint24(), coverAsset.toUint8(), 0 /* amountPaidOut */)
@@ -404,10 +447,9 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
   }
 
   function transferCovers(address from, address to, uint256[] calldata tokenIds) external override {
-    require(
-      msg.sender == address(memberRoles()),
-      "Cover: Only MemberRoles is permitted to use operator transfer"
-    );
+    if (msg.sender != address(memberRoles())) {
+      revert OnlyMemberRolesCanOperateTransfer();
+    }
 
     for (uint256 i = 0; i < tokenIds.length; i++) {
       ICoverNFT(coverNFT).operatorTransferFrom(from, to, tokenIds[i]);
@@ -415,10 +457,9 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
   }
 
   function transferStakingPoolTokens(address from, address to, uint256[] calldata tokenIds) external override {
-    require(
-      msg.sender == address(memberRoles()),
-      "Cover: Only MemberRoles is permitted to use operator transfer"
-    );
+    if (msg.sender != address(memberRoles())) {
+      revert OnlyMemberRolesCanOperateTransfer();
+    }
 
     for (uint256 i = 0; i < tokenIds.length; i++) {
       stakingNFT.operatorTransferFrom(from, to, tokenIds[i]);
@@ -442,10 +483,9 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
         uint productId = productInitParams[i].productId;
         productInitParams[i].initialPrice = _products[productId].initialPriceRatio;
 
-        require(
-          productInitParams[i].targetPrice >= GLOBAL_MIN_PRICE_RATIO,
-          "Cover: Target price below GLOBAL_MIN_PRICE_RATIO"
-        );
+        if (productInitParams[i].targetPrice < GLOBAL_MIN_PRICE_RATIO) {
+          revert TargetPriceBelowGlobalMinPriceRatio();
+        }
       }
     }
 
@@ -552,23 +592,21 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
     for (uint i = 0; i < productParams.length; i++) {
       ProductParam calldata param = productParams[i];
       Product calldata product = param.product;
-      require(product.productType < productTypesCount, "Cover: Invalid productType");
-      require(
-        areAssetsSupported(product.coverAssets, _coverAssetsFallback),
-        "Cover: Unsupported cover assets"
-      );
-      require(
-        product.initialPriceRatio >= GLOBAL_MIN_PRICE_RATIO,
-        "Cover: initialPriceRatio < GLOBAL_MIN_PRICE_RATIO"
-      );
-      require(
-        product.initialPriceRatio <= PRICE_DENOMINATOR,
-        "Cover: initialPriceRatio > 100%"
-      );
-      require(
-        product.capacityReductionRatio <= CAPACITY_REDUCTION_DENOMINATOR,
-        "Cover: capacityReductionRatio > 100%"
-      );
+      if (product.productType >= productTypesCount) {
+        revert InvalidProductType();
+      }
+      if (!areAssetsSupported(product.coverAssets, _coverAssetsFallback)) {
+        revert UnsupportedCoverAssets();
+      }
+      if (product.initialPriceRatio < GLOBAL_MIN_PRICE_RATIO) {
+        revert InitialPriceRatioBelowGlobalMinPriceRatio();
+      }
+      if (product.initialPriceRatio > PRICE_DENOMINATOR) {
+        revert InitialPriceRatioAbove100Percent();
+      }
+      if (product.capacityReductionRatio > CAPACITY_REDUCTION_DENOMINATOR) {
+        revert CapacityReductionRatioAbove100Percent();
+      }
 
       if (product.useFixedPrice) {
 
@@ -584,7 +622,9 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
       }
 
       // existing product
-      require(param.productId < _products.length, "Cover: Product doesnt exist. Set id to uint256.max to add it");
+      if (param.productId >= _products.length) {
+        revert ProductNotFound();
+      }
       Product storage newProductValue = _products[param.productId];
       newProductValue.isDeprecated = product.isDeprecated;
       newProductValue.coverAssets = product.coverAssets;
@@ -609,7 +649,9 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
         continue;
       }
 
-      require(param.productTypeId < _productTypes.length, "Cover: ProductType doesnt exist. Set id to uint256.max to add it");
+      if (param.productTypeId >= _productTypes.length) {
+        revert ProductTypeNotFound();
+      }
       _productTypes[param.productTypeId].gracePeriod = param.productType.gracePeriod;
       emit ProductTypeSet(param.productTypeId, param.ipfsMetadata);
     }
@@ -663,7 +705,9 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
 
     for (uint i = 0; i < productIds.length; i++) {
       Product memory product = _products[productIds[i]];
-      require(product.initialPriceRatio > 0, "Cover: Product deprecated or not initialized");
+      if (product.initialPriceRatio == 0) {
+        revert ProductDeprecatedOrNotInitialized();
+      }
       _initialPrices[i] = uint(product.initialPriceRatio);
       _capacityReductionRatios[i] = uint(product.capacityReductionRatio);
     }

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -139,7 +139,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
     AllocationRequest memory allocationRequest;
     {
       if (_products.length <= params.productId) {
-        revert ProductNotFound();
+        revert ProductDoesntExist();
       }
 
       Product memory product = _products[params.productId];
@@ -623,7 +623,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
 
       // existing product
       if (param.productId >= _products.length) {
-        revert ProductNotFound();
+        revert ProductDoesntExist();
       }
       Product storage newProductValue = _products[param.productId];
       newProductValue.isDeprecated = product.isDeprecated;

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -133,7 +133,6 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
       revert CoverAmountIsZero();
     }
 
-
     uint segmentId;
 
     AllocationRequest memory allocationRequest;

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -949,8 +949,9 @@ contract StakingPool is IStakingPool {
 
       coverTrancheAllocations[allocationId] = packedCoverAllocations;
 
-    if (remainingAmount != 0) {
-      revert InsufficientCapacity();
+      if (remainingAmount != 0) {
+        revert InsufficientCapacity();
+      }
     }
 
     updateExpiringCoverAmounts(

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -146,12 +146,16 @@ contract StakingPool is IStakingPool {
   uint public constant MAX_UINT = type(uint).max;
 
   modifier onlyCoverContract {
-    require(msg.sender == coverContract, "StakingPool: Only Cover contract can call this function");
+    if (msg.sender != coverContract) {
+      revert OnlyCoverContract();
+    }
     _;
   }
 
   modifier onlyManager {
-    require(msg.sender == manager, "StakingPool: Only pool manager can call this function");
+    if (msg.sender != manager) {
+      revert OnlyManager();
+    }
     _;
   }
 
@@ -184,8 +188,13 @@ contract StakingPool is IStakingPool {
     string  calldata ipfsDescriptionHash
   ) external onlyCoverContract {
 
-    require(_initialPoolFee <= _maxPoolFee, "StakingPool: Pool fee should not exceed max pool fee");
-    require(_maxPoolFee < 100, "StakingPool: Max pool fee cannot be 100%");
+    if (_initialPoolFee > _maxPoolFee) {
+      revert PoolFeeExceedsMax();
+    }
+
+    if (_maxPoolFee >= 100) {
+      revert MaxPoolFeeAbove100();
+    }
 
     manager = _manager;
     isPrivatePool = _isPrivatePool;
@@ -343,18 +352,28 @@ contract StakingPool is IStakingPool {
   ) public whenNotPaused returns (uint tokenId) {
 
     if (isPrivatePool) {
-      require(msg.sender == manager, "StakingPool: The pool is private");
+      if (msg.sender != manager) {
+        revert PrivatePool();
+      }
     }
 
-    require(block.timestamp > nxm.isLockedForMV(msg.sender), "Staking: NXM is locked for voting in governance");
+    if (block.timestamp <= nxm.isLockedForMV(msg.sender)) {
+      revert NxmIsLockedForGovernanceVote();
+    }
 
     {
       uint _firstActiveTrancheId = block.timestamp / TRANCHE_DURATION;
       uint maxTranche = _firstActiveTrancheId + MAX_ACTIVE_TRANCHES - 1;
 
-      require(amount > 0, "StakingPool: Insufficient deposit amount");
-      require(trancheId <= maxTranche, "StakingPool: Requested tranche is not yet active");
-      require(trancheId >= _firstActiveTrancheId, "StakingPool: Requested tranche has expired");
+      if (amount == 0) {
+        revert InsufficientDepositAmount();
+      }
+      if (trancheId > maxTranche) {
+        revert RequestedTrancheIsNotYetActive();
+      }
+      if (trancheId < _firstActiveTrancheId) {
+        revert RequestedTrancheIsExpired();
+      }
 
       // if the pool has no previous deposits
       if (firstActiveTrancheId == 0) {
@@ -533,10 +552,9 @@ contract StakingPool is IStakingPool {
 
           // Deposit withdrawals are not permitted while the manager is locked in governance to
           // prevent double voting.
-          require(
-            managerLockedInGovernanceUntil < block.timestamp,
-            "StakingPool: While the pool manager is locked for governance voting only rewards can be withdrawn"
-          );
+          if(managerLockedInGovernanceUntil > block.timestamp) {
+            revert ManagerNxmIsLockedForGovernanceVote();
+          }
 
           // calculate the amount of nxm for this deposit
           uint stake = expiredTranches[trancheId].stakeAmountAtExpiry;
@@ -646,7 +664,9 @@ contract StakingPool is IStakingPool {
 
     // add new rewards
     {
-      require(request.rewardRatio <= REWARDS_DENOMINATOR, "StakingPool: reward ratio exceeds denominator");
+      if(request.rewardRatio > REWARDS_DENOMINATOR) {
+        revert RewardRatioTooHigh();
+      }
 
       uint expirationBucket = Math.divCeil(block.timestamp + request.period, BUCKET_DURATION);
       uint rewardStreamPeriod = expirationBucket * BUCKET_DURATION - block.timestamp;
@@ -836,10 +856,9 @@ contract StakingPool is IStakingPool {
   ) internal view returns (uint[] memory trancheCapacities) {
 
     // TODO: this require statement seems redundant
-    require(
-      firstTrancheId >= block.timestamp / TRANCHE_DURATION,
-      "StakingPool: requested tranche has expired"
-    );
+    if(firstTrancheId < block.timestamp / TRANCHE_DURATION) {
+      revert RequestedTrancheIsExpired();
+    }
 
     uint _activeStake = activeStake;
     uint _stakeSharesSupply = stakeSharesSupply;
@@ -930,7 +949,8 @@ contract StakingPool is IStakingPool {
 
       coverTrancheAllocations[allocationId] = packedCoverAllocations;
 
-      require(remainingAmount == 0, "StakingPool: Insufficient capacity");
+    if (remainingAmount != 0) {
+      revert InsufficientCapacity();
     }
 
     updateExpiringCoverAmounts(
@@ -1047,17 +1067,28 @@ contract StakingPool is IStakingPool {
   ) external whenNotPaused {
 
     // token id MAX_UINT is only used for pool manager fee tracking, no deposits allowed
-    require(tokenId != MAX_UINT, "StakingPool: Invalid token id");
-    require(stakingNFT.isApprovedOrOwner(msg.sender, tokenId), "StakingPool: Not token owner or approved");
+    if(tokenId == MAX_UINT) {
+      revert InvalidTokenId();
+    }
+    if (!stakingNFT.isApprovedOrOwner(msg.sender, tokenId)) {
+      revert NotTokenOwnerOrApproved();
+    }
 
     uint _firstActiveTrancheId = block.timestamp / TRANCHE_DURATION;
 
     {
-      require(initialTrancheId < newTrancheId, "StakingPool: The chosen tranche cannot end before the initial one");
+      if (initialTrancheId >= newTrancheId) {
+        revert NewTrancheEndsBeforeInitialTranche();
+      }
 
       uint maxTrancheId = _firstActiveTrancheId + MAX_ACTIVE_TRANCHES - 1;
-      require(newTrancheId <= maxTrancheId, "StakingPool: The tranche is not yet available");
-      require(newTrancheId >= _firstActiveTrancheId, "StakingPool: The tranche has already expired");
+
+      if (newTrancheId > maxTrancheId) {
+        revert RequestedTrancheIsNotYetActive();
+      }
+      if (newTrancheId < firstActiveTrancheId) {
+        revert RequestedTrancheIsExpired();
+      }
     }
 
     // if the initial tranche is expired, withdraw everything and make a new deposit
@@ -1081,7 +1112,9 @@ contract StakingPool is IStakingPool {
     }
 
     if (isPrivatePool) {
-      require(msg.sender == manager, "StakingPool: The pool is private");
+      if (msg.sender != manager) {
+        revert PrivatePool();
+      }
     }
 
     // if we got here - the initial tranche is still active. move all the shares to the new tranche
@@ -1246,12 +1279,10 @@ contract StakingPool is IStakingPool {
 
     for (uint i = 0; i < numProducts; i++) {
       productIds[i] = params[i].productId;
-      require(
-        ICover(coverContract).isPoolAllowed(params[i].productId, poolId),
-        "StakingPool: Pool is not allowed for this product"
-      );
+      if (!ICover(coverContract).isPoolAllowed(params[i].productId, poolId)) {
+         revert PoolNotAllowedForThisProduct();
+      }
     }
-
     (
       uint globalCapacityRatio,
       uint globalMinPriceRatio,
@@ -1273,27 +1304,35 @@ contract StakingPool is IStakingPool {
         _product.bumpedPrice = initialPriceRatios[i].toUint96();
         _product.bumpedPriceUpdateTime = uint32(block.timestamp);
         // and make sure we set the price and the target weight
-        require(_param.setTargetPrice, "StakingPool: Must set price for new products");
-        require(_param.setTargetWeight, "StakingPool: Must set weight for new products");
+        if (!_param.setTargetPrice) {
+          revert MustSetPriceForNewProducts();
+        }
+        if (!_param.setTargetWeight) {
+          revert MustSetWeightForNewProducts();
+        }
       }
 
       if (_param.setTargetPrice) {
-        require(_param.targetPrice <= TARGET_PRICE_DENOMINATOR, "StakingPool: Target price too high");
-        require(_param.targetPrice >= globalMinPriceRatio, "StakingPool: Target price below GLOBAL_MIN_PRICE_RATIO");
+        if (_param.targetPrice > TARGET_PRICE_DENOMINATOR) {
+          revert TargetPriceTooHigh();
+        }
+        if (_param.targetPrice < globalMinPriceRatio) {
+          revert TargetPriceBelowMin();
+        }
         _product.targetPrice = _param.targetPrice;
       }
 
-      require(
-        // if setTargetWeight is set - effective weight must be recalculated
-        !_param.setTargetWeight || _param.recalculateEffectiveWeight,
-        "StakingPool: Must recalculate effectiveWeight to edit targetWeight"
-      );
+      if (_param.setTargetWeight && !_param.recalculateEffectiveWeight) {
+        revert MustRecalculateEffectiveWeight();
+      }
 
       // Must recalculate effectiveWeight to adjust targetWeight
       if (_param.recalculateEffectiveWeight) {
 
         if (_param.setTargetWeight) {
-          require(_param.targetWeight <= WEIGHT_DENOMINATOR, "StakingPool: Cannot set weight beyond 1");
+          if (_param.targetWeight > WEIGHT_DENOMINATOR) {
+            revert TargetWeightTooHigh();
+          }
 
           // totalEffectiveWeight cannot be above the max unless target  weight is not increased
           if (!targetWeightIncreased) {
@@ -1321,10 +1360,14 @@ contract StakingPool is IStakingPool {
       products[_param.productId] = _product;
     }
 
-    require(_totalTargetWeight <= MAX_TOTAL_WEIGHT, "StakingPool: Max total target weight exceeded");
+    if (_totalTargetWeight > MAX_TOTAL_WEIGHT) {
+      revert TotalTargetWeightExceeded();
+    }
 
     if (targetWeightIncreased) {
-      require(_totalEffectiveWeight <= MAX_TOTAL_WEIGHT, "StakingPool: Total max effective weight exceeded");
+      if (_totalEffectiveWeight > MAX_TOTAL_WEIGHT) {
+        revert TotalEffectiveWeightExceeded();
+      }
     }
 
     totalTargetWeight = _totalTargetWeight.toUint32();
@@ -1365,8 +1408,12 @@ contract StakingPool is IStakingPool {
     for (uint i = 0; i < params.length; i++) {
       ProductInitializationParams memory param = params[i];
       StakedProduct storage _product = products[param.productId];
-      require(param.targetPrice <= TARGET_PRICE_DENOMINATOR, "StakingPool: Target price too high");
-      require(param.weight <= WEIGHT_DENOMINATOR, "StakingPool: Cannot set weight beyond 1");
+      if (param.targetPrice > TARGET_PRICE_DENOMINATOR) {
+        revert TargetPriceTooHigh();
+      }
+      if (param.weight > WEIGHT_DENOMINATOR) {
+        revert TargetWeightTooHigh();
+      }
       _product.bumpedPrice = param.initialPrice;
       _product.bumpedPriceUpdateTime = uint32(block.timestamp);
       _product.targetPrice = param.targetPrice;
@@ -1374,14 +1421,18 @@ contract StakingPool is IStakingPool {
       _totalTargetWeight += param.weight;
     }
 
-    require(_totalTargetWeight <= MAX_TOTAL_WEIGHT, "StakingPool: Total max target weight exceeded");
+    if (_totalTargetWeight > MAX_TOTAL_WEIGHT) {
+      revert TotalTargetWeightExceeded();
+    }
     totalTargetWeight = _totalTargetWeight;
     totalEffectiveWeight = totalTargetWeight;
   }
 
   function setPoolFee(uint newFee) external onlyManager {
 
-    require(newFee <= maxPoolFee, "StakingPool: new fee exceeds max fee");
+    if (newFee > maxPoolFee) {
+      revert PoolFeeExceedsMax();
+    }
     uint oldFee = poolFee;
     poolFee = uint8(newFee);
 

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -1323,6 +1323,7 @@ contract StakingPool is IStakingPool {
         _product.targetPrice = _param.targetPrice;
       }
 
+      // if setTargetWeight is set - effective weight must be recalculated
       if (_param.setTargetWeight && !_param.recalculateEffectiveWeight) {
         revert MustRecalculateEffectiveWeight();
       }

--- a/test/integration/Cover/createStakingPool.js
+++ b/test/integration/Cover/createStakingPool.js
@@ -57,7 +57,7 @@ describe('createStakingPool', function () {
 
     await expect(
       stakingPool.connect(staker).depositTo(deposit, trancheId, MaxUint256, AddressZero), // new deposit
-    ).to.be.revertedWith('StakingPool: The pool is private');
+    ).to.be.revertedWithCustomError(stakingPool, 'PrivatePool');
   });
 
   it('should create a public staking pool', async function () {

--- a/test/unit/Cover/buyCover.js
+++ b/test/unit/Cover/buyCover.js
@@ -424,7 +424,7 @@ describe('buyCover', function () {
           value: '0',
         },
       ),
-    ).to.be.revertedWithCustomError(cover, 'ProductNotFound');
+    ).to.be.revertedWithCustomError(cover, 'ProductDoesntExist');
   });
 
   it('should revert for unsupported payout asset', async function () {

--- a/test/unit/Cover/buyCover.js
+++ b/test/unit/Cover/buyCover.js
@@ -424,7 +424,7 @@ describe('buyCover', function () {
           value: '0',
         },
       ),
-    ).to.be.revertedWith('Cover: Product not found');
+    ).to.be.revertedWithCustomError(cover, 'ProductNotFound');
   });
 
   it('should revert for unsupported payout asset', async function () {
@@ -453,7 +453,7 @@ describe('buyCover', function () {
           value: '0',
         },
       ),
-    ).to.be.revertedWith('Cover: Payout asset is not supported');
+    ).to.be.revertedWithCustomError(cover, 'PayoutAssetNotSupported');
   });
 
   it('should revert for period too short', async function () {
@@ -483,7 +483,7 @@ describe('buyCover', function () {
           value: '0',
         },
       ),
-    ).to.be.revertedWith('Cover: Cover period is too short');
+    ).to.be.revertedWithCustomError(cover, 'CoverPeriodTooShort');
   });
 
   it('should revert for period too long', async function () {
@@ -512,7 +512,7 @@ describe('buyCover', function () {
           value: '0',
         },
       ),
-    ).to.be.revertedWith('Cover: Cover period is too long');
+    ).to.be.revertedWithCustomError(cover, 'CoverPeriodTooLong');
   });
 
   it('should revert for commission rate too high', async function () {
@@ -540,7 +540,7 @@ describe('buyCover', function () {
           value: '0',
         },
       ),
-    ).to.be.revertedWith('Cover: Commission rate is too high');
+    ).to.be.revertedWithCustomError(cover, 'CommissionRateTooHigh');
   });
 
   it('should revert when cover amount is 0', async function () {
@@ -570,7 +570,7 @@ describe('buyCover', function () {
           value: expectedPremium,
         },
       ),
-    ).to.be.revertedWith('Cover: amount = 0');
+    ).to.be.revertedWithCustomError(cover, 'CoverAmountIsZero');
   });
 
   // TODO: The logic has been moved in StakingPool.sol and this test will have to be moved as well.
@@ -759,7 +759,7 @@ describe('buyCover', function () {
           value: '0',
         },
       ),
-    ).to.be.revertedWith('Cover: Payment asset deprecated');
+    ).to.be.revertedWithCustomError(cover, 'PaymentAssetDeprecated');
   });
 
   it('reverts if calculated premium is bigger than maxPremiumInAsset', async function () {
@@ -792,7 +792,7 @@ describe('buyCover', function () {
           value: expectedPremium,
         },
       ),
-    ).to.be.revertedWith('Cover: Price exceeds maxPremiumInAsset');
+    ).to.be.revertedWithCustomError(cover, 'PriceExceedsMaxPremiumInAsset');
   });
 
   it('reverts if empty array of allocationRequests', async function () {
@@ -820,7 +820,7 @@ describe('buyCover', function () {
           value: expectedPremium,
         },
       ),
-    ).to.be.revertedWith('Cover: Insufficient cover amount allocated');
+    ).to.be.revertedWithCustomError(cover, 'InsufficientCoverAmountAllocated');
   });
 
   it('reverts if allocationRequest coverAmountInAsset is 0', async function () {
@@ -848,7 +848,7 @@ describe('buyCover', function () {
           value: expectedPremium,
         },
       ),
-    ).to.be.revertedWith('Cover: Insufficient cover amount allocated');
+    ).to.be.revertedWithCustomError(cover, 'InsufficientCoverAmountAllocated');
   });
 
   it('retrieves ERC20 payment from caller and transfers it to the Pool', async function () {
@@ -1262,7 +1262,7 @@ describe('buyCover', function () {
           value: expectedPremium,
         },
       ),
-    ).to.be.revertedWith('Cover: Sending ETH to commission destination failed.');
+    ).to.be.revertedWithCustomError(cover, 'SendingEthToCommissionDestinationFailed');
   });
 
   it('correctly store cover, segment and allocation data', async function () {

--- a/test/unit/Cover/editCover.js
+++ b/test/unit/Cover/editCover.js
@@ -320,7 +320,7 @@ describe.skip('editCover', function () {
           value: extraPremium,
         },
       ),
-    ).to.be.revertedWith('Cover: Cover period is too long');
+    ).to.be.revertedWithCustomError(cover, 'CoverPeriodTooLong');
   });
 
   it('should revert when commission rate too high', async function () {
@@ -364,7 +364,7 @@ describe.skip('editCover', function () {
           value: extraPremium,
         },
       ),
-    ).to.be.revertedWith('Cover: Commission rate is too high');
+    ).to.be.revertedWithCustomError(cover, 'CommissionRateTooHigh');
   });
 
   it('should store new grace period when editing cover', async function () {

--- a/test/unit/Cover/initialize.js
+++ b/test/unit/Cover/initialize.js
@@ -38,7 +38,7 @@ describe('initialize', function () {
     const { accounts, cover } = this;
     const [governance] = accounts.governanceContracts;
     await cover.connect(governance).updateUintParameters([0], ['10000']);
-    await expect(cover.initialize()).to.be.revertedWith('Cover: already initialized');
+    await expect(cover.initialize()).to.be.revertedWithCustomError(cover, 'AlreadyInitialized');
   });
 
   it('should not initialize twice', async function () {
@@ -52,6 +52,6 @@ describe('initialize', function () {
     );
 
     await cover.initialize();
-    await expect(cover.initialize()).to.be.revertedWith('Cover: already initialized');
+    await expect(cover.initialize()).to.be.revertedWithCustomError(cover, 'AlreadyInitialized');
   });
 });

--- a/test/unit/Cover/setProductTypes.js
+++ b/test/unit/Cover/setProductTypes.js
@@ -67,8 +67,8 @@ describe('setProductTypes', function () {
     const [advisoryBoardMember0] = this.accounts.advisoryBoardMembers;
     const productTypeId = 99;
     const productTypeParams = { ...ProductTypeParamTemplate, productTypeId };
-    await expect(cover.connect(advisoryBoardMember0).setProductTypes([productTypeParams])).to.be.revertedWith(
-      'Cover: ProductType doesnt exist. Set id to uint256.max to add it',
-    );
+    await expect(
+      cover.connect(advisoryBoardMember0).setProductTypes([productTypeParams]),
+    ).to.be.revertedWithCustomError(cover, 'ProductTypeNotFound');
   });
 });

--- a/test/unit/Cover/setProducts.js
+++ b/test/unit/Cover/setProducts.js
@@ -118,7 +118,7 @@ describe('setProducts', function () {
     const productParams = { ...productParamsTemplate, productId };
     await expect(cover.connect(advisoryBoardMember0).setProducts([productParams])).to.be.revertedWithCustomError(
       cover,
-      'ProductNotFound',
+      'ProductDoesntExist',
     );
   });
 

--- a/test/unit/Cover/setProducts.js
+++ b/test/unit/Cover/setProducts.js
@@ -116,8 +116,9 @@ describe('setProducts', function () {
     const [advisoryBoardMember0] = this.accounts.advisoryBoardMembers;
     const productId = await cover.productsCount();
     const productParams = { ...productParamsTemplate, productId };
-    await expect(cover.connect(advisoryBoardMember0).setProducts([productParams])).to.be.revertedWith(
-      'Cover: Product doesnt exist. Set id to uint256.max to add it',
+    await expect(cover.connect(advisoryBoardMember0).setProducts([productParams])).to.be.revertedWithCustomError(
+      cover,
+      'ProductNotFound',
     );
   });
 
@@ -127,8 +128,9 @@ describe('setProducts', function () {
     const coverAssets = parseInt('1111', 2); // ETH DAI, USDC and WBTC supported
     const product = { ...productTemplate, coverAssets };
     const productParams = { ...productParamsTemplate, product };
-    await expect(cover.connect(advisoryBoardMember0).setProducts([productParams])).to.be.revertedWith(
-      'Cover: Unsupported cover assets',
+    await expect(cover.connect(advisoryBoardMember0).setProducts([productParams])).to.be.revertedWithCustomError(
+      cover,
+      'UnsupportedCoverAssets',
     );
   });
 
@@ -144,8 +146,9 @@ describe('setProducts', function () {
       const coverAssets = parseInt('1111', 2); // ETH DAI, USDC and WBTC supported
       const product = { ...productTemplate, coverAssets };
       const productParams = { ...productParamsTemplate, product, productId };
-      await expect(cover.connect(advisoryBoardMember0).setProducts([productParams])).to.be.revertedWith(
-        'Cover: Unsupported cover assets',
+      await expect(cover.connect(advisoryBoardMember0).setProducts([productParams])).to.be.revertedWithCustomError(
+        cover,
+        'UnsupportedCoverAssets',
       );
     }
   });
@@ -156,8 +159,9 @@ describe('setProducts', function () {
     const initialPriceRatio = priceDenominator + 1;
     const product = { ...productTemplate, initialPriceRatio };
     const productParams = { ...productParamsTemplate, product };
-    await expect(cover.connect(advisoryBoardMember0).setProducts([productParams])).to.be.revertedWith(
-      'Cover: initialPriceRatio > 100%',
+    await expect(cover.connect(advisoryBoardMember0).setProducts([productParams])).to.be.revertedWithCustomError(
+      cover,
+      'InitialPriceRatioAbove100Percent',
     );
   });
 
@@ -173,8 +177,9 @@ describe('setProducts', function () {
       const initialPriceRatio = priceDenominator + 1;
       const product = { ...productTemplate, initialPriceRatio };
       const productParams = { ...productParamsTemplate, product, productId };
-      await expect(cover.connect(advisoryBoardMember0).setProducts([productParams])).to.be.revertedWith(
-        'Cover: initialPriceRatio > 100%',
+      await expect(cover.connect(advisoryBoardMember0).setProducts([productParams])).to.be.revertedWithCustomError(
+        cover,
+        'InitialPriceRatioAbove100Percent',
       );
     }
   });
@@ -186,8 +191,9 @@ describe('setProducts', function () {
     const initialPriceRatio = GLOBAL_MIN_PRICE_RATIO - 1;
     const product = { ...productTemplate, initialPriceRatio };
     const productParams = { ...productParamsTemplate, product };
-    await expect(cover.connect(advisoryBoardMember0).setProducts([productParams])).to.be.revertedWith(
-      'Cover: initialPriceRatio < GLOBAL_MIN_PRICE_RATIO',
+    await expect(cover.connect(advisoryBoardMember0).setProducts([productParams])).to.be.revertedWithCustomError(
+      cover,
+      'InitialPriceRatioBelowGlobalMinPriceRatio',
     );
   });
 
@@ -202,8 +208,9 @@ describe('setProducts', function () {
       const initialPriceRatio = GLOBAL_MIN_PRICE_RATIO - 1;
       const product = { ...productTemplate, initialPriceRatio };
       const productParams = { ...productParamsTemplate, product, productId };
-      await expect(cover.connect(advisoryBoardMember0).setProducts([productParams])).to.be.revertedWith(
-        'Cover: initialPriceRatio < GLOBAL_MIN_PRICE_RATIO',
+      await expect(cover.connect(advisoryBoardMember0).setProducts([productParams])).to.be.revertedWithCustomError(
+        cover,
+        'InitialPriceRatioBelowGlobalMinPriceRatio',
       );
     }
   });
@@ -214,8 +221,9 @@ describe('setProducts', function () {
     const capacityReductionRatio = capacityFactor + 1; // 100.01 %
     const product = { ...productTemplate, capacityReductionRatio };
     const productParams = { ...productParamsTemplate, product };
-    await expect(cover.connect(advisoryBoardMember0).setProducts([productParams])).to.be.revertedWith(
-      'Cover: capacityReductionRatio > 100%',
+    await expect(cover.connect(advisoryBoardMember0).setProducts([productParams])).to.be.revertedWithCustomError(
+      cover,
+      'CapacityReductionRatioAbove100Percent',
     );
   });
 
@@ -233,7 +241,7 @@ describe('setProducts', function () {
     const productParamsOverCapacity = { ...productParamsTemplate, product, productId };
     await expect(
       cover.connect(advisoryBoardMember0).setProducts([productParamsOverCapacity]), // should revert
-    ).to.be.revertedWith('Cover: capacityReductionRatio > 100%');
+    ).to.be.revertedWithCustomError(cover, 'CapacityReductionRatioAbove100Percent');
   });
 
   it('should fail to buy cover for deprecated product', async function () {
@@ -279,7 +287,7 @@ describe('setProducts', function () {
       cover.connect(coverBuyer).buyCover(buyCoverParams, [poolAllocationRequestTemplate], {
         value: expectedPremium,
       }),
-    ).to.be.revertedWith('Cover: Product is deprecated');
+    ).to.be.revertedWithCustomError(cover, 'ProductDeprecated');
   });
 
   it('should fail to edit cover for deprecated product', async function () {
@@ -331,7 +339,7 @@ describe('setProducts', function () {
     // edit cover
     await expect(
       cover.connect(coverBuyer).buyCover(editCoverParams, [poolAllocationRequestTemplate], { value: expectedPremium }),
-    ).to.be.revertedWith('Cover: Product is deprecated');
+    ).to.be.revertedWithCustomError(cover, 'ProductDeprecated');
   });
 
   it('should be able to buy cover on a previously deprecated product', async function () {

--- a/test/unit/StakingPool/depositTo.js
+++ b/test/unit/StakingPool/depositTo.js
@@ -87,9 +87,9 @@ describe('depositTo', function () {
 
     await stakingPool.connect(manager).setPoolPrivacy(true);
 
-    await expect(stakingPool.connect(user).depositTo(amount, trancheId, tokenId, destination)).to.be.revertedWith(
-      'StakingPool: The pool is private',
-    );
+    await expect(
+      stakingPool.connect(user).depositTo(amount, trancheId, tokenId, destination),
+    ).to.be.revertedWithCustomError(stakingPool, 'PrivatePool');
 
     await nxm.mint(manager.address, amount);
     await nxm.connect(manager).approve(tokenController.address, amount);
@@ -105,8 +105,9 @@ describe('depositTo', function () {
     const [user] = this.accounts.members;
     const { trancheId, tokenId, destination } = depositToFixture;
 
-    await expect(stakingPool.connect(user).depositTo(0, trancheId, tokenId, destination)).to.be.revertedWith(
-      'StakingPool: Insufficient deposit amount',
+    await expect(stakingPool.connect(user).depositTo(0, trancheId, tokenId, destination)).to.be.revertedWithCustomError(
+      stakingPool,
+      'InsufficientDepositAmount',
     );
   });
 
@@ -118,9 +119,9 @@ describe('depositTo', function () {
     const { maxTranche } = await getTranches(DEFAULT_PERIOD, DEFAULT_GRACE_PERIOD);
     const trancheId = maxTranche + 1;
 
-    await expect(stakingPool.connect(user).depositTo(amount, trancheId, tokenId, destination)).to.be.revertedWith(
-      'StakingPool: Requested tranche is not yet active',
-    );
+    await expect(
+      stakingPool.connect(user).depositTo(amount, trancheId, tokenId, destination),
+    ).to.be.revertedWithCustomError(stakingPool, 'RequestedTrancheIsNotYetActive');
   });
 
   it('reverts if requested tranche expired', async function () {
@@ -131,9 +132,9 @@ describe('depositTo', function () {
     const { firstActiveTrancheId } = await getTranches(DEFAULT_PERIOD, DEFAULT_GRACE_PERIOD);
     const trancheId = firstActiveTrancheId - 2;
 
-    await expect(stakingPool.connect(user).depositTo(amount, trancheId, tokenId, destination)).to.be.revertedWith(
-      'StakingPool: Requested tranche has expired',
-    );
+    await expect(
+      stakingPool.connect(user).depositTo(amount, trancheId, tokenId, destination),
+    ).to.be.revertedWithCustomError(stakingPool, 'RequestedTrancheIsExpired');
   });
 
   it('mints a new nft if token id is max uint', async function () {
@@ -615,6 +616,6 @@ describe('depositTo', function () {
 
     await expect(
       stakingPool.connect(user).depositTo(amount, firstActiveTrancheId, tokenId, destination),
-    ).to.be.revertedWith('Staking: NXM is locked for voting in governance');
+    ).to.be.revertedWithCustomError(stakingPool, 'NxmIsLockedForGovernanceVote');
   });
 });

--- a/test/unit/StakingPool/extendDeposit.js
+++ b/test/unit/StakingPool/extendDeposit.js
@@ -81,7 +81,7 @@ describe('extendDeposit', function () {
 
     await expect(
       stakingPool.connect(managerSigner).extendDeposit(MaxUint256, firstActiveTrancheId, maxTranche, 0),
-    ).to.be.revertedWith('StakingPool: Invalid token id');
+    ).to.be.revertedWithCustomError(stakingPool, 'InvalidTokenId');
   });
 
   it('reverts if new tranche ends before the initial tranche', async function () {
@@ -92,7 +92,7 @@ describe('extendDeposit', function () {
 
     await expect(
       stakingPool.connect(user).extendDeposit(depositNftId, maxTranche, firstActiveTrancheId, 0),
-    ).to.be.revertedWith('StakingPool: The chosen tranche cannot end before the initial one');
+    ).to.be.revertedWithCustomError(stakingPool, 'NewTrancheEndsBeforeInitialTranche');
   });
 
   it('reverts if new tranche is not yet available', async function () {
@@ -103,7 +103,7 @@ describe('extendDeposit', function () {
 
     await expect(
       stakingPool.connect(user).extendDeposit(depositNftId, firstActiveTrancheId, maxTranche + 1, 0),
-    ).to.be.revertedWith('StakingPool: The tranche is not yet available');
+    ).to.be.revertedWithCustomError(stakingPool, 'RequestedTrancheIsNotYetActive');
   });
 
   it('reverts if the new tranche already expired', async function () {
@@ -116,7 +116,7 @@ describe('extendDeposit', function () {
 
     await expect(
       stakingPool.connect(user).extendDeposit(depositNftId, firstActiveTrancheId, firstActiveTrancheId + 1, 0),
-    ).to.be.revertedWith('StakingPool: The tranche has already expired');
+    ).to.be.revertedWithCustomError(stakingPool, 'RequestedTrancheIsExpired');
   });
 
   it('reverts when the user is not token owner nor approved tries to extend the deposit', async function () {
@@ -128,7 +128,7 @@ describe('extendDeposit', function () {
       stakingPool
         .connect(notNFTOwnerNorApproved)
         .extendDeposit(depositNftId, firstActiveTrancheId, firstActiveTrancheId + 1, 0),
-    ).to.be.revertedWith('StakingPool: Not token owner or approved');
+    ).to.be.revertedWithCustomError(stakingPool, 'NotTokenOwnerOrApproved');
   });
 
   it('withdraws and make a new deposit if initial tranche is expired', async function () {
@@ -426,7 +426,7 @@ describe('extendDeposit', function () {
     const topUpAmount = parseEther('50');
     await expect(
       stakingPool.connect(user).extendDeposit(depositNftId, firstActiveTrancheId, maxTranche, topUpAmount),
-    ).to.be.revertedWith('StakingPool: The pool is private');
+    ).to.be.revertedWithCustomError(stakingPool, 'PrivatePool');
   });
 
   it('reverts if pool is private and tranche expired', async function () {
@@ -443,6 +443,6 @@ describe('extendDeposit', function () {
     const topUpAmount = parseEther('50');
     await expect(
       stakingPool.connect(user).extendDeposit(depositNftId, firstActiveTrancheId, maxTranche, topUpAmount),
-    ).to.be.revertedWith('StakingPool: The pool is private');
+    ).to.be.revertedWithCustomError(stakingPool, 'PrivatePool');
   });
 });

--- a/test/unit/StakingPool/initialize.js
+++ b/test/unit/StakingPool/initialize.js
@@ -39,7 +39,7 @@ describe('initialize', function () {
         poolId,
         ipfsDescriptionHash,
       ),
-    ).to.be.revertedWith('StakingPool: Only Cover contract can call this function');
+    ).to.be.revertedWithCustomError(stakingPool, 'OnlyCoverContract');
 
     const coverSigner = await ethers.getImpersonatedSigner(cover.address);
     await setEtherBalance(coverSigner.address, ethers.utils.parseEther('1'));
@@ -83,7 +83,7 @@ describe('initialize', function () {
           poolId,
           ipfsDescriptionHash,
         ),
-    ).to.be.revertedWith('StakingPool: Pool fee should not exceed max pool fee');
+    ).to.be.revertedWithCustomError(stakingPool, 'PoolFeeExceedsMax');
   });
 
   it('reverts if max pool fee is 100%', async function () {
@@ -111,7 +111,7 @@ describe('initialize', function () {
           poolId,
           ipfsDescriptionHash,
         ),
-    ).to.be.revertedWith('StakingPool: Max pool fee cannot be 100%');
+    ).to.be.revertedWithCustomError(stakingPool, 'MaxPoolFeeAbove100');
   });
 
   it('reverts if product target price is too high', async function () {
@@ -141,7 +141,7 @@ describe('initialize', function () {
           poolId,
           ipfsDescriptionHash,
         ),
-    ).to.be.revertedWith('StakingPool: Target price too high');
+    ).to.be.revertedWithCustomError(stakingPool, 'TargetPriceTooHigh');
 
     await expect(
       stakingPool
@@ -185,7 +185,7 @@ describe('initialize', function () {
           poolId,
           ipfsDescriptionHash,
         ),
-    ).to.be.revertedWith('StakingPool: Cannot set weight beyond 1');
+    ).to.be.revertedWithCustomError(stakingPool, 'TargetWeightTooHigh');
 
     await expect(
       stakingPool
@@ -234,7 +234,7 @@ describe('initialize', function () {
           poolId,
           ipfsDescriptionHash,
         ),
-    ).to.be.revertedWith('StakingPool: Total max target weight exceeded');
+    ).to.be.revertedWithCustomError(stakingPool, 'TotalTargetWeightExceeded');
 
     await expect(
       stakingPool
@@ -385,8 +385,9 @@ describe('initialize', function () {
       .to.emit(stakingPool, 'PoolDescriptionSet')
       .withArgs(poolId, 'newIPFSHash');
 
-    await expect(stakingPool.connect(nonManager).setPoolDescription('newIPFSHash')).to.be.revertedWith(
-      'StakingPool: Only pool manager can call this function',
+    await expect(stakingPool.connect(nonManager).setPoolDescription('newIPFSHash')).to.be.revertedWithCustomError(
+      stakingPool,
+      'OnlyManager',
     );
   });
 });

--- a/test/unit/StakingPool/requestAllocation.js
+++ b/test/unit/StakingPool/requestAllocation.js
@@ -422,7 +422,7 @@ describe('requestAllocation', function () {
 
     await expect(
       stakingPool.connect(user).requestAllocation(amount, previousPremium, allocationRequestParams),
-    ).to.be.revertedWith('StakingPool: Only Cover contract can call this function');
+    ).to.be.revertedWithCustomError(stakingPool, 'OnlyCoverContract');
   });
 
   it('correctly allocates capacity to the correct product and current tranche', async function () {
@@ -1015,7 +1015,7 @@ describe('requestAllocation', function () {
       stakingPool
         .connect(this.coverSigner)
         .requestAllocation(maxAllocationAmount.add(1), previousPremium, allocationRequestParams),
-    ).to.be.revertedWith('StakingPool: Insufficient capacity');
+    ).to.be.revertedWithCustomError(stakingPool, 'InsufficientCapacity');
 
     {
       const allocationAmount = parseEther('10');
@@ -1032,7 +1032,7 @@ describe('requestAllocation', function () {
       stakingPool
         .connect(this.coverSigner)
         .requestAllocation(maxAllocationAmount.add(1), previousPremium, allocationRequestParams),
-    ).to.be.revertedWith('StakingPool: Insufficient capacity');
+    ).to.be.revertedWithCustomError(stakingPool, 'InsufficientCapacity');
 
     {
       const allocationAmount = parseEther('20');
@@ -1049,7 +1049,7 @@ describe('requestAllocation', function () {
       stakingPool
         .connect(this.coverSigner)
         .requestAllocation(maxAllocationAmount.add(1), previousPremium, allocationRequestParams),
-    ).to.be.revertedWith('StakingPool: Insufficient capacity');
+    ).to.be.revertedWithCustomError(stakingPool, 'InsufficientCapacity');
 
     {
       const allocationAmount = parseEther('30');
@@ -1064,7 +1064,7 @@ describe('requestAllocation', function () {
     // exceed max allocation
     await expect(
       stakingPool.connect(this.coverSigner).requestAllocation(1, previousPremium, allocationRequestParams),
-    ).to.be.revertedWith('StakingPool: Insufficient capacity');
+    ).to.be.revertedWithCustomError(stakingPool, 'InsufficientCapacity');
   });
 
   it('updates expiring cover amounts', async function () {
@@ -1382,7 +1382,7 @@ describe('requestAllocation', function () {
       stakingPool
         .connect(this.coverSigner)
         .requestAllocation(maxAllocationAmount.add(1), previousPremium, allocationRequestParams),
-    ).to.be.revertedWith('StakingPool: Insufficient capacity');
+    ).to.be.revertedWithCustomError(stakingPool, 'InsufficientCapacity');
 
     const newGlobalCapacityRatio = 30000;
     maxAllocationAmount = depositAmount.mul(newGlobalCapacityRatio).div(GLOBAL_CAPACITY_DENOMINATOR);
@@ -1392,7 +1392,7 @@ describe('requestAllocation', function () {
         ...allocationRequestParams,
         globalCapacityRatio: newGlobalCapacityRatio,
       }),
-    ).to.be.revertedWith('StakingPool: Insufficient capacity');
+    ).to.be.revertedWithCustomError(stakingPool, 'InsufficientCapacity');
 
     await expect(
       stakingPool.connect(this.coverSigner).requestAllocation(maxAllocationAmount, previousPremium, {
@@ -1438,7 +1438,7 @@ describe('requestAllocation', function () {
         ...allocationRequestParams,
         productId: productId3,
       }),
-    ).to.be.revertedWith('StakingPool: Insufficient capacity');
+    ).to.be.revertedWithCustomError(stakingPool, 'InsufficientCapacity');
 
     await expect(
       stakingPool.connect(this.coverSigner).requestAllocation(maxAllocationAmountProduct3, previousPremium, {
@@ -1476,7 +1476,7 @@ describe('requestAllocation', function () {
         ...allocationRequestParams,
         capacityReductionRatio,
       }),
-    ).to.be.revertedWith('StakingPool: Insufficient capacity');
+    ).to.be.revertedWithCustomError(stakingPool, 'InsufficientCapacity');
 
     await expect(
       stakingPool.connect(this.coverSigner).requestAllocation(maxAllocationAmount.add(1), previousPremium, {

--- a/test/unit/StakingPool/setPoolFee.js
+++ b/test/unit/StakingPool/setPoolFee.js
@@ -72,8 +72,9 @@ describe('setPoolFee', function () {
       },
     } = this;
 
-    await expect(stakingPool.connect(nonManager).setPoolFee(5)).to.be.revertedWith(
-      'StakingPool: Only pool manager can call this function',
+    await expect(stakingPool.connect(nonManager).setPoolFee(5)).to.be.revertedWithCustomError(
+      stakingPool,
+      'OnlyManager',
     );
     await expect(stakingPool.connect(manager).setPoolFee(5)).to.not.be.reverted;
   });
@@ -85,8 +86,9 @@ describe('setPoolFee', function () {
     } = this;
     const { maxPoolFee } = initializeParams;
 
-    await expect(stakingPool.connect(manager).setPoolFee(maxPoolFee + 1)).to.be.revertedWith(
-      'StakingPool: new fee exceeds max fee',
+    await expect(stakingPool.connect(manager).setPoolFee(maxPoolFee + 1)).to.be.revertedWithCustomError(
+      stakingPool,
+      'PoolFeeExceedsMax',
     );
     await expect(stakingPool.connect(manager).setPoolFee(maxPoolFee)).to.not.be.reverted;
   });

--- a/test/unit/StakingPool/setPoolPrivacy.js
+++ b/test/unit/StakingPool/setPoolPrivacy.js
@@ -53,8 +53,9 @@ describe('setPoolPrivacy', function () {
       },
     } = this;
 
-    await expect(stakingPool.connect(nonManager).setPoolPrivacy(true)).to.be.revertedWith(
-      'StakingPool: Only pool manager can call this function',
+    await expect(stakingPool.connect(nonManager).setPoolPrivacy(true)).to.be.revertedWithCustomError(
+      stakingPool,
+      'OnlyManager',
     );
     await expect(stakingPool.connect(manager).setPoolPrivacy(true)).to.not.be.reverted;
   });

--- a/test/unit/StakingPool/setProducts.js
+++ b/test/unit/StakingPool/setProducts.js
@@ -68,8 +68,9 @@ describe('setProducts unit tests', function () {
     await cover.initializeStaking(stakingPool.address, manager.address, false, 5, 5, [], 0, IPFS_DESCRIPTION_HASH);
     const product = { ...newProductTemplate };
     await cover.setProduct({ ...coverProductTemplate }, product.productId);
-    await expect(stakingPool.connect(nonManager).setProducts([product])).to.be.revertedWith(
-      'StakingPool: Only pool manager can call this function',
+    await expect(stakingPool.connect(nonManager).setProducts([product])).to.be.revertedWithCustomError(
+      stakingPool,
+      'OnlyManager',
     );
   });
 
@@ -139,7 +140,7 @@ describe('setProducts unit tests', function () {
         0,
         IPFS_DESCRIPTION_HASH,
       ),
-    ).to.be.revertedWith('StakingPool: Total max target weight exceeded');
+    ).to.be.revertedWithCustomError(stakingPool, 'TotalTargetWeightExceeded');
   });
 
   it('should set products and store values correctly', async function () {
@@ -166,8 +167,9 @@ describe('setProducts unit tests', function () {
     await cover.setProduct({ ...coverProductTemplate }, product.productId);
 
     product.recalculateEffectiveWeight = false;
-    await expect(stakingPool.connect(manager).setProducts([product])).to.be.revertedWith(
-      'StakingPool: Must recalculate effectiveWeight to edit targetWeight',
+    await expect(stakingPool.connect(manager).setProducts([product])).to.be.revertedWithCustomError(
+      stakingPool,
+      'MustRecalculateEffectiveWeight',
     );
   });
 
@@ -179,8 +181,9 @@ describe('setProducts unit tests', function () {
     const product = { ...newProductTemplate, setTargetPrice: false };
     await cover.setProduct({ ...coverProductTemplate }, product.productId);
 
-    await expect(stakingPool.connect(manager).setProducts([product])).to.be.revertedWith(
-      'StakingPool: Must set price for new products',
+    await expect(stakingPool.connect(manager).setProducts([product])).to.be.revertedWithCustomError(
+      stakingPool,
+      'MustSetPriceForNewProducts',
     );
   });
 
@@ -267,8 +270,9 @@ describe('setProducts unit tests', function () {
 
     await cover.setProduct({ ...coverProductTemplate }, newStakingProduct.productId);
 
-    await expect(stakingPool.connect(manager).setProducts([newStakingProduct])).to.be.revertedWith(
-      'StakingPool: Max total target weight exceeded',
+    await expect(stakingPool.connect(manager).setProducts([newStakingProduct])).to.be.revertedWithCustomError(
+      stakingPool,
+      'TotalTargetWeightExceeded',
     );
   });
 
@@ -289,7 +293,7 @@ describe('setProducts unit tests', function () {
         0,
         IPFS_DESCRIPTION_HASH,
       ),
-    ).to.be.revertedWith('StakingPool: Cannot set weight beyond 1');
+    ).to.be.revertedWithCustomError(stakingPool, 'TargetWeightTooHigh');
   });
 
   it('should fail to make product weight higher than 1', async function () {
@@ -299,8 +303,9 @@ describe('setProducts unit tests', function () {
     await cover.initializeStaking(stakingPool.address, manager.address, false, 5, 5, [], 0, IPFS_DESCRIPTION_HASH);
     const product = { ...newProductTemplate, targetWeight: 101 };
     await cover.setProduct({ ...coverProductTemplate }, product.productId);
-    await expect(stakingPool.connect(manager).setProducts([product])).to.be.revertedWith(
-      'StakingPool: Cannot set weight beyond 1',
+    await expect(stakingPool.connect(manager).setProducts([product])).to.be.revertedWithCustomError(
+      stakingPool,
+      'TargetWeightTooHigh',
     );
   });
 
@@ -339,8 +344,9 @@ describe('setProducts unit tests', function () {
     await stakingPool.connect(manager).setProducts([product]);
     product.recalculateEffectiveWeight = false;
     product.targetWeight = 100;
-    await expect(stakingPool.connect(manager).setProducts([product])).to.be.revertedWith(
-      'StakingPool: Must recalculate effectiveWeight to edit targetWeight',
+    await expect(stakingPool.connect(manager).setProducts([product])).to.be.revertedWithCustomError(
+      stakingPool,
+      'MustRecalculateEffectiveWeight',
     );
   });
 
@@ -399,8 +405,9 @@ describe('setProducts unit tests', function () {
     await cover.initializeStaking(stakingPool.address, manager.address, false, 5, 5, [], 0, IPFS_DESCRIPTION_HASH);
     const product = { ...newProductTemplate, targetPrice: 10001 };
     await cover.setProduct({ ...coverProductTemplate }, product.productId);
-    await expect(stakingPool.connect(manager).setProducts([product])).to.be.revertedWith(
-      'StakingPool: Target price too high',
+    await expect(stakingPool.connect(manager).setProducts([product])).to.be.revertedWithCustomError(
+      stakingPool,
+      'TargetPriceTooHigh',
     );
   });
 
@@ -423,8 +430,9 @@ describe('setProducts unit tests', function () {
     await cover.initializeStaking(stakingPool.address, manager.address, false, 5, 5, [], 0, IPFS_DESCRIPTION_HASH);
     const product = { ...newProductTemplate, targetPrice: GLOBAL_MIN_PRICE_RATIO - 1 };
     await cover.setProduct({ ...coverProductTemplate }, product.productId);
-    await expect(stakingPool.connect(manager).setProducts([product])).to.be.revertedWith(
-      'StakingPool: Target price below GLOBAL_MIN_PRICE_RATIO',
+    await expect(stakingPool.connect(manager).setProducts([product])).to.be.revertedWithCustomError(
+      stakingPool,
+      'TargetPriceBelowMin',
     );
   });
 
@@ -485,8 +493,9 @@ describe('setProducts unit tests', function () {
     products[10].targetWeight = 50;
     const newProducts = [products[10], { ...newProductTemplate, productId: 50 }];
     await cover.setProduct({ ...coverProductTemplate }, newProducts[1].productId);
-    await expect(stakingPool.connect(manager).setProducts(newProducts)).to.be.revertedWith(
-      'StakingPool: Max total target weight exceeded',
+    await expect(stakingPool.connect(manager).setProducts(newProducts)).to.be.revertedWithCustomError(
+      stakingPool,
+      'TotalTargetWeightExceeded',
     );
   });
 
@@ -549,8 +558,9 @@ describe('setProducts unit tests', function () {
       { ...newProductTemplate, productId: 50 },
     ];
     await cover.setProduct({ ...coverProductTemplate }, newProducts[1].productId);
-    await expect(stakingPool.connect(manager).setProducts(newProducts)).to.be.revertedWith(
-      'StakingPool: Max total target weight exceeded',
+    await expect(stakingPool.connect(manager).setProducts(newProducts)).to.be.revertedWithCustomError(
+      stakingPool,
+      'TotalTargetWeightExceeded',
     );
   });
 

--- a/test/unit/StakingPool/withdraw.js
+++ b/test/unit/StakingPool/withdraw.js
@@ -105,9 +105,7 @@ describe('withdraw', function () {
 
     await expect(
       stakingPool.connect(user).withdraw(tokenId, withdrawStake, withdrawRewards, trancheIds),
-    ).to.be.revertedWith(
-      'StakingPool: While the pool manager is locked for governance voting only rewards can be withdrawn',
-    );
+    ).to.be.revertedWithCustomError(stakingPool, 'ManagerNxmIsLockedForGovernanceVote');
   });
 
   it('allows to withdraw only stake', async function () {


### PR DESCRIPTION
## Context

Closes #402 

## Changes proposed in this pull request

Changed all require statements to throw a 4 byte custom error instead of the 32..n byte string errors.
Bytecode size with optimizer on:
Cover (before) : 23,478 Bytes
Cover (after):     21,466  Bytes
Staking (before): 25,849 Bytes
Staking (after): 23,572  Bytes

## Test plan

The chai matchers now expect custom errors to be used for Cover/StakingPool calls


## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [x] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
