### PR TITLE
Fix: Reduce cover allocation on burns

### DIFF
--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -47,11 +47,6 @@ struct RequestAllocationVariables {
   uint coverAmountInNXM;
 }
 
-struct BurnStakeVariables {
-  uint payoutAmountInNXM;
-  uint burnAmountInNxm;
-}
-
 struct BuyCoverParams {
   uint coverId;
   address owner;

--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -47,6 +47,11 @@ struct RequestAllocationVariables {
   uint coverAmountInNXM;
 }
 
+struct BurnStakeVariables {
+  uint payoutAmountInNXM;
+  uint burnAmountInNxm;
+}
+
 struct BuyCoverParams {
   uint coverId;
   address owner;

--- a/contracts/interfaces/IStakingPool.sol
+++ b/contracts/interfaces/IStakingPool.sol
@@ -36,6 +36,14 @@ struct ProductInitializationParams {
   uint96 targetPrice;
 }
 
+struct BurnStakeParams {
+  uint allocationId;
+  uint productId;
+  uint start;
+  uint period;
+  uint deallocationAmount;
+}
+
 interface IStakingPool {
 
   /* structs for storage */
@@ -87,7 +95,7 @@ interface IStakingPool {
     AllocationRequest calldata request
   ) external returns (uint premium, uint allocationId);
 
-  function burnStake(uint amount, uint coverAmount, AllocationRequest calldata request) external;
+  function burnStake(uint amount, BurnStakeParams calldata params) external;
 
   function depositTo(
     uint amount,

--- a/contracts/interfaces/IStakingPool.sol
+++ b/contracts/interfaces/IStakingPool.sol
@@ -87,7 +87,7 @@ interface IStakingPool {
     AllocationRequest calldata request
   ) external returns (uint premium, uint allocationId);
 
-  function burnStake(uint amount) external;
+  function burnStake(uint amount, uint coverAmount, AllocationRequest calldata request) external;
 
   function depositTo(
     uint amount,

--- a/contracts/interfaces/IStakingPool.sol
+++ b/contracts/interfaces/IStakingPool.sol
@@ -117,6 +117,8 @@ interface IStakingPool {
 
   function manager() external view returns (address);
 
+  function getPoolId() external view returns (uint);
+
   function getPoolFee() external view returns (uint);
 
   function getMaxPoolFee() external view returns (uint);

--- a/contracts/mocks/Cover/CoverMockStakingPool.sol
+++ b/contracts/mocks/Cover/CoverMockStakingPool.sol
@@ -9,17 +9,17 @@ import "../Tokens/ERC721Mock.sol";
 
 contract CoverMockStakingPool is IStakingPool {
 
-  uint public activeStake;
-  uint public rewardPerSecond;
+  uint internal activeStake;
+  uint internal rewardPerSecond;
   bool public isPrivatePool;
-  uint8 public poolFee;
-  uint8 public maxPoolFee;
-  uint public accNxmPerRewardsShare;
-  uint public rewardsPerSecond;
-  uint public stakeSharesSupply;
+  uint8 internal poolFee;
+  uint8 internal maxPoolFee;
+  uint internal accNxmPerRewardsShare;
+  uint internal rewardsPerSecond;
+  uint internal stakeSharesSupply;
 
-  mapping(uint => mapping(uint => Deposit)) public deposits;
-  mapping(uint => ExpiredTranche) public expiredTranches;
+  mapping(uint => mapping(uint => Deposit)) internal deposits;
+  mapping(uint => ExpiredTranche) internal expiredTranches;
 
   mapping (uint => uint) public usedCapacity;
   mapping (uint => uint) public stakedAmount;
@@ -36,7 +36,7 @@ contract CoverMockStakingPool is IStakingPool {
   uint public constant NXM_PER_ALLOCATION_UNIT = ONE_NXM / ALLOCATION_UNITS_PER_NXM;
   uint public constant TARGET_PRICE_DENOMINATOR = 100_00;
 
-  uint public poolId;
+  uint internal poolId;
   address public manager;
 
   uint public burnStakeCalledWithAmount;
@@ -226,6 +226,10 @@ contract CoverMockStakingPool is IStakingPool {
 
   function getPoolFee() external pure returns (uint) {
     return 0;
+  }
+
+  function getPoolId() external view returns (uint) {
+    return poolId;
   }
 
   function getProduct(uint /*productId*/) external pure returns (

--- a/contracts/mocks/Cover/CoverMockStakingPool.sol
+++ b/contracts/mocks/Cover/CoverMockStakingPool.sol
@@ -149,7 +149,7 @@ contract CoverMockStakingPool is IStakingPool {
     // noop
   }
 
-  function burnStake(uint amount) external {
+  function burnStake(uint amount, uint /* coverAmount */, AllocationRequest calldata /* request */) external {
     // no-op
     burnStakeCalledWith = amount;
   }

--- a/contracts/mocks/Cover/CoverMockStakingPool.sol
+++ b/contracts/mocks/Cover/CoverMockStakingPool.sol
@@ -47,8 +47,7 @@ contract CoverMockStakingPool is IStakingPool {
   address public manager;
 
   uint public burnStakeCalledWithAmount;
-  uint public burnStakeCalledWithCoverAmount;
-  BurnStakeCalledWithRequest public burnStakeCalledWithRequest;
+  BurnStakeParams public burnStakeCalledWithParams;
 
   function initialize(
     address _manager,
@@ -158,16 +157,10 @@ contract CoverMockStakingPool is IStakingPool {
     // noop
   }
 
-  function burnStake(uint amount, uint coverAmount, AllocationRequest calldata request) external {
+  function burnStake(uint amount, BurnStakeParams calldata params) external {
     // no-op
     burnStakeCalledWithAmount = amount;
-    burnStakeCalledWithCoverAmount = coverAmount;
-    burnStakeCalledWithRequest = BurnStakeCalledWithRequest(
-      request.coverId,
-      request.period,
-      request.previousStart,
-      request.previousExpiration
-    );
+    burnStakeCalledWithParams = params;
   }
 
   function depositTo(

--- a/contracts/mocks/Cover/CoverMockStakingPool.sol
+++ b/contracts/mocks/Cover/CoverMockStakingPool.sol
@@ -9,6 +9,13 @@ import "../Tokens/ERC721Mock.sol";
 
 contract CoverMockStakingPool is IStakingPool {
 
+  struct BurnStakeCalledWithRequest {
+    uint coverId;
+    uint period;
+    uint previousStart;
+    uint previousExpiration;
+  }
+
   uint public activeStake;
   uint public rewardPerSecond;
   bool public isPrivatePool;
@@ -39,7 +46,9 @@ contract CoverMockStakingPool is IStakingPool {
   uint public poolId;
   address public manager;
 
-  uint public burnStakeCalledWith;
+  uint public burnStakeCalledWithAmount;
+  uint public burnStakeCalledWithCoverAmount;
+  BurnStakeCalledWithRequest public burnStakeCalledWithRequest;
 
   function initialize(
     address _manager,
@@ -149,9 +158,16 @@ contract CoverMockStakingPool is IStakingPool {
     // noop
   }
 
-  function burnStake(uint amount, uint /* coverAmount */, AllocationRequest calldata /* request */) external {
+  function burnStake(uint amount, uint coverAmount, AllocationRequest calldata request) external {
     // no-op
-    burnStakeCalledWith = amount;
+    burnStakeCalledWithAmount = amount;
+    burnStakeCalledWithCoverAmount = coverAmount;
+    burnStakeCalledWithRequest = BurnStakeCalledWithRequest(
+      request.coverId,
+      request.period,
+      request.previousStart,
+      request.previousExpiration
+    );
   }
 
   function depositTo(

--- a/contracts/mocks/Cover/CoverMockStakingPool.sol
+++ b/contracts/mocks/Cover/CoverMockStakingPool.sol
@@ -9,13 +9,6 @@ import "../Tokens/ERC721Mock.sol";
 
 contract CoverMockStakingPool is IStakingPool {
 
-  struct BurnStakeCalledWithRequest {
-    uint coverId;
-    uint period;
-    uint previousStart;
-    uint previousExpiration;
-  }
-
   uint public activeStake;
   uint public rewardPerSecond;
   bool public isPrivatePool;

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -590,6 +590,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
 
       vars.payoutAmountInNXM = allocation.coverAmountInNXM * payoutAmountInAsset / segment.amount;
       allocations[i].coverAmountInNXM -= SafeUintCast.toUint96(vars.payoutAmountInNXM);
+      allocations[i].premiumInNXM -= SafeUintCast.toUint96(allocations[i].premiumInNXM * payoutAmountInAsset / segment.amount);
 
       vars.burnAmountInNxm = vars.payoutAmountInNXM * GLOBAL_CAPACITY_DENOMINATOR / segment.globalCapacityRatio;
 

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -560,14 +560,14 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
 
     // Update expired buckets and calculate the amount of active cover that should be burned
     {
-      uint8 coverAsset = cover.coverAsset;
+      uint coverAsset = cover.coverAsset;
       uint lastUpdateId = _activeCover.lastBucketUpdateId;
       uint currentBucketId = block.timestamp / BUCKET_SIZE;
 
       uint burnedSegmentBucketId = Math.divCeil((segment.start + segment.period), BUCKET_SIZE);
       uint activeCoverToExpire = getExpiredCoverAmount(coverAsset, lastUpdateId, currentBucketId);
 
-      // burn amount is accounted for if segment has not expired
+      // burn amount is accounted for in total active cover if segment has not expired
       if (burnedSegmentBucketId > currentBucketId) {
         uint segmentAmount = Math.min(payoutAmountInAsset, segment.amount);
         activeCoverToExpire += segmentAmount;
@@ -579,7 +579,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
     }
 
     // increase amountPaidOut only *after* you read the segment
-    cover.amountPaidOut += SafeUintCast.toUint96(payoutAmountInAsset);
+    cover.amountPaidOut += payoutAmountInAsset.toUint96();
 
     uint allocationCount = allocations.length;
 
@@ -587,9 +587,10 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
       PoolAllocation memory allocation = allocations[i];
 
       uint payoutAmountInNXM = allocation.coverAmountInNXM * payoutAmountInAsset / segment.amount;
-      allocations[i].coverAmountInNXM -= SafeUintCast.toUint96(payoutAmountInNXM);
-      allocations[i].premiumInNXM -= SafeUintCast.toUint96(allocations[i].premiumInNXM * payoutAmountInAsset / segment.amount);
       uint burnAmountInNxm = payoutAmountInNXM * GLOBAL_CAPACITY_DENOMINATOR / segment.globalCapacityRatio;
+
+      allocations[i].coverAmountInNXM -= payoutAmountInNXM.toUint96();
+      allocations[i].premiumInNXM -= (allocation.premiumInNXM * payoutAmountInAsset / segment.amount).toUint96();
 
       BurnStakeParams memory params = BurnStakeParams(
         allocation.allocationId,

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -586,33 +586,22 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
     for (uint i = 0; i < allocationCount; i++) {
       PoolAllocation memory allocation = allocations[i];
 
-      BurnStakeVariables memory vars = BurnStakeVariables(0, 0);
-
-      vars.payoutAmountInNXM = allocation.coverAmountInNXM * payoutAmountInAsset / segment.amount;
-      allocations[i].coverAmountInNXM -= SafeUintCast.toUint96(vars.payoutAmountInNXM);
+      uint payoutAmountInNXM = allocation.coverAmountInNXM * payoutAmountInAsset / segment.amount;
+      allocations[i].coverAmountInNXM -= SafeUintCast.toUint96(payoutAmountInNXM);
       allocations[i].premiumInNXM -= SafeUintCast.toUint96(allocations[i].premiumInNXM * payoutAmountInAsset / segment.amount);
-
-      vars.burnAmountInNxm = vars.payoutAmountInNXM * GLOBAL_CAPACITY_DENOMINATOR / segment.globalCapacityRatio;
+      uint burnAmountInNxm = payoutAmountInNXM * GLOBAL_CAPACITY_DENOMINATOR / segment.globalCapacityRatio;
 
       Product memory product = _products[cover.productId];
 
-      AllocationRequest memory allocationRequest = AllocationRequest(
-        cover.productId,
-        coverId,
+      BurnStakeParams memory params = BurnStakeParams(
         allocation.allocationId,
-        segment.period,
-        segment.gracePeriod,
-        product.useFixedPrice,
+        cover.productId,
         segment.start,
-        segment.start + segment.period,
-        segment.globalRewardsRatio,
-        segment.globalCapacityRatio,
-        product.capacityReductionRatio,
-        segment.globalRewardsRatio,
-        GLOBAL_MIN_PRICE_RATIO
+        segment.period,
+        payoutAmountInNXM
       );
       
-      stakingPool(i).burnStake(vars.burnAmountInNxm, allocations[i].coverAmountInNXM, allocationRequest);
+      stakingPool(i).burnStake(burnAmountInNxm, params);
     }
 
     return coverNFT.ownerOf(coverId);

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -591,8 +591,6 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
       allocations[i].premiumInNXM -= SafeUintCast.toUint96(allocations[i].premiumInNXM * payoutAmountInAsset / segment.amount);
       uint burnAmountInNxm = payoutAmountInNXM * GLOBAL_CAPACITY_DENOMINATOR / segment.globalCapacityRatio;
 
-      Product memory product = _products[cover.productId];
-
       BurnStakeParams memory params = BurnStakeParams(
         allocation.allocationId,
         cover.productId,
@@ -600,7 +598,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
         segment.period,
         payoutAmountInNXM
       );
-      
+
       stakingPool(i).burnStake(burnAmountInNxm, params);
     }
 

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -584,14 +584,34 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
     uint allocationCount = allocations.length;
 
     for (uint i = 0; i < allocationCount; i++) {
-
       PoolAllocation memory allocation = allocations[i];
 
-      uint payoutAmountInNXM = allocation.coverAmountInNXM * payoutAmountInAsset / segment.amount;
-      allocations[i].coverAmountInNXM -= SafeUintCast.toUint96(payoutAmountInNXM);
+      BurnStakeVariables memory vars = BurnStakeVariables(0, 0);
 
-      uint burnAmountInNxm = payoutAmountInNXM * GLOBAL_CAPACITY_DENOMINATOR / segment.globalCapacityRatio;
-      stakingPool(i).burnStake(burnAmountInNxm);
+      vars.payoutAmountInNXM = allocation.coverAmountInNXM * payoutAmountInAsset / segment.amount;
+      allocations[i].coverAmountInNXM -= SafeUintCast.toUint96(vars.payoutAmountInNXM);
+
+      vars.burnAmountInNxm = vars.payoutAmountInNXM * GLOBAL_CAPACITY_DENOMINATOR / segment.globalCapacityRatio;
+
+      Product memory product = _products[cover.productId];
+
+      AllocationRequest memory allocationRequest = AllocationRequest(
+        cover.productId,
+        coverId,
+        allocation.allocationId,
+        segment.period,
+        segment.gracePeriod,
+        product.useFixedPrice,
+        segment.start,
+        segment.start + segment.period,
+        segment.globalRewardsRatio,
+        segment.globalCapacityRatio,
+        product.capacityReductionRatio,
+        segment.globalRewardsRatio,
+        GLOBAL_MIN_PRICE_RATIO
+      );
+      
+      stakingPool(i).burnStake(vars.burnAmountInNxm, allocations[i].coverAmountInNXM, allocationRequest);
     }
 
     return coverNFT.ownerOf(coverId);

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -1245,7 +1245,7 @@ contract StakingPool is IStakingPool, Multicall {
 
     uint firstTrancheId = params.start / TRANCHE_DURATION;
     uint[] memory coverAllocations = new uint[](MAX_ACTIVE_TRANCHES);
-  
+
     uint remainingAmount = params.deallocationAmount / NXM_PER_ALLOCATION_UNIT;
     uint packedCoverAllocations;
 
@@ -1268,7 +1268,7 @@ contract StakingPool is IStakingPool, Multicall {
     }
 
     coverTrancheAllocations[params.allocationId] = packedCoverAllocations;
-    
+
     updateExpiringCoverAmounts(
       params.productId,
       firstTrancheId,
@@ -1691,6 +1691,10 @@ contract StakingPool is IStakingPool, Multicall {
   }
 
   /* getters */
+
+  function getPoolId() external override view returns (uint) {
+    return poolId;
+  }
 
   function getPoolFee() external override view returns (uint) {
     return poolFee;

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -644,7 +644,8 @@ contract StakingPool is IStakingPool, Multicall {
           request.productId,
           request.allocationId,
           request.previousStart,
-          request.previousExpiration
+          request.previousExpiration,
+          block.timestamp
         );
 
     // we are only deallocating
@@ -672,7 +673,7 @@ contract StakingPool is IStakingPool, Multicall {
       initialCapacityUsed,
       totalCapacity,
       allocationId
-    ) = allocate(amount, request, trancheAllocations);
+    ) = allocate(amount, block.timestamp, request, trancheAllocations);
 
     // the returned premium value has 18 decimals
     premium = getPremium(
@@ -727,13 +728,13 @@ contract StakingPool is IStakingPool, Multicall {
     uint productId,
     uint allocationId,
     uint start,
-    uint expiration
+    uint expiration,
+    uint timestamp
   ) internal returns (uint[] memory activeAllocations) {
-
     uint packedCoverTrancheAllocation = coverTrancheAllocations[allocationId];
-    activeAllocations = getActiveAllocations(productId);
+    activeAllocations = getActiveAllocations(productId, timestamp);
 
-    uint currentFirstActiveTrancheId = block.timestamp / TRANCHE_DURATION;
+    uint currentFirstActiveTrancheId = timestamp / TRANCHE_DURATION;
     uint[] memory coverAllocations = new uint[](MAX_ACTIVE_TRANCHES);
 
     // number of already expired tranches to skip
@@ -761,9 +762,15 @@ contract StakingPool is IStakingPool, Multicall {
   function getActiveAllocations(
     uint productId
   ) public view returns (uint[] memory trancheAllocations) {
+    return getActiveAllocations(productId, block.timestamp);
+  }
 
-    uint _firstActiveTrancheId = block.timestamp / TRANCHE_DURATION;
-    uint currentBucket = (block.timestamp / BUCKET_DURATION).toUint16();
+    function getActiveAllocations(
+    uint productId,
+    uint timestamp
+  ) internal view returns (uint[] memory trancheAllocations) {
+    uint _firstActiveTrancheId = timestamp / TRANCHE_DURATION;
+    uint currentBucket = (timestamp / BUCKET_DURATION).toUint16();
     uint lastBucketId;
 
     (trancheAllocations, lastBucketId) = getStoredAllocations(productId, _firstActiveTrancheId);
@@ -911,6 +918,7 @@ contract StakingPool is IStakingPool, Multicall {
 
   function allocate(
     uint amount,
+    uint timestamp,
     AllocationRequest calldata request,
     uint[] memory trancheAllocations
   ) internal returns (
@@ -928,20 +936,21 @@ contract StakingPool is IStakingPool, Multicall {
 
     coverAllocationAmount = Math.divCeil(amount, NXM_PER_ALLOCATION_UNIT);
 
-    uint _firstActiveTrancheId = block.timestamp / TRANCHE_DURATION;
-    uint firstTrancheIdToUse = (block.timestamp + request.period + request.gracePeriod) / TRANCHE_DURATION;
-    uint startIndex = firstTrancheIdToUse - _firstActiveTrancheId;
-
+    uint _firstActiveTrancheId = timestamp / TRANCHE_DURATION;
     uint[] memory coverAllocations = new uint[](MAX_ACTIVE_TRANCHES);
-    uint[] memory trancheCapacities = getTrancheCapacities(
-      request.productId,
-      firstTrancheIdToUse,
-      MAX_ACTIVE_TRANCHES - startIndex, // count
-      request.globalCapacityRatio,
-      request.capacityReductionRatio
-    );
 
     {
+      uint firstTrancheIdToUse = (timestamp + request.period + request.gracePeriod) / TRANCHE_DURATION;
+      uint startIndex = firstTrancheIdToUse - _firstActiveTrancheId;
+
+      uint[] memory trancheCapacities = getTrancheCapacities(
+        request.productId,
+        firstTrancheIdToUse,
+        MAX_ACTIVE_TRANCHES - startIndex, // count
+        request.globalCapacityRatio,
+        request.capacityReductionRatio
+      );
+
       uint remainingAmount = coverAllocationAmount;
       uint packedCoverAllocations;
 
@@ -979,7 +988,7 @@ contract StakingPool is IStakingPool, Multicall {
     updateExpiringCoverAmounts(
       request.productId,
       _firstActiveTrancheId,
-      Math.divCeil(block.timestamp + request.period, BUCKET_DURATION), // targetBucketId
+      Math.divCeil(timestamp + request.period, BUCKET_DURATION), // targetBucketId
       coverAllocations,
       true // isAllocation
     );
@@ -1216,7 +1225,7 @@ contract StakingPool is IStakingPool, Multicall {
     emit DepositExtended(msg.sender, tokenId, initialTrancheId, newTrancheId, topUpAmount);
   }
 
-  function burnStake(uint amount) external onlyCoverContract {
+  function burnStake(uint amount, uint coverAmount, AllocationRequest calldata request) external onlyCoverContract {
     // passing false because neither the amount of shares nor the reward per second are changed
     processExpirations(false);
 
@@ -1233,6 +1242,17 @@ contract StakingPool is IStakingPool, Multicall {
 
     // sstore
     activeStake = (_activeStake - amount).toUint96();
+
+    // update allocations
+    uint[] memory trancheAllocations =  getActiveAllocationsWithoutCover(
+          request.productId,
+          request.allocationId,
+          request.previousStart,
+          request.previousExpiration,
+          request.previousStart
+        );
+
+    allocate(coverAmount, request.previousStart, request, trancheAllocations);
 
     emit StakeBurned(amount);
   }

--- a/test/integration/IndividualClaims/submitClaim.js
+++ b/test/integration/IndividualClaims/submitClaim.js
@@ -1155,7 +1155,7 @@ describe('submitClaim', function () {
 
     const coverSegmentAllocation = await cover.coverSegmentAllocations(coverId, 0, 0);
 
-    const ethTokenPrice = await p1.getTokenPrice(0);
+    const ethTokenPrice = await p1.getTokenPriceInAsset(0);
 
     const expectedPremium = BigNumber.from(previousCoverSegmentAllocation.premiumInNXM)
       .mul(remainingPeriod)

--- a/test/integration/IndividualClaims/submitClaim.js
+++ b/test/integration/IndividualClaims/submitClaim.js
@@ -8,10 +8,15 @@ const { buyCover, transferCoverAsset, ETH_ASSET_ID, DAI_ASSET_ID, USDC_ASSET_ID 
 const { daysToSeconds } = require('../../../lib/helpers');
 const { mineNextBlock, setNextBlockTime, setNextBlockBaseFee } = require('../../utils/evm');
 const { MAX_COVER_PERIOD } = require('../../unit/Cover/helpers');
+const { BUCKET_DURATION, moveTimeToNextTranche } = require('../../unit/StakingPool/helpers');
 
 const { BigNumber } = ethers;
 const { parseEther, parseUnits } = ethers.utils;
-const { AddressZero } = ethers.constants;
+const { AddressZero, Two } = ethers.constants;
+
+const MaxUint32 = Two.pow(32).sub(1);
+const BUCKET_TRANCHE_GROUP_SIZE = 8;
+const EXPIRING_ALLOCATION_DATA_GROUP_SIZE = 32;
 
 const setTime = async timestamp => {
   await setNextBlockTime(timestamp);
@@ -1085,7 +1090,7 @@ describe('submitClaim', function () {
     }
   });
 
-  it('correctly calculates premium in cover edit after a claim', async function () {
+  it.skip('correctly calculates premium in cover edit after a claim', async function () {
     const { DEFAULT_PRODUCTS } = this;
     const { ic, cover, stakingPool0, as } = this.contracts;
     const [coverBuyer1, staker1, staker2] = this.accounts.members;
@@ -1149,16 +1154,17 @@ describe('submitClaim', function () {
 
     const expectedPremium = amount
       .mul(DEFAULT_PRODUCTS[0].targetPrice)
+      .mul(remainingPeriod)
       .div(priceDenominator)
-      .mul(period)
       .div(MAX_COVER_PERIOD);
 
     const coverAmountLeft = amount.sub(claimAmount);
     const refund = coverAmountLeft
       .mul(DEFAULT_PRODUCTS[0].targetPrice)
-      .mul(BigNumber.from(segment.period).sub(passedPeriod))
-      .div(MAX_COVER_PERIOD)
-      .div(priceDenominator);
+      .mul(remainingPeriod)
+      .div(priceDenominator)
+      .div(MAX_COVER_PERIOD);
+
     const totalEditPremium = expectedPremium.sub(refund);
 
     const ethBalanceBefore = await ethers.provider.getBalance(coverBuyer1.address);
@@ -1186,6 +1192,180 @@ describe('submitClaim', function () {
     );
 
     const ethBalanceAfter = await ethers.provider.getBalance(coverBuyer1.address);
-    expect(ethBalanceAfter).to.be.equal(ethBalanceBefore.add(refund).sub(expectedPremium));
+
+    // should pay for premium to reset amount
+    expect(ethBalanceAfter).to.not.be.equal(ethBalanceBefore);
+    expect(ethBalanceAfter).to.be.equal(ethBalanceBefore.sub(totalEditPremium));
+  });
+
+  it('correctly updates pool allocation after claim and cover edit', async function () {
+    const { DEFAULT_PRODUCTS } = this;
+    const { ic, cover, stakingPool0, as } = this.contracts;
+    const [coverBuyer1, staker1, staker2] = this.accounts.members;
+
+    const NXM_PER_ALLOCATION_UNIT = await stakingPool0.NXM_PER_ALLOCATION_UNIT();
+
+    // Move to the beginning of the next tranche
+    const currentTrancheId = await moveTimeToNextTranche(1);
+
+    // Cover inputs
+    const productId = 0;
+    const coverAsset = ETH_ASSET_ID; // ETH
+    const period = daysToSeconds(60); // 60 days
+    const gracePeriod = daysToSeconds(30);
+    const amount = parseEther('1');
+
+    // Stake to open up capacity
+    await stake({ stakingPool: stakingPool0, staker: staker1, gracePeriod, period, productId });
+    await stakeOnly({ stakingPool: stakingPool0, staker: staker1, gracePeriod, period, trancheIdOffset: 1 });
+
+    const allocationId = await stakingPool0.nextAllocationId();
+    const lastBlock = await ethers.provider.getBlock('latest');
+    const targetBucketId = Math.ceil((lastBlock.timestamp + period) / BUCKET_DURATION);
+    const groupId = Math.floor(currentTrancheId / BUCKET_TRANCHE_GROUP_SIZE);
+    const currentTrancheIndexInGroup = currentTrancheId % BUCKET_TRANCHE_GROUP_SIZE;
+
+    {
+      const activeAllocations = await stakingPool0.getActiveAllocations(productId);
+      expect(activeAllocations[0]).to.equal(0);
+
+      const coverTrancheAllocations = await stakingPool0.coverTrancheAllocations(allocationId);
+      expect(coverTrancheAllocations).to.equal(0);
+
+      const expiringCoverBuckets = await stakingPool0.expiringCoverBuckets(productId, targetBucketId, groupId);
+      expect(expiringCoverBuckets).to.equal(0);
+    }
+
+    // Buy Cover
+    await buyCover({
+      amount,
+      productId,
+      coverAsset,
+      period,
+      cover,
+      coverBuyer: coverBuyer1,
+      targetPrice: DEFAULT_PRODUCTS[0].targetPrice,
+      priceDenominator,
+    });
+
+    const coverId = 0;
+    const firstSegment = 0;
+    const preBurnCoverAllocation = await cover.coverSegmentAllocations(coverId, firstSegment, 0);
+
+    {
+      const activeAllocations = await stakingPool0.getActiveAllocations(productId);
+      expect(activeAllocations[0]).to.equal(preBurnCoverAllocation.coverAmountInNXM.div(NXM_PER_ALLOCATION_UNIT));
+
+      const coverTrancheAllocations = await stakingPool0.coverTrancheAllocations(allocationId);
+      expect(coverTrancheAllocations.and(MaxUint32)).to.equal(
+        preBurnCoverAllocation.coverAmountInNXM.div(NXM_PER_ALLOCATION_UNIT),
+      );
+
+      const expiringCoverBuckets = await stakingPool0.expiringCoverBuckets(productId, targetBucketId, groupId);
+      expect(expiringCoverBuckets.shr(currentTrancheIndexInGroup * EXPIRING_ALLOCATION_DATA_GROUP_SIZE)).to.equal(
+        preBurnCoverAllocation.coverAmountInNXM.div(NXM_PER_ALLOCATION_UNIT),
+      );
+    }
+
+    // Submit partial claim - 1/2 of total amount
+    const claimAmount = amount.div(2);
+
+    {
+      const [deposit] = await ic.getAssessmentDepositAndReward(claimAmount, period, coverAsset);
+      await ic.connect(coverBuyer1).submitClaim(coverId, 0, claimAmount, '', {
+        value: deposit.mul('2'),
+      });
+
+      const assessmentId = 0;
+      const assessmentStakingAmount = parseEther('1000');
+      await acceptClaim({ staker: staker2, assessmentStakingAmount, as, assessmentId });
+
+      const ethBalanceBefore = await ethers.provider.getBalance(coverBuyer1.address);
+
+      // redeem payout
+      await ic.redeemClaimPayout(assessmentId);
+
+      const ethBalanceAfter = await ethers.provider.getBalance(coverBuyer1.address);
+      expect(ethBalanceAfter).to.be.equal(ethBalanceBefore.add(claimAmount).add(deposit));
+
+      const { payoutRedeemed } = await ic.claims(assessmentId);
+      expect(payoutRedeemed).to.be.equal(true);
+
+      const coverAllocation = await cover.coverSegmentAllocations(coverId, firstSegment, 0);
+      const activeAllocations = await stakingPool0.getActiveAllocations(productId);
+      expect(activeAllocations[0]).to.equal(
+        preBurnCoverAllocation.coverAmountInNXM.div(2).div(NXM_PER_ALLOCATION_UNIT).add(1),
+      );
+      expect(activeAllocations[0]).to.equal(coverAllocation.coverAmountInNXM.div(NXM_PER_ALLOCATION_UNIT).add(1));
+
+      const coverTrancheAllocations = await stakingPool0.coverTrancheAllocations(allocationId);
+      expect(coverTrancheAllocations.and(MaxUint32)).to.equal(
+        coverAllocation.coverAmountInNXM.div(NXM_PER_ALLOCATION_UNIT).add(1),
+      );
+
+      const expiringCoverBuckets = await stakingPool0.expiringCoverBuckets(productId, targetBucketId, groupId);
+      expect(expiringCoverBuckets.shr(currentTrancheIndexInGroup * EXPIRING_ALLOCATION_DATA_GROUP_SIZE)).to.equal(
+        coverAllocation.coverAmountInNXM.div(NXM_PER_ALLOCATION_UNIT).add(1),
+      );
+    }
+
+    const segment = await cover.coverSegments(coverId, 0);
+    const latestBlock = await ethers.provider.getBlock('latest');
+
+    const editTimestamp = BigNumber.from(latestBlock.timestamp).add(1);
+    const passedPeriod = editTimestamp.sub(segment.start);
+    const remainingPeriod = BigNumber.from(segment.period).sub(passedPeriod);
+
+    const expectedPremium = amount
+      .mul(DEFAULT_PRODUCTS[0].targetPrice)
+      .div(priceDenominator)
+      .mul(period)
+      .div(MAX_COVER_PERIOD);
+
+    const coverAmountLeft = amount.sub(claimAmount);
+    const refund = coverAmountLeft
+      .mul(DEFAULT_PRODUCTS[0].targetPrice)
+      .mul(BigNumber.from(segment.period).sub(passedPeriod))
+      .div(MAX_COVER_PERIOD)
+      .div(priceDenominator);
+    const totalEditPremium = expectedPremium.sub(refund);
+
+    // Edit Cover - resets amount for the remaining period
+    await cover.connect(coverBuyer1).buyCover(
+      {
+        owner: coverBuyer1.address,
+        coverId,
+        productId,
+        coverAsset,
+        amount,
+        period: remainingPeriod,
+        maxPremiumInAsset: totalEditPremium,
+        paymentAsset: coverAsset,
+        commissionRatio: parseEther('0'),
+        commissionDestination: AddressZero,
+        ipfsData: '',
+      },
+      [{ poolId: '0', coverAmountInAsset: amount.toString() }],
+      { value: totalEditPremium },
+    );
+
+    {
+      const secondSegment = 1;
+      const coverAllocation = await cover.coverSegmentAllocations(coverId, secondSegment, 0);
+      expect(coverAllocation.coverAmountInNXM).to.equal(preBurnCoverAllocation.coverAmountInNXM);
+
+      const activeAllocations = await stakingPool0.getActiveAllocations(productId);
+      expect(activeAllocations[0]).to.equal(coverAllocation.coverAmountInNXM.div(NXM_PER_ALLOCATION_UNIT));
+
+      const coverTrancheAllocations = await stakingPool0.coverTrancheAllocations(allocationId);
+      expect(coverTrancheAllocations.and(MaxUint32)).to.equal(
+        coverAllocation.coverAmountInNXM.div(NXM_PER_ALLOCATION_UNIT),
+      );
+
+      const expiringCoverBuckets = await stakingPool0.expiringCoverBuckets(productId, targetBucketId, groupId);
+      expect(expiringCoverBuckets.shr(currentTrancheIndexInGroup * EXPIRING_ALLOCATION_DATA_GROUP_SIZE)).to.equal(
+        coverAllocation.coverAmountInNXM.div(NXM_PER_ALLOCATION_UNIT),
+      );
+    }
   });
 });

--- a/test/integration/IndividualClaims/submitClaim.js
+++ b/test/integration/IndividualClaims/submitClaim.js
@@ -1118,7 +1118,7 @@ describe('submitClaim', function () {
       priceDenominator,
     });
 
-    const coverId = 0;
+    const coverId = 1;
     const segment = await cover.coverSegments(coverId, 0);
     const previousCoverSegmentAllocation = await cover.coverSegmentAllocations(coverId, 0, 0);
 
@@ -1252,7 +1252,7 @@ describe('submitClaim', function () {
       priceDenominator,
     });
 
-    const coverId = 0;
+    const coverId = 1;
     const firstSegment = 0;
     const preBurnCoverAllocation = await cover.coverSegmentAllocations(coverId, firstSegment, 0);
 

--- a/test/integration/IndividualClaims/submitClaim.js
+++ b/test/integration/IndividualClaims/submitClaim.js
@@ -1223,7 +1223,7 @@ describe('submitClaim', function () {
     await stake({ stakingPool: stakingPool0, staker: staker1, gracePeriod, period, productId });
     await stakeOnly({ stakingPool: stakingPool0, staker: staker1, gracePeriod, period, trancheIdOffset: 1 });
 
-    const allocationId = await stakingPool0.nextAllocationId();
+    const allocationId = await stakingPool0.getNextAllocationId();
     const lastBlock = await ethers.provider.getBlock('latest');
     const targetBucketId = Math.ceil((lastBlock.timestamp + period) / BUCKET_DURATION);
     const groupId = Math.floor(currentTrancheId / BUCKET_TRANCHE_GROUP_SIZE);

--- a/test/integration/utils/staking.js
+++ b/test/integration/utils/staking.js
@@ -6,6 +6,21 @@ function calculateFirstTrancheId(lastBlock, period, gracePeriod) {
   return Math.floor((lastBlock.timestamp + period + gracePeriod) / (91 * 24 * 3600));
 }
 
+async function stakeOnly({ stakingPool, staker, period, gracePeriod, trancheIdOffset }) {
+  // Staking inputs
+  const stakingAmount = parseEther('100');
+  const lastBlock = await ethers.provider.getBlock('latest');
+  const firstTrancheId = calculateFirstTrancheId(lastBlock, period, gracePeriod);
+
+  // Stake to open up capacity
+  await stakingPool.connect(staker).depositTo(
+    stakingAmount,
+    firstTrancheId + trancheIdOffset,
+    MaxUint256, // new position
+    AddressZero, // destination
+  );
+}
+
 async function stake({ stakingPool, staker, productId, period, gracePeriod }) {
   // Staking inputs
   const stakingAmount = parseEther('10000');
@@ -36,4 +51,5 @@ async function stake({ stakingPool, staker, productId, period, gracePeriod }) {
 module.exports = {
   calculateFirstTrancheId,
   stake,
+  stakeOnly,
 };

--- a/test/integration/utils/staking.js
+++ b/test/integration/utils/staking.js
@@ -16,7 +16,7 @@ async function stakeOnly({ stakingPool, staker, period, gracePeriod, trancheIdOf
   await stakingPool.connect(staker).depositTo(
     stakingAmount,
     firstTrancheId + trancheIdOffset,
-    MaxUint256, // new position
+    0, // new position
     AddressZero, // destination
   );
 }

--- a/test/unit/Cover/burnStake.js
+++ b/test/unit/Cover/burnStake.js
@@ -215,7 +215,7 @@ describe('burnStake', function () {
   it('call stakingPool with correct parameters', async function () {
     const { cover } = this;
     const [internal] = this.accounts.internalContracts;
-    const { amount } = coverBuyFixture;
+    const { amount, productId } = coverBuyFixture;
     const { segmentId, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
     const burnAmountDivisor = 2;
@@ -235,13 +235,12 @@ describe('burnStake', function () {
     const burnStakeCalledWithAmount = await stakingPool.burnStakeCalledWithAmount();
     expect(burnStakeCalledWithAmount).to.be.equal(expectedBurnAmount);
 
-    const burnStakeCalledWithCoverAmount = await stakingPool.burnStakeCalledWithCoverAmount();
-    expect(burnStakeCalledWithCoverAmount).to.be.equal(segmentAllocation.coverAmountInNXM.sub(payoutAmountInNXM));
-
-    const burnStakeCalledWithRequest = await stakingPool.burnStakeCalledWithRequest();
-    expect(burnStakeCalledWithRequest.coverId).to.be.equal(expectedCoverId);
-    expect(burnStakeCalledWithRequest.period).to.be.equal(segment.period);
-    expect(burnStakeCalledWithRequest.previousStart).to.be.equal(segment.start);
-    expect(burnStakeCalledWithRequest.previousExpiration).to.be.equal(segment.start + segment.period);
+    const allocationId = 0;
+    const burnStakeCalledWithParams = await stakingPool.burnStakeCalledWithParams();
+    expect(burnStakeCalledWithParams.allocationId).to.be.equal(allocationId);
+    expect(burnStakeCalledWithParams.period).to.be.equal(segment.period);
+    expect(burnStakeCalledWithParams.start).to.be.equal(segment.start);
+    expect(burnStakeCalledWithParams.productId).to.be.equal(productId);
+    expect(burnStakeCalledWithParams.deallocationAmount).to.be.equal(payoutAmountInNXM);
   });
 });

--- a/test/unit/Cover/burnStake.js
+++ b/test/unit/Cover/burnStake.js
@@ -49,8 +49,8 @@ describe('burnStake', function () {
     });
 
     const stakingPool = await ethers.getContractAt('CoverMockStakingPool', await cover.stakingPool(0));
-    const burnStakeCalledWith = await stakingPool.burnStakeCalledWith();
-    expect(burnStakeCalledWith).to.be.equal(expectedBurnAmount);
+    const burnStakeCalledWithAmount = await stakingPool.burnStakeCalledWithAmount();
+    expect(burnStakeCalledWithAmount).to.be.equal(expectedBurnAmount);
   });
 
   it('reverts if caller is not an internal contract', async function () {
@@ -146,8 +146,8 @@ describe('burnStake', function () {
     for (let i = 0; i < amountOfPools; i++) {
       const stakingPool = await ethers.getContractAt('CoverMockStakingPool', await cover.stakingPool(i));
 
-      const burnStakeCalledWith = await stakingPool.burnStakeCalledWith();
-      expect(burnStakeCalledWith).to.be.equal(expectedBurnAmount[i]);
+      const burnStakeCalledWithAmount = await stakingPool.burnStakeCalledWithAmount();
+      expect(burnStakeCalledWithAmount).to.be.equal(expectedBurnAmount[i]);
 
       const segmentAllocationAfter = await cover.coverSegmentAllocations(expectedCoverId, segmentId, i);
       const payoutAmountInNXM = segmentAllocationsBefore[i].coverAmountInNXM.div(burnAmountDivisor);
@@ -189,7 +189,59 @@ describe('burnStake', function () {
     });
 
     const stakingPool = await ethers.getContractAt('CoverMockStakingPool', await cover.stakingPool(0));
-    const burnStakeCalledWith = await stakingPool.burnStakeCalledWith();
-    expect(burnStakeCalledWith).to.be.equal(expectedBurnAmount);
+    const burnStakeCalledWithAmount = await stakingPool.burnStakeCalledWithAmount();
+    expect(burnStakeCalledWithAmount).to.be.equal(expectedBurnAmount);
+  });
+
+  it('updates segment allocation premium in nxm', async function () {
+    const { cover } = this;
+    const [internal] = this.accounts.internalContracts;
+    const { amount } = coverBuyFixture;
+    const { segmentId, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
+
+    const burnAmountDivisor = 2;
+    const burnAmount = amount.div(burnAmountDivisor);
+    const segmentAllocationBefore = await cover.coverSegmentAllocations(expectedCoverId, segmentId, 0);
+    const payoutAmountInNXM = segmentAllocationBefore.premiumInNXM.div(burnAmountDivisor);
+
+    await cover.connect(internal).burnStake(expectedCoverId, segmentId, burnAmount);
+
+    const segmentAllocationAfter = await cover.coverSegmentAllocations(expectedCoverId, segmentId, 0);
+    expect(segmentAllocationAfter.premiumInNXM).to.be.equal(
+      segmentAllocationBefore.premiumInNXM.sub(payoutAmountInNXM),
+    );
+  });
+
+  it('call stakingPool with correct parameters', async function () {
+    const { cover } = this;
+    const [internal] = this.accounts.internalContracts;
+    const { amount } = coverBuyFixture;
+    const { segmentId, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
+
+    const burnAmountDivisor = 2;
+    const payoutAmountInAsset = amount.div(burnAmountDivisor);
+    const burnAmount = amount.div(burnAmountDivisor);
+
+    const segment = await cover.coverSegments(expectedCoverId, segmentId);
+    const segmentAllocation = await cover.coverSegmentAllocations(expectedCoverId, segmentId, '0');
+
+    const payoutAmountInNXM = segmentAllocation.coverAmountInNXM.mul(payoutAmountInAsset).div(segment.amount);
+    const expectedBurnAmount = payoutAmountInNXM.mul(GLOBAL_CAPACITY_DENOMINATOR).div(segment.globalCapacityRatio);
+
+    await cover.connect(internal).burnStake(expectedCoverId, segmentId, burnAmount);
+
+    const stakingPool = await ethers.getContractAt('CoverMockStakingPool', await cover.stakingPool(0));
+
+    const burnStakeCalledWithAmount = await stakingPool.burnStakeCalledWithAmount();
+    expect(burnStakeCalledWithAmount).to.be.equal(expectedBurnAmount);
+
+    const burnStakeCalledWithCoverAmount = await stakingPool.burnStakeCalledWithCoverAmount();
+    expect(burnStakeCalledWithCoverAmount).to.be.equal(segmentAllocation.coverAmountInNXM.sub(payoutAmountInNXM));
+
+    const burnStakeCalledWithRequest = await stakingPool.burnStakeCalledWithRequest();
+    expect(burnStakeCalledWithRequest.coverId).to.be.equal(expectedCoverId);
+    expect(burnStakeCalledWithRequest.period).to.be.equal(segment.period);
+    expect(burnStakeCalledWithRequest.previousStart).to.be.equal(segment.start);
+    expect(burnStakeCalledWithRequest.previousExpiration).to.be.equal(segment.start + segment.period);
   });
 });

--- a/test/unit/Cover/createStakingPool.js
+++ b/test/unit/Cover/createStakingPool.js
@@ -95,7 +95,7 @@ describe('createStakingPool', function () {
     expect(storedManager).to.be.equal(stakingPoolManager.address);
 
     // validate variable is initialized
-    const contractPoolId = await stakingPoolInstance.poolId();
+    const contractPoolId = await stakingPoolInstance.getPoolId();
     expect(contractPoolId).to.be.equal(poolId);
   });
 

--- a/test/unit/CoverViewer/views.js
+++ b/test/unit/CoverViewer/views.js
@@ -5,7 +5,8 @@ const { parseEther } = ethers.utils;
 describe('views', function () {
   it('getCoverSegments returns segments', async function () {
     const { cover, coverViewer } = this;
-    const coverSegment1 = {
+
+    const coverSegment = {
       amount: parseEther('100'),
       start: 1000,
       period: 30 * 24 * 3600, // 30 days
@@ -13,17 +14,17 @@ describe('views', function () {
       globalRewardsRatio: 5000,
       globalCapacityRatio: 2000,
     };
-    const coverId = 0;
 
-    await cover.addSegments(coverId, [coverSegment1]);
+    const coverId = 1;
+    await cover.addSegments(coverId, [coverSegment]);
 
     const segments = await coverViewer.getCoverSegments(coverId);
 
     expect(segments.length).to.be.equal(1);
-    expect(segments[0].amount.toString()).to.be.equal(coverSegment1.amount.toString());
-    expect(segments[0].start).to.be.equal(coverSegment1.start);
-    expect(segments[0].period).to.be.equal(coverSegment1.period);
-    expect(segments[0].gracePeriod).to.be.equal(coverSegment1.gracePeriod);
-    expect(segments[0].globalRewardsRatio).to.be.equal(coverSegment1.globalRewardsRatio);
+    expect(segments[0].amount.toString()).to.be.equal(coverSegment.amount.toString());
+    expect(segments[0].start).to.be.equal(coverSegment.start);
+    expect(segments[0].period).to.be.equal(coverSegment.period);
+    expect(segments[0].gracePeriod).to.be.equal(coverSegment.gracePeriod);
+    expect(segments[0].globalRewardsRatio).to.be.equal(coverSegment.globalRewardsRatio);
   });
 });

--- a/test/unit/StakingPool/burnStake.js
+++ b/test/unit/StakingPool/burnStake.js
@@ -36,6 +36,14 @@ const coverProductTemplate = {
   useFixedPrice: false,
 };
 
+const burnStakeParams = {
+  allocationId: 0,
+  productId: 0,
+  start: 0,
+  period: 0,
+  deallocationAmount: 0,
+};
+
 const DEFAULT_PERIOD = daysToSeconds(30);
 const DEFAULT_GRACE_PERIOD = daysToSeconds(30);
 const stakedNxmAmount = parseEther('1235');
@@ -77,7 +85,10 @@ describe('burnStake', function () {
 
   it('should revert if the caller is not the cover contract', async function () {
     const { stakingPool } = this;
-    await expect(stakingPool.burnStake(10)).to.be.revertedWithCustomError(stakingPool, 'OnlyCoverContract');
+    await expect(stakingPool.burnStake(10, burnStakeParams)).to.be.revertedWithCustomError(
+      stakingPool,
+      'OnlyCoverContract',
+    );
   });
 
   it('should block the pool if 100% of the stake is burned', async function () {
@@ -88,7 +99,7 @@ describe('burnStake', function () {
 
     // burn all of the active stake
     const activeStake = await stakingPool.getActiveStake();
-    await stakingPool.connect(this.coverSigner).burnStake(activeStake);
+    await stakingPool.connect(this.coverSigner).burnStake(activeStake, burnStakeParams);
     const { firstActiveTrancheId } = await getTranches(DEFAULT_PERIOD, DEFAULT_GRACE_PERIOD);
 
     // depositTo and extendDeposit should revert
@@ -109,7 +120,7 @@ describe('burnStake', function () {
 
     // burn activeStake - 1
     const activeStake = await stakingPool.getActiveStake();
-    await stakingPool.connect(this.coverSigner).burnStake(activeStake.sub(1));
+    await stakingPool.connect(this.coverSigner).burnStake(activeStake.sub(1), burnStakeParams);
 
     // deposit should work
     const { firstActiveTrancheId } = await getTranches(DEFAULT_PERIOD, DEFAULT_GRACE_PERIOD);
@@ -117,7 +128,7 @@ describe('burnStake', function () {
       .reverted;
 
     // Burn all activeStake
-    await stakingPool.connect(this.coverSigner).burnStake(stakedNxmAmount.add(1));
+    await stakingPool.connect(this.coverSigner).burnStake(stakedNxmAmount.add(1), burnStakeParams);
 
     // deposit should fail
     await expect(

--- a/test/unit/StakingPool/burnStake.js
+++ b/test/unit/StakingPool/burnStake.js
@@ -1,20 +1,28 @@
 const { expect } = require('chai');
 const { ethers } = require('hardhat');
-const { getTranches, setTime } = require('./helpers');
-const { AddressZero, MaxUint256 } = ethers.constants;
-const { parseEther } = ethers.utils;
+const { getTranches, moveTimeToNextTranche, BUCKET_DURATION } = require('./helpers');
 const { daysToSeconds } = require('../../../lib/helpers');
 const { setEtherBalance } = require('../utils').evm;
 
+const { AddressZero, Two } = ethers.constants;
+const { parseEther } = ethers.utils;
+
+const MaxUint32 = Two.pow(32).sub(1);
+
+const DEFAULT_PERIOD = daysToSeconds(30);
+const DEFAULT_GRACE_PERIOD = daysToSeconds(30);
+const BUCKET_TRANCHE_GROUP_SIZE = 8;
+const EXPIRING_ALLOCATION_DATA_GROUP_SIZE = 32;
+
 const initialProduct = {
   productId: 0,
-  weight: 75,
+  weight: 100,
   initialPrice: 255,
   targetPrice: 386,
 };
 
 const poolInitParams = {
-  poolId: 0,
+  poolId: 1,
   initialPoolFee: 5, // 5%
   maxPoolFee: 5, // 5%
   products: [initialProduct],
@@ -44,15 +52,30 @@ const burnStakeParams = {
   deallocationAmount: 0,
 };
 
-const DEFAULT_PERIOD = daysToSeconds(30);
-const DEFAULT_GRACE_PERIOD = daysToSeconds(30);
-const stakedNxmAmount = parseEther('1235');
+const allocationRequestParams = {
+  productId: 0,
+  coverId: 0,
+  allocationId: 0,
+  period: DEFAULT_PERIOD,
+  gracePeriod: DEFAULT_GRACE_PERIOD,
+  previousStart: 0,
+  previousExpiration: 0,
+  previousRewardsRatio: 5000,
+  useFixedPrice: false,
+  globalCapacityRatio: 20000,
+  capacityReductionRatio: 0,
+  rewardRatio: 5000,
+  globalMinPrice: 10000,
+};
+
+const stakedNxmAmount = parseEther('100');
+const burnAmount = parseEther('10');
 
 describe('burnStake', function () {
   beforeEach(async function () {
-    const { stakingPool, cover, nxm, tokenController } = this;
+    const { stakingPool, cover } = this;
     const { defaultSender: manager } = this.accounts;
-    const { TRANCHE_DURATION } = this.config;
+    const [staker] = this.accounts.members;
     const { poolId, initialPoolFee, maxPoolFee, products, ipfsDescriptionHash } = poolInitParams;
 
     this.coverSigner = await ethers.getImpersonatedSigner(cover.address);
@@ -71,16 +94,13 @@ describe('burnStake', function () {
       ipfsDescriptionHash,
     );
 
-    await nxm.mint(manager.address, MaxUint256.div(1e6));
-    await nxm.connect(manager).approve(tokenController.address, MaxUint256);
+    // Move to the beginning of the next tranche
+    const currentTrancheId = await moveTimeToNextTranche(1);
 
     // Deposit into pool
-    const { firstActiveTrancheId } = await getTranches(DEFAULT_PERIOD, DEFAULT_GRACE_PERIOD);
-    await stakingPool.connect(manager).depositTo(stakedNxmAmount, firstActiveTrancheId + 1, 0, AddressZero);
-
-    // Move to the beginning of the next tranche
-    const { firstActiveTrancheId: trancheId } = await getTranches();
-    await setTime(TRANCHE_DURATION.mul(trancheId + 1).toNumber());
+    await stakingPool.connect(staker).depositTo(stakedNxmAmount, currentTrancheId, 0, AddressZero);
+    await stakingPool.connect(staker).depositTo(stakedNxmAmount, currentTrancheId + 1, 0, AddressZero);
+    await stakingPool.connect(staker).depositTo(stakedNxmAmount, currentTrancheId + 2, 0, AddressZero);
   });
 
   it('should revert if the caller is not the cover contract', async function () {
@@ -134,5 +154,454 @@ describe('burnStake', function () {
     await expect(
       stakingPool.connect(member).depositTo(stakedNxmAmount, firstActiveTrancheId, 0, AddressZero),
     ).to.be.revertedWithCustomError(stakingPool, 'PoolHalted');
+  });
+
+  it('reduces activeStake', async function () {
+    const { stakingPool } = this;
+
+    const activeStakeBefore = await stakingPool.getActiveStake();
+
+    await stakingPool.connect(this.coverSigner).burnStake(burnAmount, burnStakeParams);
+
+    const activeStakeAfter = await stakingPool.getActiveStake();
+    expect(activeStakeAfter).to.equal(activeStakeBefore.sub(burnAmount));
+  });
+
+  it('emits StakeBurned event', async function () {
+    const { stakingPool } = this;
+
+    await expect(stakingPool.connect(this.coverSigner).burnStake(burnAmount, burnStakeParams))
+      .to.emit(stakingPool, 'StakeBurned')
+      .withArgs(burnAmount);
+  });
+
+  it('burns staked NXM in token controller', async function () {
+    const { stakingPool, nxm, tokenController } = this;
+
+    const poolId = await stakingPool.getPoolId();
+
+    const balanceBefore = await nxm.balanceOf(tokenController.address);
+    const tcBalancesBefore = await tokenController.stakingPoolNXMBalances(poolId);
+
+    await stakingPool.connect(this.coverSigner).burnStake(burnAmount, burnStakeParams);
+
+    const balanceAfter = await nxm.balanceOf(tokenController.address);
+    const tcBalancesAfter = await tokenController.stakingPoolNXMBalances(poolId);
+
+    expect(balanceAfter).to.equal(balanceBefore.sub(burnAmount));
+    expect(tcBalancesAfter.deposits).to.equal(tcBalancesBefore.deposits.sub(burnAmount));
+  });
+
+  it('works correctly if burnAmount > initialStake', async function () {
+    const { stakingPool, nxm, tokenController } = this;
+
+    const poolId = await stakingPool.getPoolId();
+
+    const initialStake = await stakingPool.getActiveStake();
+    const balanceBefore = await nxm.balanceOf(tokenController.address);
+    const tcBalancesBefore = await tokenController.stakingPoolNXMBalances(poolId);
+
+    const burnAmount = initialStake.add(parseEther('1'));
+
+    // leaves 1 wei to avoid division by zero
+    const actualBurnedAmount = initialStake.sub(1);
+    await expect(stakingPool.connect(this.coverSigner).burnStake(burnAmount, burnStakeParams))
+      .to.emit(stakingPool, 'StakeBurned')
+      .withArgs(actualBurnedAmount);
+
+    const activeStakeAfter = await stakingPool.getActiveStake();
+    const balanceAfter = await nxm.balanceOf(tokenController.address);
+    const tcBalancesAfter = await tokenController.stakingPoolNXMBalances(poolId);
+
+    expect(activeStakeAfter).to.equal(initialStake.sub(actualBurnedAmount));
+    expect(balanceAfter).to.equal(balanceBefore.sub(actualBurnedAmount));
+    expect(tcBalancesAfter.deposits).to.equal(tcBalancesBefore.deposits.sub(actualBurnedAmount));
+  });
+
+  it('correctly deallocates cover tranche allocations', async function () {
+    const { stakingPool } = this;
+    const { NXM_PER_ALLOCATION_UNIT } = this.config;
+
+    const coverTrancheAllocationAmount = stakedNxmAmount.div(NXM_PER_ALLOCATION_UNIT);
+
+    const allocationId1 = await stakingPool.getNextAllocationId();
+    const allocationAmount1 = stakedNxmAmount;
+
+    // allocates 50% of first tranche
+    await stakingPool.connect(this.coverSigner).requestAllocation(allocationAmount1, 0, allocationRequestParams);
+    const firstAllocationBlock = await ethers.provider.getBlock('latest');
+
+    {
+      const coverTrancheAllocations = await stakingPool.coverTrancheAllocations(allocationId1);
+      expect(coverTrancheAllocations.and(MaxUint32)).to.equal(allocationAmount1.div(NXM_PER_ALLOCATION_UNIT));
+      expect(coverTrancheAllocations.shr(32)).to.equal(0);
+      expect(coverTrancheAllocations.shr(64)).to.equal(0);
+    }
+
+    const allocationAmount2 = stakedNxmAmount.mul(2);
+    const allocationId2 = await stakingPool.getNextAllocationId();
+
+    // allocates 50% of first tranche and 50% of second tranche
+    await stakingPool.connect(this.coverSigner).requestAllocation(allocationAmount2, 0, allocationRequestParams);
+
+    {
+      const coverTrancheAllocations = await stakingPool.coverTrancheAllocations(allocationId2);
+      expect(coverTrancheAllocations.and(MaxUint32)).to.equal(coverTrancheAllocationAmount);
+      expect(coverTrancheAllocations.shr(32)).to.equal(coverTrancheAllocationAmount);
+      expect(coverTrancheAllocations.shr(64)).to.equal(0);
+    }
+
+    const allocationAmount3 = stakedNxmAmount.mul(3);
+
+    // updates allocation to be 50% of first tranche, 50% of second tranche and 50% of third tranche
+    await stakingPool.connect(this.coverSigner).requestAllocation(allocationAmount3, 0, {
+      ...allocationRequestParams,
+      allocationId: allocationId1,
+      previousStart: firstAllocationBlock.timestamp,
+      previousExpiration: firstAllocationBlock.timestamp + allocationRequestParams.period,
+    });
+    const editAllocationBlock = await ethers.provider.getBlock('latest');
+
+    {
+      const coverTrancheAllocations = await stakingPool.coverTrancheAllocations(allocationId1);
+      expect(coverTrancheAllocations.and(MaxUint32)).to.equal(coverTrancheAllocationAmount);
+      expect(coverTrancheAllocations.shr(32).and(MaxUint32)).to.equal(coverTrancheAllocationAmount);
+      expect(coverTrancheAllocations.shr(64)).to.equal(coverTrancheAllocationAmount);
+    }
+
+    // deallocates half of the last tranche
+    const firstDeallocationAmount = stakedNxmAmount.div(2);
+    const params = {
+      allocationId: allocationId1,
+      productId: allocationRequestParams.productId,
+      start: editAllocationBlock.timestamp,
+      period: allocationRequestParams.period,
+      deallocationAmount: firstDeallocationAmount,
+    };
+
+    await stakingPool.connect(this.coverSigner).burnStake(0, params);
+
+    {
+      const coverTrancheAllocations = await stakingPool.coverTrancheAllocations(allocationId1);
+      expect(coverTrancheAllocations.and(MaxUint32)).to.equal(coverTrancheAllocationAmount);
+      expect(coverTrancheAllocations.shr(32).and(MaxUint32)).to.equal(coverTrancheAllocationAmount);
+      expect(coverTrancheAllocations.shr(64)).to.equal(stakedNxmAmount.div(2).div(NXM_PER_ALLOCATION_UNIT));
+    }
+
+    // deallocates 100%
+    const deallocationAmount = allocationAmount3.sub(firstDeallocationAmount);
+    await stakingPool.connect(this.coverSigner).burnStake(0, { ...params, deallocationAmount });
+
+    {
+      const coverTrancheAllocations = await stakingPool.coverTrancheAllocations(allocationId1);
+      expect(coverTrancheAllocations.and(MaxUint32)).to.equal(0);
+      expect(coverTrancheAllocations.shr(32)).to.equal(0);
+      expect(coverTrancheAllocations.shr(64)).to.equal(0);
+    }
+  });
+
+  it('correctly deallocates stored tranche allocations', async function () {
+    const { stakingPool } = this;
+    const { NXM_PER_ALLOCATION_UNIT } = this.config;
+
+    const { productId } = allocationRequestParams;
+
+    const allocationId1 = await stakingPool.getNextAllocationId();
+    const allocationAmount1 = stakedNxmAmount;
+
+    {
+      const activeAllocations = await stakingPool.getActiveAllocations(productId);
+      expect(activeAllocations[0]).to.equal(0);
+    }
+
+    // allocates 50% of first tranche
+    await stakingPool.connect(this.coverSigner).requestAllocation(allocationAmount1, 0, allocationRequestParams);
+    const firstAllocationBlock = await ethers.provider.getBlock('latest');
+
+    const allocationAmountInUnit = stakedNxmAmount.div(NXM_PER_ALLOCATION_UNIT);
+
+    {
+      const activeAllocations = await stakingPool.getActiveAllocations(productId);
+      expect(activeAllocations[0]).to.equal(allocationAmountInUnit);
+      expect(activeAllocations[1]).to.equal(0);
+      expect(activeAllocations[2]).to.equal(0);
+    }
+
+    const allocationAmount2 = stakedNxmAmount.mul(2);
+
+    // allocates 50% of first tranche and 50% of second tranche
+    await stakingPool.connect(this.coverSigner).requestAllocation(allocationAmount2, 0, allocationRequestParams);
+
+    {
+      const activeAllocations = await stakingPool.getActiveAllocations(productId);
+      expect(activeAllocations[0]).to.equal(allocationAmountInUnit.mul(2));
+      expect(activeAllocations[1]).to.equal(allocationAmountInUnit);
+      expect(activeAllocations[2]).to.equal(0);
+    }
+
+    const allocationAmount3 = stakedNxmAmount.mul(3);
+
+    // updates allocation to be 50% of first tranche, 50% of second tranche and 50% of third tranche
+    await stakingPool.connect(this.coverSigner).requestAllocation(allocationAmount3, 0, {
+      ...allocationRequestParams,
+      allocationId: allocationId1,
+      previousStart: firstAllocationBlock.timestamp,
+      previousExpiration: firstAllocationBlock.timestamp + allocationRequestParams.period,
+    });
+    const editAllocationBlock = await ethers.provider.getBlock('latest');
+
+    {
+      const activeAllocations = await stakingPool.getActiveAllocations(productId);
+      expect(activeAllocations[0]).to.equal(allocationAmountInUnit.mul(2));
+      expect(activeAllocations[1]).to.equal(allocationAmountInUnit.mul(2));
+      expect(activeAllocations[2]).to.equal(allocationAmountInUnit);
+    }
+
+    // deallocates half of the last tranche
+    const firstDeallocationAmount = stakedNxmAmount.div(2);
+    const params = {
+      allocationId: allocationId1,
+      productId,
+      start: editAllocationBlock.timestamp,
+      period: allocationRequestParams.period,
+      deallocationAmount: firstDeallocationAmount,
+    };
+
+    await stakingPool.connect(this.coverSigner).burnStake(0, params);
+
+    {
+      const activeAllocations = await stakingPool.getActiveAllocations(productId);
+      expect(activeAllocations[0]).to.equal(allocationAmountInUnit.mul(2));
+      expect(activeAllocations[1]).to.equal(allocationAmountInUnit.mul(2));
+      expect(activeAllocations[2]).to.equal(allocationAmountInUnit.div(2));
+    }
+
+    // deallocates 100%
+    const deallocationAmount = allocationAmount3.sub(firstDeallocationAmount);
+    await stakingPool.connect(this.coverSigner).burnStake(0, { ...params, deallocationAmount });
+
+    {
+      const activeAllocations = await stakingPool.getActiveAllocations(productId);
+      expect(activeAllocations[0]).to.equal(allocationAmountInUnit);
+      expect(activeAllocations[1]).to.equal(allocationAmountInUnit);
+      expect(activeAllocations[2]).to.equal(0);
+    }
+  });
+
+  it('correctly deallocates expiring cover amounts', async function () {
+    const { stakingPool } = this;
+    const { NXM_PER_ALLOCATION_UNIT } = this.config;
+
+    const { productId, period } = allocationRequestParams;
+
+    const allocationId1 = await stakingPool.getNextAllocationId();
+    const allocationAmount1 = stakedNxmAmount;
+
+    {
+      const activeAllocations = await stakingPool.getActiveAllocations(productId);
+      expect(activeAllocations[0]).to.equal(0);
+    }
+
+    // allocates 50% of first tranche
+    await stakingPool.connect(this.coverSigner).requestAllocation(allocationAmount1, 0, allocationRequestParams);
+    const firstAllocationBlock = await ethers.provider.getBlock('latest');
+
+    const { firstActiveTrancheId: currentTrancheId } = await getTranches();
+
+    const targetBucketId = Math.ceil((firstAllocationBlock.timestamp + period) / BUCKET_DURATION);
+
+    const firstTrancheGroupId = Math.floor(currentTrancheId / BUCKET_TRANCHE_GROUP_SIZE);
+    const firstTrancheIndexInGroup = currentTrancheId % BUCKET_TRANCHE_GROUP_SIZE;
+
+    const secondTrancheId = currentTrancheId + 1;
+    const secondTrancheGroupId = Math.floor(secondTrancheId / BUCKET_TRANCHE_GROUP_SIZE);
+    const secondTrancheIndexInGroup = secondTrancheId % BUCKET_TRANCHE_GROUP_SIZE;
+
+    const thirdTrancheId = currentTrancheId + 2;
+    const thirdTrancheGroupId = Math.floor(thirdTrancheId / BUCKET_TRANCHE_GROUP_SIZE);
+    const thirdTrancheIndexInGroup = thirdTrancheId % BUCKET_TRANCHE_GROUP_SIZE;
+
+    const allocationAmountInUnit = stakedNxmAmount.div(NXM_PER_ALLOCATION_UNIT);
+
+    {
+      const expiringCoverBuckets = await stakingPool.expiringCoverBuckets(
+        productId,
+        targetBucketId,
+        firstTrancheGroupId,
+      );
+      expect(expiringCoverBuckets.shr(firstTrancheIndexInGroup * EXPIRING_ALLOCATION_DATA_GROUP_SIZE)).to.equal(
+        allocationAmountInUnit,
+      );
+    }
+
+    const allocationAmount2 = stakedNxmAmount.mul(2);
+
+    // allocates 50% of first tranche and 50% of second tranche
+    await stakingPool.connect(this.coverSigner).requestAllocation(allocationAmount2, 0, allocationRequestParams);
+
+    {
+      const expiringCoverBuckets = await stakingPool.expiringCoverBuckets(
+        productId,
+        targetBucketId,
+        firstTrancheGroupId,
+      );
+      expect(
+        expiringCoverBuckets.shr(firstTrancheIndexInGroup * EXPIRING_ALLOCATION_DATA_GROUP_SIZE).and(MaxUint32),
+      ).to.equal(allocationAmountInUnit.mul(2));
+    }
+
+    {
+      const expiringCoverBuckets = await stakingPool.expiringCoverBuckets(
+        productId,
+        targetBucketId,
+        secondTrancheGroupId,
+      );
+      expect(
+        expiringCoverBuckets.shr(secondTrancheIndexInGroup * EXPIRING_ALLOCATION_DATA_GROUP_SIZE).and(MaxUint32),
+      ).to.equal(allocationAmountInUnit);
+    }
+
+    const allocationAmount3 = stakedNxmAmount.mul(3);
+
+    // updates allocation to be 50% of first tranche, 50% of second tranche and 50% of third tranche
+    await stakingPool.connect(this.coverSigner).requestAllocation(allocationAmount3, 0, {
+      ...allocationRequestParams,
+      allocationId: allocationId1,
+      previousStart: firstAllocationBlock.timestamp,
+      previousExpiration: firstAllocationBlock.timestamp + allocationRequestParams.period,
+    });
+    const editAllocationBlock = await ethers.provider.getBlock('latest');
+
+    {
+      const expiringCoverBuckets = await stakingPool.expiringCoverBuckets(
+        productId,
+        targetBucketId,
+        firstTrancheGroupId,
+      );
+      expect(
+        expiringCoverBuckets.shr(firstTrancheIndexInGroup * EXPIRING_ALLOCATION_DATA_GROUP_SIZE).and(MaxUint32),
+      ).to.equal(allocationAmountInUnit.mul(2));
+    }
+
+    {
+      const expiringCoverBuckets = await stakingPool.expiringCoverBuckets(
+        productId,
+        targetBucketId,
+        secondTrancheGroupId,
+      );
+      expect(
+        expiringCoverBuckets.shr(secondTrancheIndexInGroup * EXPIRING_ALLOCATION_DATA_GROUP_SIZE).and(MaxUint32),
+      ).to.equal(allocationAmountInUnit.mul(2));
+    }
+
+    {
+      const expiringCoverBuckets = await stakingPool.expiringCoverBuckets(
+        productId,
+        targetBucketId,
+        thirdTrancheGroupId,
+      );
+      expect(
+        expiringCoverBuckets.shr(thirdTrancheIndexInGroup * EXPIRING_ALLOCATION_DATA_GROUP_SIZE).and(MaxUint32),
+      ).to.equal(allocationAmountInUnit);
+    }
+
+    // deallocates half of the last tranche
+    const firstDeallocationAmount = stakedNxmAmount.div(2);
+    const params = {
+      allocationId: allocationId1,
+      productId,
+      start: editAllocationBlock.timestamp,
+      period: allocationRequestParams.period,
+      deallocationAmount: firstDeallocationAmount,
+    };
+
+    await stakingPool.connect(this.coverSigner).burnStake(0, params);
+
+    {
+      const expiringCoverBuckets = await stakingPool.expiringCoverBuckets(
+        productId,
+        targetBucketId,
+        firstTrancheGroupId,
+      );
+      expect(
+        expiringCoverBuckets.shr(firstTrancheIndexInGroup * EXPIRING_ALLOCATION_DATA_GROUP_SIZE).and(MaxUint32),
+      ).to.equal(allocationAmountInUnit.mul(2));
+    }
+
+    {
+      const expiringCoverBuckets = await stakingPool.expiringCoverBuckets(
+        productId,
+        targetBucketId,
+        secondTrancheGroupId,
+      );
+      expect(
+        expiringCoverBuckets.shr(secondTrancheIndexInGroup * EXPIRING_ALLOCATION_DATA_GROUP_SIZE).and(MaxUint32),
+      ).to.equal(allocationAmountInUnit.mul(2));
+    }
+
+    {
+      const expiringCoverBuckets = await stakingPool.expiringCoverBuckets(
+        productId,
+        targetBucketId,
+        thirdTrancheGroupId,
+      );
+      expect(
+        expiringCoverBuckets.shr(thirdTrancheIndexInGroup * EXPIRING_ALLOCATION_DATA_GROUP_SIZE).and(MaxUint32),
+      ).to.equal(allocationAmountInUnit.div(2));
+    }
+
+    // deallocates 100%
+    const deallocationAmount = allocationAmount3.sub(firstDeallocationAmount);
+    await stakingPool.connect(this.coverSigner).burnStake(0, { ...params, deallocationAmount });
+
+    {
+      const expiringCoverBuckets = await stakingPool.expiringCoverBuckets(
+        productId,
+        targetBucketId,
+        firstTrancheGroupId,
+      );
+      expect(
+        expiringCoverBuckets.shr(firstTrancheIndexInGroup * EXPIRING_ALLOCATION_DATA_GROUP_SIZE).and(MaxUint32),
+      ).to.equal(allocationAmountInUnit);
+    }
+
+    {
+      const expiringCoverBuckets = await stakingPool.expiringCoverBuckets(
+        productId,
+        targetBucketId,
+        secondTrancheGroupId,
+      );
+      expect(
+        expiringCoverBuckets.shr(secondTrancheIndexInGroup * EXPIRING_ALLOCATION_DATA_GROUP_SIZE).and(MaxUint32),
+      ).to.equal(allocationAmountInUnit);
+    }
+
+    {
+      const expiringCoverBuckets = await stakingPool.expiringCoverBuckets(
+        productId,
+        targetBucketId,
+        thirdTrancheGroupId,
+      );
+      expect(
+        expiringCoverBuckets.shr(thirdTrancheIndexInGroup * EXPIRING_ALLOCATION_DATA_GROUP_SIZE).and(MaxUint32),
+      ).to.equal(0);
+    }
+  });
+
+  it('calls process expirations', async function () {
+    const { stakingPool } = this;
+
+    const initialFirstActiveBucketId = await stakingPool.getFirstActiveBucketId();
+    const initialFirstActiveTrancheId = await stakingPool.getFirstActiveTrancheId();
+
+    await moveTimeToNextTranche(2);
+
+    await stakingPool.connect(this.coverSigner).burnStake(burnAmount, burnStakeParams);
+
+    const firstActiveBucketId = await stakingPool.getFirstActiveBucketId();
+    const firstActiveTrancheId = await stakingPool.getFirstActiveTrancheId();
+
+    expect(firstActiveBucketId).to.gt(initialFirstActiveBucketId);
+    expect(firstActiveTrancheId).to.gt(initialFirstActiveTrancheId);
   });
 });


### PR DESCRIPTION
## Context

Closes #632 


## Changes proposed in this pull request

- `Cover.burnStake()`:
  - Reduces coverSegmentAllocations `premiumInNXM` which is used for the refund calculation
  - Builds the cover parameters to replicate the allocation request and pass it to `stakingPool.burnStake()` along with the reduced cover amount after the claim
 
- `StakingPool.burnStake()`:
  - Calls `getActiveAllocationsWithoutCover()` and `allocate()` to reduce the allocation. Sets the current timestamp to the `segment.start` so the allocation is removed and set into the same tranches from the initial allocation

- Some internal methods were updated to have the timestamp as a parameter instead of using `block.timestamp` directly. This was needed for the previous item

## Test plan

- Added a new integration test for the specific scenario from the issue in `test/integration/IndividualClaims/submitClaim.js`
- Added other integration test to validate the consistency of the allocations in `test/integration/IndividualClaims/submitClaim.js`
- Updated and added new unit tests for cover.burnStake() in `test/unit/Cover/burnStake.js`
- StakingPool.burnStake() unit tests should consider these new changes when adding the tests in https://github.com/NexusMutual/smart-contracts/issues/564


## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
