### PR TITLE
Feature: Reduce StakingPool size by moving the products to StakingProducts contract

### DIFF
--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -76,13 +76,11 @@ struct ProductTypeParam {
   ProductType productType;
 }
 
-struct PoolInitializationParams {
-  uint poolId;
-  address manager;
-  bool isPrivatePool;
-  uint initialPoolFee;
-  uint maxPoolFee;
-  uint globalMinPriceRatio;
+struct ProductInitializationParams {
+  uint productId;
+  uint8 weight;
+  uint96 initialPrice;
+  uint96 targetPrice;
 }
 
 /* storage structs */

--- a/contracts/interfaces/ICowSettlement.sol
+++ b/contracts/interfaces/ICowSettlement.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
+
 pragma solidity ^0.8.0;
 
 interface ICowSettlement {

--- a/contracts/interfaces/IMasterAwareV2.sol
+++ b/contracts/interfaces/IMasterAwareV2.sol
@@ -10,6 +10,7 @@ interface IMasterAwareV2 {
     MR, // MemberRoles.sol
     MC, // MCR.sol
     CO, // Cover.sol
+    SP, // StakingProducts.sol
     AS, // Assessment.sol
     TK, // NXMToken.sol
     PS, // LegacyPooledStaking.sol

--- a/contracts/interfaces/IStakingPool.sol
+++ b/contracts/interfaces/IStakingPool.sol
@@ -29,20 +29,13 @@ struct StakedProductParam {
   uint96 targetPrice;
 }
 
-struct ProductInitializationParams {
-  uint productId;
-  uint8 weight;
-  uint96 initialPrice;
-  uint96 targetPrice;
-}
-
-struct BurnStakeParams {
-  uint allocationId;
-  uint productId;
-  uint start;
-  uint period;
-  uint deallocationAmount;
-}
+  struct BurnStakeParams {
+    uint allocationId;
+    uint productId;
+    uint start;
+    uint period;
+    uint deallocationAmount;
+  }
 
 interface IStakingPool {
 
@@ -69,20 +62,11 @@ interface IStakingPool {
     uint128 rewardsShares;
   }
 
-  struct StakedProduct {
-    uint16 lastEffectiveWeight;
-    uint8 targetWeight;
-    uint96 targetPrice;
-    uint96 bumpedPrice;
-    uint32 bumpedPriceUpdateTime;
-  }
-
   function initialize(
     address _manager,
     bool isPrivatePool,
     uint initialPoolFee,
     uint maxPoolFee,
-    ProductInitializationParams[] calldata params,
     uint _poolId,
     string memory ipfsDescriptionHash
   ) external;
@@ -141,23 +125,11 @@ interface IStakingPool {
 
   function getNextAllocationId() external view returns (uint);
 
-  function getTotalTargetWeight() external view returns (uint);
-
-  function getTotalEffectiveWeight() external view returns (uint);
-
   function getDeposit(uint tokenId, uint trancheId) external view returns (
     uint lastAccNxmPerRewardShare,
     uint pendingRewards,
     uint stakeShares,
     uint rewardsShares
-  );
-
-  function getProduct(uint productId) external view returns (
-    uint lastEffectiveWeight,
-    uint targetWeight,
-    uint targetPrice,
-    uint bumpedPrice,
-    uint bumpedPriceUpdateTime
   );
 
   function getTranche(uint trancheId) external view returns (
@@ -175,7 +147,17 @@ interface IStakingPool {
 
   function setPoolPrivacy(bool isPrivatePool) external;
 
-  function setProducts(StakedProductParam[] memory params) external;
+  function getActiveAllocations(
+    uint productId
+  ) external view returns (uint[] memory trancheAllocations);
+
+  function getTrancheCapacities(
+    uint productId,
+    uint firstTrancheId,
+    uint trancheCount,
+    uint capacityRatio,
+    uint reductionRatio
+  ) external view returns (uint[] memory trancheCapacities);
 
   /* ========== EVENTS ========== */
 
@@ -192,8 +174,6 @@ interface IStakingPool {
   event Withdraw(address indexed user, uint indexed tokenId, uint tranche, uint amountStakeWithdrawn, uint amountRewardsWithdrawn);
 
   event StakeBurned(uint amount);
-
-  event ProductUpdated(uint productId, uint8 targetWeight, uint96 targetPrice);
 
   // Auth
   error OnlyCoverContract();
@@ -215,8 +195,9 @@ interface IStakingPool {
   error RewardRatioTooHigh();
 
   // Staking NFTs
+  error InvalidTokenId();
   error NotTokenOwnerOrApproved();
-  error TokenDoesNotBelongToPool();
+  error InvalidStakingPoolForToken();
 
   // Tranche & capacity
   error NewTrancheEndsBeforeInitialTranche();
@@ -224,14 +205,4 @@ interface IStakingPool {
   error RequestedTrancheIsExpired();
   error InsufficientCapacity();
 
-  // Products & weights
-  error PoolNotAllowedForThisProduct();
-  error MustSetPriceForNewProducts();
-  error MustSetWeightForNewProducts();
-  error TargetPriceTooHigh();
-  error TargetPriceBelowMin();
-  error TargetWeightTooHigh();
-  error MustRecalculateEffectiveWeight();
-  error TotalTargetWeightExceeded();
-  error TotalEffectiveWeightExceeded();
 }

--- a/contracts/interfaces/IStakingProducts.sol
+++ b/contracts/interfaces/IStakingProducts.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity ^0.8.9;
+
+import "./ICover.sol";
+import "./IStakingPool.sol";
+
+interface IStakingProducts {
+
+  // TODO: resize values?
+  struct Weights {
+    uint32 totalEffectiveWeight;
+    uint32 totalTargetWeight;
+  }
+
+  struct StakedProduct {
+    uint16 lastEffectiveWeight;
+    uint8 targetWeight;
+    uint96 targetPrice;
+    uint96 bumpedPrice;
+    uint32 bumpedPriceUpdateTime;
+  }
+
+  /* ============= PRODUCT FUNCTIONS ============= */
+
+  function setProducts(uint poolId, StakedProductParam[] memory params) external;
+
+  function setInitialProducts(uint poolId, ProductInitializationParams[] memory params) external;
+
+  function getProductTargetWeight(uint poolId, uint productId) external view returns (uint);
+
+  function getTotalTargetWeight(uint poolId) external view returns (uint);
+
+  function getTotalEffectiveWeight(uint poolId) external view returns (uint);
+
+  function getProduct(uint poolId, uint productId) external view returns (
+    uint lastEffectiveWeight,
+    uint targetWeight,
+    uint targetPrice,
+    uint bumpedPrice,
+    uint bumpedPriceUpdateTime
+  );
+
+  /* ============= PRICING FUNCTIONS ============= */
+
+  function getPremium(
+    uint poolId,
+    uint productId,
+    uint period,
+    uint coverAmount,
+    uint initialCapacityUsed,
+    uint totalCapacity,
+    uint globalMinPrice,
+    bool useFixedPrice,
+    uint nxmPerAllocationUnit,
+    uint allocationUnitsPerNxm
+  ) external returns (uint premium);
+
+  function calculateFixedPricePremium(
+    uint coverAmount,
+    uint period,
+    uint fixedPrice,
+    uint nxmPerAllocationUnit,
+    uint targetPriceDenominator
+  ) external pure returns (uint);
+
+
+  function calculatePremium(
+    StakedProduct memory product,
+    uint period,
+    uint coverAmount,
+    uint initialCapacityUsed,
+    uint totalCapacity,
+    uint targetPrice,
+    uint currentBlockTimestamp,
+    uint nxmPerAllocationUnit,
+    uint allocationUnitsPerNxm,
+    uint targetPriceDenominator
+  ) external pure returns (uint premium, StakedProduct memory);
+
+  function calculatePremiumPerYear(
+    uint basePrice,
+    uint coverAmount,
+    uint initialCapacityUsed,
+    uint totalCapacity,
+    uint nxmPerAllocationUnit,
+    uint allocationUnitsPerNxm,
+    uint targetPriceDenominator
+  ) external pure returns (uint);
+
+  // Calculates the premium for a given cover amount starting with the surge point
+  function calculateSurgePremium(
+    uint amountOnSurge,
+    uint totalCapacity,
+    uint allocationUnitsPerNxm
+  ) external pure returns (uint);
+
+  /* ============= EVENTS ============= */
+
+  event ProductUpdated(uint productId, uint8 targetWeight, uint96 targetPrice);
+
+  /* ============= ERRORS ============= */
+
+  // Auth
+  error OnlyStakingPool();
+  error OnlyCoverContract();
+  error OnlyManager();
+
+  // Inputs
+  error InvalidStakingPool();
+
+  // Products & weights
+  error PoolNotAllowedForThisProduct();
+  error MustSetPriceForNewProducts();
+  error MustSetWeightForNewProducts();
+  error TargetPriceTooHigh();
+  error TargetPriceBelowMin();
+  error TargetWeightTooHigh();
+  error MustRecalculateEffectiveWeight();
+  error TotalTargetWeightExceeded();
+  error TotalEffectiveWeightExceeded();
+
+}

--- a/contracts/interfaces/IWeth.sol
+++ b/contracts/interfaces/IWeth.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
+
 pragma solidity ^0.8.0;
 
 interface IWeth {

--- a/contracts/mocks/Cover/CoverMockStakingPool.sol
+++ b/contracts/mocks/Cover/CoverMockStakingPool.sol
@@ -2,10 +2,8 @@
 
 pragma solidity ^0.8.16;
 
-import "@openzeppelin/contracts-v4/token/ERC20/IERC20.sol";
 import "../../interfaces/IStakingPool.sol";
-import "../../modules/staking/StakingPool.sol";
-import "../Tokens/ERC721Mock.sol";
+import "../../libraries/Math.sol";
 
 contract CoverMockStakingPool is IStakingPool {
 
@@ -24,8 +22,6 @@ contract CoverMockStakingPool is IStakingPool {
   mapping (uint => uint) public usedCapacity;
   mapping (uint => uint) public stakedAmount;
 
-  // product id => StakedProduct
-  mapping(uint => StakedProduct) public products;
   mapping (uint => uint) public mockPrices;
 
   uint public constant MAX_PRICE_RATIO = 10_000;
@@ -42,19 +38,28 @@ contract CoverMockStakingPool is IStakingPool {
   uint public burnStakeCalledWithAmount;
   BurnStakeParams public burnStakeCalledWithParams;
 
+  struct StakedProduct {
+    uint16 lastEffectiveWeight;
+    uint8 targetWeight;
+    uint96 targetPrice;
+    uint96 bumpedPrice;
+    uint32 bumpedPriceUpdateTime;
+  }
+
+  // product id => StakedProduct
+  mapping(uint => StakedProduct) public products;
+
   function initialize(
     address _manager,
     bool _isPrivatePool,
     uint _initialPoolFee,
     uint _maxPoolFee,
-    ProductInitializationParams[] calldata params,
     uint _poolId,
     string calldata /* ipfsDescriptionHash */
   ) external {
     _isPrivatePool;
     _initialPoolFee;
     _maxPoolFee;
-    params;
     manager = _manager;
     poolId = _poolId;
   }
@@ -64,27 +69,30 @@ contract CoverMockStakingPool is IStakingPool {
     uint /*previousPremium*/,
     AllocationRequest calldata request
   ) external override returns (uint premium, uint allocationId) {
-    usedCapacity[request.productId] += amount;
-    if (request.useFixedPrice) {
-      return (calculateFixedPricePremium(amount, request.period, mockPrices[request.productId]), allocationId);
-    }
-    return (calculatePremium(mockPrices[request.productId], amount, request.period), allocationId);
-  }
 
+    usedCapacity[request.productId] += amount;
+
+    premium = request.useFixedPrice
+      ? calculateFixedPricePremium(amount, request.period, mockPrices[request.productId])
+      : calculatePremium(mockPrices[request.productId], amount, request.period);
+
+    return (premium, allocationId);
+  }
 
   function calculateFixedPricePremium(
     uint coverAmount,
     uint period,
     uint fixedPrice
   ) public pure returns (uint) {
+
     // NOTE: the actual function takes coverAmount scaled down by NXM_PER_ALLOCATION_UNIT as an argument
     coverAmount = Math.divCeil(coverAmount, NXM_PER_ALLOCATION_UNIT);
 
     uint premiumPerYear =
-    coverAmount
-    * NXM_PER_ALLOCATION_UNIT
-    * fixedPrice
-    / TARGET_PRICE_DENOMINATOR;
+      coverAmount
+      * NXM_PER_ALLOCATION_UNIT
+      * fixedPrice
+      / TARGET_PRICE_DENOMINATOR;
 
     return premiumPerYear * period / 365 days;
   }
@@ -118,20 +126,12 @@ contract CoverMockStakingPool is IStakingPool {
     return usedCapacity[productId];
   }
 
-  function getTargetPrice(uint productId) external /*override*/ view returns (uint) {
-    return products[productId].targetPrice;
-  }
-
   function getStake(uint productId) external /*override*/ view returns (uint) {
     return stakedAmount[productId];
   }
 
   function setUsedCapacity(uint productId, uint amount) external {
     usedCapacity[productId] = amount;
-  }
-
-    function setTargetPrice(uint productId, uint amount) external {
-    products[productId].targetPrice = uint96(amount);
   }
 
   function setStake(uint productId, uint amount) external {
@@ -285,4 +285,19 @@ contract CoverMockStakingPool is IStakingPool {
     return false;
   }
 
+  function getActiveAllocations(
+    uint /*productId*/
+  ) external pure returns (uint[] memory /*trancheAllocations*/){
+    revert("CoverMockStakingPool: not callable");
+  }
+
+  function getTrancheCapacities(
+    uint /*productId*/,
+    uint /*firstTrancheId*/,
+    uint /*trancheCount*/,
+    uint /*capacityRatio*/,
+    uint /*reductionRatio*/
+  ) external pure returns (uint[] memory /*trancheCapacities*/){
+    revert("CoverMockStakingPool: not callable");
+  }
 }

--- a/contracts/mocks/Cover/CoverMockStakingProducts.sol
+++ b/contracts/mocks/Cover/CoverMockStakingProducts.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity ^0.8.16;
+
+import "../../interfaces/IStakingProducts.sol";
+
+contract CoverMockStakingProducts is IStakingProducts {
+
+  function setProducts(uint /*poolId*/, StakedProductParam[] memory /*params*/) external pure {
+    revert('CoverMockStakingProducts: Not callable');
+  }
+
+  function setInitialProducts(uint /*poolId*/, ProductInitializationParams[] memory /*params*/) external pure {
+    // revert('CoverMockStakingProducts: Not callable');
+  }
+
+  function getProductTargetWeight(uint /*poolId*/, uint /*productId*/) external pure returns (uint) {
+    revert('CoverMockStakingProducts: Not callable');
+  }
+
+  function getTotalTargetWeight(uint /*poolId*/) external pure returns (uint) {
+    revert('CoverMockStakingProducts: Not callable');
+  }
+
+  function getTotalEffectiveWeight(uint /*poolId*/) external pure returns (uint) {
+    revert('CoverMockStakingProducts: Not callable');
+  }
+
+  function getProduct(uint /*poolId*/, uint /*productId*/) external pure returns (
+    uint /*lastEffectiveWeight*/,
+    uint /*targetWeight*/,
+    uint /*targetPrice*/,
+    uint /*bumpedPrice*/,
+    uint /*bumpedPriceUpdateTime*/
+  ) {
+    revert('CoverMockStakingProducts: Not callable');
+  }
+
+  function getPremium(
+    uint /*poolId*/,
+    uint /*productId*/,
+    uint /*period*/,
+    uint /*coverAmount*/,
+    uint /*initialCapacityUsed*/,
+    uint /*totalCapacity*/,
+    uint /*globalMinPrice*/,
+    bool /*useFixedPrice*/,
+    uint /*nxmPerAllocationUnit*/,
+    uint /*allocationUnitsPerNxm*/
+  ) external pure returns (uint /*premium*/) {
+    revert('CoverMockStakingProducts: Not callable');
+  }
+
+  function calculateFixedPricePremium(
+    uint /*coverAmount*/,
+    uint /*period*/,
+    uint /*fixedPrice*/,
+    uint /*nxmPerAllocationUnit*/,
+    uint /*targetPriceDenominator*/
+  ) external pure returns (uint) {
+    revert('CoverMockStakingProducts: Not callable');
+  }
+
+  function calculatePremium(
+    StakedProduct memory /*product*/,
+    uint /*period*/,
+    uint /*coverAmount*/,
+    uint /*initialCapacityUsed*/,
+    uint /*totalCapacity*/,
+    uint /*targetPrice*/,
+    uint /*currentBlockTimestamp*/,
+    uint /*nxmPerAllocationUnit*/,
+    uint /*allocationUnitsPerNxm*/,
+    uint /*targetPriceDenominator*/
+  ) external pure returns (uint /*premium*/, StakedProduct memory) {
+    revert('CoverMockStakingProducts: Not callable');
+  }
+
+  function calculatePremiumPerYear(
+    uint /*basePrice*/,
+    uint /*coverAmount*/,
+    uint /*initialCapacityUsed*/,
+    uint /*totalCapacity*/,
+    uint /*nxmPerAllocationUnit*/,
+    uint /*allocationUnitsPerNxm*/,
+    uint /*targetPriceDenominator*/
+  ) external pure returns (uint) {
+    revert('CoverMockStakingProducts: Not callable');
+  }
+
+  function calculateSurgePremium(
+    uint /*amountOnSurge*/,
+    uint /*totalCapacity*/,
+    uint /*allocationUnitsPerNxm*/
+  ) external pure returns (uint) {
+    revert('CoverMockStakingProducts: Not callable');
+  }
+
+}

--- a/contracts/mocks/StakingPool/SPMockCover.sol
+++ b/contracts/mocks/StakingPool/SPMockCover.sol
@@ -134,22 +134,15 @@ contract SPMockCover {
     bool _isPrivatePool,
     uint _initialPoolFee,
     uint _maxPoolFee,
-    ProductInitializationParams[] memory params,
     uint _poolId,
     string calldata ipfsDescriptionHash
   ) external {
-
-    for (uint i = 0; i < params.length; i++) {
-      params[i].initialPrice = products[params[i].productId].initialPriceRatio;
-      require(params[i].targetPrice >= GLOBAL_MIN_PRICE_RATIO, "Cover: Target price below GLOBAL_MIN_PRICE_RATIO");
-    }
 
     IStakingPool(staking_).initialize(
       _manager,
       _isPrivatePool,
       _initialPoolFee,
       _maxPoolFee,
-      params,
       _poolId,
       ipfsDescriptionHash
     );

--- a/contracts/mocks/Stub.sol
+++ b/contracts/mocks/Stub.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity ^0.8.0;
+
+contract Stub {
+  // stub contract
+}

--- a/contracts/mocks/SwapOperator/SOMockVaultRelayer.sol
+++ b/contracts/mocks/SwapOperator/SOMockVaultRelayer.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
+
 pragma solidity ^0.8.16;
 
 import '@openzeppelin/contracts-v4/token/ERC20/IERC20.sol';

--- a/contracts/modules/capital/SwapOperator.sol
+++ b/contracts/modules/capital/SwapOperator.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
+
 pragma solidity ^0.8.9;
 
 import "@openzeppelin/contracts-v4/token/ERC20/IERC20.sol";

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -19,6 +19,7 @@ import "../../interfaces/ITokenController.sol";
 import "../../libraries/Math.sol";
 import "../../libraries/SafeUintCast.sol";
 import "../../libraries/StakingPoolLibrary.sol";
+import "../../interfaces/IStakingProducts.sol";
 
 contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
   using SafeERC20 for IERC20;
@@ -524,10 +525,11 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
       isPrivatePool,
       initialPoolFee,
       maxPoolFee,
-      productInitParams,
       poolId,
       ipfsDescriptionHash
     );
+
+    stakingProducts().setInitialProducts(poolId, productInitParams);
 
     return (poolId, stakingPoolAddress);
   }
@@ -838,12 +840,16 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
     return IIndividualClaims(getInternalContractAddress(ID.IC));
   }
 
+  function stakingProducts() internal view returns (IStakingProducts) {
+    return IStakingProducts(getInternalContractAddress(ID.SP));
+  }
+
   function changeDependentContractAddress() external override {
-    master = INXMMaster(master);
     internalContracts[uint(ID.P1)] = master.getLatestAddress("P1");
     internalContracts[uint(ID.TC)] = master.getLatestAddress("TC");
     internalContracts[uint(ID.IC)] = master.getLatestAddress("IC");
     internalContracts[uint(ID.MR)] = master.getLatestAddress("MR");
+    internalContracts[uint(ID.SP)] = master.getLatestAddress("SP");
   }
 
   /**

--- a/contracts/modules/staking/StakingNFT.sol
+++ b/contracts/modules/staking/StakingNFT.sol
@@ -22,8 +22,9 @@ contract StakingNFT is IStakingNFT {
   mapping(address => mapping(address => bool)) public isApprovedForAll;
 
   uint96 internal _totalSupply;
-  address public stakingPoolFactory;
   address public operator;
+
+  address public immutable stakingPoolFactory;
 
   constructor(
     string memory _name,

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -10,6 +10,7 @@ import "../../interfaces/IStakingNFT.sol";
 import "../../interfaces/ITokenController.sol";
 import "../../interfaces/INXMMaster.sol";
 import "../../interfaces/INXMToken.sol";
+import "../../interfaces/IStakingProducts.sol";
 import "../../libraries/Math.sol";
 import "../../libraries/UncheckedMath.sol";
 import "../../libraries/SafeUintCast.sol";
@@ -67,10 +68,8 @@ contract StakingPool is IStakingPool, Multicall {
 
   // slot 4
   address public override manager;
-  uint32 internal totalEffectiveWeight;
-  uint32 internal totalTargetWeight;
 
-  // 32 bytes left in slot 4
+  // 96 bytes left in slot 4
 
   // tranche id => tranche data
   mapping(uint => Tranche) internal tranches;
@@ -91,9 +90,6 @@ contract StakingPool is IStakingPool, Multicall {
   // starts with the first active tranche at the time of cover buy
   mapping(uint => uint) public coverTrancheAllocations;
 
-  // product id => Product
-  mapping(uint => StakedProduct) public products;
-
   // token id => tranche id => deposit data
   mapping(uint => mapping(uint => Deposit)) public deposits;
 
@@ -104,6 +100,7 @@ contract StakingPool is IStakingPool, Multicall {
   ITokenController public  immutable tokenController;
   address public immutable coverContract;
   INXMMaster public immutable masterContract;
+  IStakingProducts public immutable stakingProducts;
 
   /* constants */
 
@@ -117,7 +114,6 @@ contract StakingPool is IStakingPool, Multicall {
 
   uint public constant REWARD_BONUS_PER_TRANCHE_RATIO = 10_00; // 10.00%
   uint public constant REWARD_BONUS_PER_TRANCHE_DENOMINATOR = 100_00;
-  uint public constant MAX_TOTAL_WEIGHT = 20_00; // 20x
   uint public constant WEIGHT_DENOMINATOR = 100;
   uint public constant REWARDS_DENOMINATOR = 100_00;
   uint public constant POOL_FEE_DENOMINATOR = 100;
@@ -125,22 +121,8 @@ contract StakingPool is IStakingPool, Multicall {
   // denominators for cover contract parameters
   uint public constant GLOBAL_CAPACITY_DENOMINATOR = 100_00;
   uint public constant CAPACITY_REDUCTION_DENOMINATOR = 100_00;
-  uint public constant INITIAL_PRICE_DENOMINATOR = 100_00;
-  uint public constant TARGET_PRICE_DENOMINATOR = 100_00;
-
-  // base price bump
-  // +0.2% for each 1% of capacity used, ie +20% for 100%
-  uint public constant PRICE_BUMP_RATIO = 20_00; // 20%
-
-  // bumped price smoothing
-  // 0.5% per day
-  uint public constant PRICE_CHANGE_PER_DAY = 50; // 0.5%
 
   // +2% for every 1%, ie +200% for 100%
-  uint public constant SURGE_PRICE_RATIO = 2 ether;
-
-  uint public constant SURGE_THRESHOLD_RATIO = 90_00; // 90.00%
-  uint public constant SURGE_THRESHOLD_DENOMINATOR = 100_00; // 100.00%
 
   // 1 nxm = 1e18
   uint public constant ONE_NXM = 1 ether;
@@ -168,7 +150,9 @@ contract StakingPool is IStakingPool, Multicall {
   }
 
   modifier whenNotPaused {
-    require(!masterContract.isPause(), "System is paused");
+    if (masterContract.isPause()) {
+      revert SystemPaused();
+    }
     _;
   }
 
@@ -179,26 +163,20 @@ contract StakingPool is IStakingPool, Multicall {
     _;
   }
 
-  // validate token id exists and belongs to this pool
-  // stakingPoolOf() reverts for non-existent tokens
-  function requireTokenBelongsToPool(uint tokenId) internal view {
-    if (stakingNFT.stakingPoolOf(tokenId) != poolId) {
-      revert TokenDoesNotBelongToPool();
-    }
-  }
-
   constructor (
     address _stakingNFT,
     address _token,
     address _coverContract,
     address _tokenController,
-    address _master
+    address _master,
+    address _stakingProducts
   ) {
     stakingNFT = IStakingNFT(_stakingNFT);
     nxm = INXMToken(_token);
     coverContract = _coverContract;
     tokenController = ITokenController(_tokenController);
     masterContract = INXMMaster(_master);
+    stakingProducts = IStakingProducts(_stakingProducts);
   }
 
   function initialize(
@@ -206,7 +184,6 @@ contract StakingPool is IStakingPool, Multicall {
     bool _isPrivatePool,
     uint _initialPoolFee,
     uint _maxPoolFee,
-    ProductInitializationParams[] calldata params,
     uint _poolId,
     string  calldata ipfsDescriptionHash
   ) external onlyCoverContract {
@@ -224,8 +201,6 @@ contract StakingPool is IStakingPool, Multicall {
     poolFee = uint8(_initialPoolFee);
     maxPoolFee = uint8(_maxPoolFee);
     poolId = _poolId.toUint40();
-
-    _setInitialProducts(params);
 
     emit PoolDescriptionSet(ipfsDescriptionHash);
   }
@@ -375,10 +350,8 @@ contract StakingPool is IStakingPool, Multicall {
     address destination
   ) public whenNotPaused whenNotHalted returns (uint tokenId) {
 
-    if (isPrivatePool) {
-      if (msg.sender != manager) {
-        revert PrivatePool();
-      }
+    if (isPrivatePool && msg.sender != manager) {
+      revert PrivatePool();
     }
 
     if (block.timestamp <= nxm.isLockedForMV(msg.sender)) {
@@ -392,9 +365,11 @@ contract StakingPool is IStakingPool, Multicall {
       if (amount == 0) {
         revert InsufficientDepositAmount();
       }
+
       if (trancheId > maxTranche) {
         revert RequestedTrancheIsNotYetActive();
       }
+
       if (trancheId < _firstActiveTrancheId) {
         revert RequestedTrancheIsExpired();
       }
@@ -422,7 +397,11 @@ contract StakingPool is IStakingPool, Multicall {
       address to = destination == address(0) ? msg.sender : destination;
       tokenId = stakingNFT.mint(poolId, to);
     } else {
-      requireTokenBelongsToPool(requestTokenId);
+      // validate token id exists and belongs to this pool
+      // stakingPoolOf() reverts for non-existent tokens
+      if (stakingNFT.stakingPoolOf(requestTokenId) != poolId) {
+        revert InvalidStakingPoolForToken();
+      }
       tokenId = requestTokenId;
     }
 
@@ -636,8 +615,6 @@ contract StakingPool is IStakingPool, Multicall {
     // passing true because we change the reward per second
     processExpirations(true);
 
-    uint _firstActiveTrancheId = block.timestamp / TRANCHE_DURATION;
-
     uint[] memory trancheAllocations = request.allocationId == 0
       ? getActiveAllocations(request.productId)
       : getActiveAllocationsWithoutCover(
@@ -654,7 +631,7 @@ contract StakingPool is IStakingPool, Multicall {
       // store deallocated amount
       updateStoredAllocations(
         request.productId,
-        _firstActiveTrancheId,
+        block.timestamp / TRANCHE_DURATION, // firstActiveTrancheId
         trancheAllocations
       );
 
@@ -675,14 +652,17 @@ contract StakingPool is IStakingPool, Multicall {
     ) = allocate(amount, request, trancheAllocations);
 
     // the returned premium value has 18 decimals
-    premium = getPremium(
+    premium = stakingProducts.getPremium(
+      poolId,
       request.productId,
       request.period,
       coverAllocationAmount,
       initialCapacityUsed,
       totalCapacity,
       request.globalMinPrice,
-      request.useFixedPrice
+      request.useFixedPrice,
+      NXM_PER_ALLOCATION_UNIT,
+      ALLOCATION_UNITS_PER_NXM
     );
 
     // add new rewards
@@ -763,7 +743,7 @@ contract StakingPool is IStakingPool, Multicall {
     return getActiveAllocations(productId, block.timestamp);
   }
 
-    function getActiveAllocations(
+  function getActiveAllocations(
     uint productId,
     uint timestamp
   ) internal view returns (uint[] memory trancheAllocations) {
@@ -881,9 +861,9 @@ contract StakingPool is IStakingPool, Multicall {
     uint trancheCount,
     uint capacityRatio,
     uint reductionRatio
-  ) internal view returns (uint[] memory trancheCapacities) {
+  ) public view returns (uint[] memory trancheCapacities) {
 
-    // TODO: this require statement seems redundant
+    // will revert if with unprocessed expirations
     if (firstTrancheId < block.timestamp / TRANCHE_DURATION) {
       revert RequestedTrancheIsExpired();
     }
@@ -896,10 +876,11 @@ contract StakingPool is IStakingPool, Multicall {
       return trancheCapacities;
     }
 
+    // TODO: can we get rid of the extra call to SP here?
     uint multiplier =
       capacityRatio
       * (CAPACITY_REDUCTION_DENOMINATOR - reductionRatio)
-      * products[productId].targetWeight;
+      * stakingProducts.getProductTargetWeight(poolId, productId);
 
     uint denominator =
       GLOBAL_CAPACITY_DENOMINATOR
@@ -1095,7 +1076,20 @@ contract StakingPool is IStakingPool, Multicall {
     uint topUpAmount
   ) external whenNotPaused whenNotHalted {
 
-    requireTokenBelongsToPool(tokenId);
+    // token id 0 is only used for pool manager fee tracking, no deposits allowed
+    if (tokenId == 0) {
+      revert InvalidTokenId();
+    }
+
+    // validate token id exists and belongs to this pool
+    // stakingPoolOf() reverts for non-existent tokens
+    if (stakingNFT.stakingPoolOf(tokenId) != poolId) {
+      revert InvalidStakingPoolForToken();
+    }
+
+    if (isPrivatePool && msg.sender != manager) {
+      revert PrivatePool();
+    }
 
     if (!stakingNFT.isApprovedOrOwner(msg.sender, tokenId)) {
       revert NotTokenOwnerOrApproved();
@@ -1137,12 +1131,6 @@ contract StakingPool is IStakingPool, Multicall {
 
       return;
       // done! skip the rest of the function.
-    }
-
-    if (isPrivatePool) {
-      if (msg.sender != manager) {
-        revert PrivatePool();
-      }
     }
 
     // if we got here - the initial tranche is still active. move all the shares to the new tranche
@@ -1288,192 +1276,6 @@ contract StakingPool is IStakingPool, Multicall {
 
   /* pool management */
 
-  function recalculateEffectiveWeights(uint[] calldata productIds) external {
-    (
-    uint globalCapacityRatio,
-    /* globalMinPriceRatio */,
-    /* initialPriceRatios */,
-    /* capacityReductionRatios */
-    uint[] memory capacityReductionRatios
-    ) = ICover(coverContract).getPriceAndCapacityRatios(productIds);
-
-    uint _totalEffectiveWeight = totalEffectiveWeight;
-
-    for (uint i = 0; i < productIds.length; i++) {
-      uint productId = productIds[i];
-      StakedProduct memory _product = products[productId];
-
-      uint16 previousEffectiveWeight = _product.lastEffectiveWeight;
-      _product.lastEffectiveWeight = getEffectiveWeight(
-        productId,
-        _product.targetWeight,
-        globalCapacityRatio,
-        capacityReductionRatios[i]
-      );
-      _totalEffectiveWeight = _totalEffectiveWeight - previousEffectiveWeight + _product.lastEffectiveWeight;
-      products[productId] = _product;
-    }
-    totalEffectiveWeight = _totalEffectiveWeight.toUint32();
-  }
-
-  function setProducts(StakedProductParam[] memory params) external onlyManager {
-    uint numProducts = params.length;
-    uint[] memory productIds = new uint[](numProducts);
-
-    for (uint i = 0; i < numProducts; i++) {
-      productIds[i] = params[i].productId;
-      if (!ICover(coverContract).isPoolAllowed(params[i].productId, poolId)) {
-        revert PoolNotAllowedForThisProduct();
-      }
-    }
-    (
-      uint globalCapacityRatio,
-      uint globalMinPriceRatio,
-      uint[] memory initialPriceRatios,
-      uint[] memory capacityReductionRatios
-    ) = ICover(coverContract).getPriceAndCapacityRatios(productIds);
-
-    uint _totalTargetWeight = totalTargetWeight;
-    uint _totalEffectiveWeight = totalEffectiveWeight;
-    bool targetWeightIncreased;
-
-    for (uint i = 0; i < numProducts; i++) {
-      StakedProductParam memory _param = params[i];
-      StakedProduct memory _product = products[_param.productId];
-
-      // if this is a new product
-      if (_product.bumpedPriceUpdateTime == 0) {
-        // initialize the bumpedPrice
-        _product.bumpedPrice = initialPriceRatios[i].toUint96();
-        _product.bumpedPriceUpdateTime = uint32(block.timestamp);
-        // and make sure we set the price and the target weight
-        if (!_param.setTargetPrice) {
-          revert MustSetPriceForNewProducts();
-        }
-        if (!_param.setTargetWeight) {
-          revert MustSetWeightForNewProducts();
-        }
-      }
-
-      if (_param.setTargetPrice) {
-        if (_param.targetPrice > TARGET_PRICE_DENOMINATOR) {
-          revert TargetPriceTooHigh();
-        }
-        if (_param.targetPrice < globalMinPriceRatio) {
-          revert TargetPriceBelowMin();
-        }
-        _product.targetPrice = _param.targetPrice;
-      }
-
-      // if setTargetWeight is set - effective weight must be recalculated
-      if (_param.setTargetWeight && !_param.recalculateEffectiveWeight) {
-        revert MustRecalculateEffectiveWeight();
-      }
-
-      // Must recalculate effectiveWeight to adjust targetWeight
-      if (_param.recalculateEffectiveWeight) {
-
-        if (_param.setTargetWeight) {
-          if (_param.targetWeight > WEIGHT_DENOMINATOR) {
-            revert TargetWeightTooHigh();
-          }
-
-          // totalEffectiveWeight cannot be above the max unless target  weight is not increased
-          if (!targetWeightIncreased) {
-            targetWeightIncreased = _param.targetWeight > _product.targetWeight;
-          }
-          _totalTargetWeight = _totalTargetWeight - _product.targetWeight + _param.targetWeight;
-          _product.targetWeight = _param.targetWeight;
-        }
-
-        // subtract the previous effective weight
-        _totalEffectiveWeight -= _product.lastEffectiveWeight;
-
-        _product.lastEffectiveWeight = getEffectiveWeight(
-          _param.productId,
-          _product.targetWeight,
-          globalCapacityRatio,
-          capacityReductionRatios[i]
-        );
-
-        // add the new effective weight
-        _totalEffectiveWeight += _product.lastEffectiveWeight;
-      }
-
-      // sstore
-      products[_param.productId] = _product;
-
-      emit ProductUpdated(_param.productId, _param.targetWeight, _param.targetPrice);
-    }
-
-    if (_totalTargetWeight > MAX_TOTAL_WEIGHT) {
-      revert TotalTargetWeightExceeded();
-    }
-
-    if (targetWeightIncreased) {
-      if (_totalEffectiveWeight > MAX_TOTAL_WEIGHT) {
-        revert TotalEffectiveWeightExceeded();
-      }
-    }
-
-    totalTargetWeight = _totalTargetWeight.toUint32();
-    totalEffectiveWeight = _totalEffectiveWeight.toUint32();
-  }
-
-  function getEffectiveWeight(
-    uint productId,
-    uint targetWeight,
-    uint globalCapacityRatio,
-    uint capacityReductionRatio
-  ) internal view returns (uint16 effectiveWeight) {
-
-    uint[] memory trancheCapacities = getTrancheCapacities(
-      productId,
-      block.timestamp / TRANCHE_DURATION, // first active tranche id
-      MAX_ACTIVE_TRANCHES,
-      globalCapacityRatio,
-      capacityReductionRatio
-    );
-
-    uint totalCapacity = Math.sum(trancheCapacities);
-
-    if (totalCapacity == 0) {
-      return targetWeight.toUint16();
-    }
-
-    uint[] memory activeAllocations = getActiveAllocations(productId);
-    uint totalAllocation = Math.sum(activeAllocations);
-    uint actualWeight = Math.min(totalAllocation * WEIGHT_DENOMINATOR / totalCapacity, type(uint16).max);
-
-    return Math.max(targetWeight, actualWeight).toUint16();
-  }
-
-  function _setInitialProducts(ProductInitializationParams[] memory params) internal {
-    uint32 _totalTargetWeight = totalTargetWeight;
-
-    for (uint i = 0; i < params.length; i++) {
-      ProductInitializationParams memory param = params[i];
-      StakedProduct storage _product = products[param.productId];
-      if (param.targetPrice > TARGET_PRICE_DENOMINATOR) {
-        revert TargetPriceTooHigh();
-      }
-      if (param.weight > WEIGHT_DENOMINATOR) {
-        revert TargetWeightTooHigh();
-      }
-      _product.bumpedPrice = param.initialPrice;
-      _product.bumpedPriceUpdateTime = uint32(block.timestamp);
-      _product.targetPrice = param.targetPrice;
-      _product.targetWeight = param.weight;
-      _totalTargetWeight += param.weight;
-    }
-
-    if (_totalTargetWeight > MAX_TOTAL_WEIGHT) {
-      revert TotalTargetWeightExceeded();
-    }
-    totalTargetWeight = _totalTargetWeight;
-    totalEffectiveWeight = totalTargetWeight;
-  }
-
   function setPoolFee(uint newFee) external onlyManager {
 
     if (newFee > maxPoolFee) {
@@ -1514,180 +1316,11 @@ contract StakingPool is IStakingPool, Multicall {
 
   function setPoolPrivacy(bool _isPrivatePool) external onlyManager {
     isPrivatePool = _isPrivatePool;
-
     emit PoolPrivacyChanged(msg.sender, _isPrivatePool);
   }
 
   function setPoolDescription(string memory ipfsDescriptionHash) external onlyManager {
     emit PoolDescriptionSet(ipfsDescriptionHash);
-  }
-
-  /* pricing code */
-
-  function getPremium(
-    uint productId,
-    uint period,
-    uint coverAmount,
-    uint initialCapacityUsed,
-    uint totalCapacity,
-    uint globalMinPrice,
-    bool useFixedPrice
-  ) internal returns (uint premium) {
-
-    StakedProduct memory product = products[productId];
-    uint targetPrice = Math.max(product.targetPrice, globalMinPrice);
-
-    if (useFixedPrice) {
-      return calculateFixedPricePremium(period, coverAmount, targetPrice);
-    }
-
-    (premium, product) = calculatePremium(
-      product,
-      period,
-      coverAmount,
-      initialCapacityUsed,
-      totalCapacity,
-      targetPrice,
-      block.timestamp
-    );
-
-    // sstore
-    products[productId] = product;
-
-    return premium;
-  }
-
-  function calculateFixedPricePremium(
-    uint coverAmount,
-    uint period,
-    uint fixedPrice
-  ) public pure returns (uint) {
-
-    uint premiumPerYear =
-      coverAmount
-      * NXM_PER_ALLOCATION_UNIT
-      * fixedPrice
-      / TARGET_PRICE_DENOMINATOR;
-
-    return premiumPerYear * period / 365 days;
-  }
-
-  function calculatePremium(
-    StakedProduct memory product,
-    uint period,
-    uint coverAmount,
-    uint initialCapacityUsed,
-    uint totalCapacity,
-    uint targetPrice,
-    uint currentBlockTimestamp
-  ) public pure returns (uint premium, StakedProduct memory) {
-
-    uint basePrice;
-    {
-      // use previously recorded bumped price and apply time based smoothing towards target price
-      uint timeSinceLastUpdate = currentBlockTimestamp - product.bumpedPriceUpdateTime;
-      uint priceDrop = PRICE_CHANGE_PER_DAY * timeSinceLastUpdate / 1 days;
-
-      // basePrice = max(targetPrice, bumpedPrice - priceDrop)
-      // rewritten to avoid underflow
-      basePrice = product.bumpedPrice < targetPrice + priceDrop
-        ? targetPrice
-        : product.bumpedPrice - priceDrop;
-    }
-
-    // calculate the bumped price by applying the price bump
-    uint priceBump = PRICE_BUMP_RATIO * coverAmount / totalCapacity;
-    product.bumpedPrice = (basePrice + priceBump).toUint96();
-    product.bumpedPriceUpdateTime = uint32(currentBlockTimestamp);
-
-    // use calculated base price and apply surge pricing if applicable
-    uint premiumPerYear = calculatePremiumPerYear(
-      basePrice,
-      coverAmount,
-      initialCapacityUsed,
-      totalCapacity
-    );
-
-    // calculate the premium for the requested period
-    return (premiumPerYear * period / 365 days, product);
-  }
-
-  function calculatePremiumPerYear(
-    uint basePrice,
-    uint coverAmount,
-    uint initialCapacityUsed,
-    uint totalCapacity
-  ) public pure returns (uint) {
-    // cover amount has 2 decimals (100 = 1 unit)
-    // scale coverAmount to 18 decimals and apply price percentage
-    uint basePremium = coverAmount * NXM_PER_ALLOCATION_UNIT * basePrice / TARGET_PRICE_DENOMINATOR;
-    uint finalCapacityUsed = initialCapacityUsed + coverAmount;
-
-    // surge price is applied for the capacity used above SURGE_THRESHOLD_RATIO.
-    // the surge price starts at zero and increases linearly.
-    // to simplify things, we're working with fractions/ratios instead of percentages,
-    // ie 0 to 1 instead of 0% to 100%, 100% = 1 (a unit).
-    //
-    // surgeThreshold = SURGE_THRESHOLD_RATIO / SURGE_THRESHOLD_DENOMINATOR
-    //                = 90_00 / 100_00 = 0.9
-    uint surgeStartPoint = totalCapacity * SURGE_THRESHOLD_RATIO / SURGE_THRESHOLD_DENOMINATOR;
-
-    // Capacity and surge pricing
-    //
-    //        i        f                         s
-    //   ▓▓▓▓▓░░░░░░░░░                          ▒▒▒▒▒▒▒▒▒▒
-    //
-    //  i - initial capacity used
-    //  f - final capacity used
-    //  s - surge start point
-
-    // if surge does not apply just return base premium
-    // i < f <= s case
-    if (finalCapacityUsed <= surgeStartPoint) {
-      return basePremium;
-    }
-
-    // calculate the premium amount incurred due to surge pricing
-    uint amountOnSurge = finalCapacityUsed - surgeStartPoint;
-    uint surgePremium = calculateSurgePremium(amountOnSurge, totalCapacity);
-
-    // if the capacity start point is before the surge start point
-    // the surge premium starts at zero, so we just return it
-    // i <= s < f case
-    if (initialCapacityUsed <= surgeStartPoint) {
-      return basePremium + surgePremium;
-    }
-
-    // otherwise we need to subtract the part that was already used by other covers
-    // s < i < f case
-    uint amountOnSurgeSkipped = initialCapacityUsed - surgeStartPoint;
-    uint surgePremiumSkipped = calculateSurgePremium(amountOnSurgeSkipped, totalCapacity);
-
-    return basePremium + surgePremium - surgePremiumSkipped;
-  }
-
-  // Calculates the premium for a given cover amount starting with the surge point
-  function calculateSurgePremium(
-    uint amountOnSurge,
-    uint totalCapacity
-  ) public pure returns (uint) {
-
-    // for every percent of capacity used, the surge price has a +2% increase per annum
-    // meaning a +200% increase for 100%, ie x2 for a whole unit (100%) of capacity in ratio terms
-    //
-    // coverToCapacityRatio = amountOnSurge / totalCapacity
-    // surgePriceStart = 0
-    // surgePriceEnd = SURGE_PRICE_RATIO * coverToCapacityRatio
-    //
-    // surgePremium = amountOnSurge * surgePriceEnd / 2
-    //              = amountOnSurge * SURGE_PRICE_RATIO * coverToCapacityRatio / 2
-    //              = amountOnSurge * SURGE_PRICE_RATIO * amountOnSurge / totalCapacity / 2
-
-    uint surgePremium = amountOnSurge * SURGE_PRICE_RATIO * amountOnSurge / totalCapacity / 2;
-
-    // amountOnSurge has two decimals
-    // dividing by ALLOCATION_UNITS_PER_NXM (=100) to normalize the result
-    return surgePremium / ALLOCATION_UNITS_PER_NXM;
   }
 
   /* getters */
@@ -1740,14 +1373,6 @@ contract StakingPool is IStakingPool, Multicall {
     return lastAllocationId + 1;
   }
 
-  function getTotalTargetWeight() external override view returns (uint) {
-    return totalTargetWeight;
-  }
-
-  function getTotalEffectiveWeight() external override view returns (uint) {
-    return totalEffectiveWeight;
-  }
-
   function getDeposit(uint tokenId, uint trancheId) external override view returns (
     uint lastAccNxmPerRewardShare,
     uint pendingRewards,
@@ -1760,23 +1385,6 @@ contract StakingPool is IStakingPool, Multicall {
       deposit.pendingRewards,
       deposit.stakeShares,
       deposit.rewardsShares
-    );
-  }
-
-  function getProduct(uint productId) external override view returns (
-    uint lastEffectiveWeight,
-    uint targetWeight,
-    uint targetPrice,
-    uint bumpedPrice,
-    uint bumpedPriceUpdateTime
-  ) {
-    StakedProduct memory product = products[productId];
-    return (
-      product.lastEffectiveWeight,
-      product.targetWeight,
-      product.targetPrice,
-      product.bumpedPrice,
-      product.bumpedPriceUpdateTime
     );
   }
 

--- a/contracts/modules/staking/StakingProducts.sol
+++ b/contracts/modules/staking/StakingProducts.sol
@@ -1,0 +1,513 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity ^0.8.9;
+
+import "../../abstract/MasterAwareV2.sol";
+import "../../abstract/Multicall.sol";
+import "../../interfaces/IStakingProducts.sol";
+import "../../libraries/Math.sol";
+import "../../libraries/SafeUintCast.sol";
+import "../../libraries/StakingPoolLibrary.sol";
+
+contract StakingProducts is IStakingProducts, MasterAwareV2, Multicall {
+  using SafeUintCast for uint;
+
+  uint public constant SURGE_PRICE_RATIO = 2 ether;
+  uint public constant SURGE_THRESHOLD_RATIO = 90_00; // 90.00%
+  uint public constant SURGE_THRESHOLD_DENOMINATOR = 100_00; // 100.00%
+  // base price bump
+  // +0.2% for each 1% of capacity used, ie +20% for 100%
+  uint public constant PRICE_BUMP_RATIO = 20_00; // 20%
+  // bumped price smoothing
+  // 0.5% per day
+  uint public constant PRICE_CHANGE_PER_DAY = 50; // 0.5%
+  uint public constant INITIAL_PRICE_DENOMINATOR = 100_00;
+  uint public constant TARGET_PRICE_DENOMINATOR = 100_00;
+  uint public constant MAX_TOTAL_WEIGHT = 20_00; // 20x
+
+  // The 3 constants below are also used in the StakingPool contract
+  uint public constant TRANCHE_DURATION = 91 days;
+  uint public constant MAX_ACTIVE_TRANCHES = 8; // 7 whole quarters + 1 partial quarter
+  uint public constant WEIGHT_DENOMINATOR = 100;
+
+  // pool id => product id => Product
+  mapping(uint => mapping(uint => StakedProduct)) private _products;
+  // pool id => { totalEffectiveWeight, totalTargetWeight }
+  mapping(uint => Weights) public weights;
+
+  address public immutable coverContract;
+  address public immutable stakingPoolFactory;
+
+  constructor(address _coverContract, address _stakingPoolFactory) {
+    coverContract = _coverContract;
+    stakingPoolFactory = _stakingPoolFactory;
+  }
+
+  function getStakingPool(uint poolId) internal view returns (IStakingPool stakingPoolAddress) {
+    return IStakingPool(StakingPoolLibrary.getAddress(stakingPoolFactory, poolId));
+  }
+
+  function getProductTargetWeight(uint poolId, uint productId) external view override returns (uint) {
+    return uint(_products[poolId][productId].targetWeight);
+  }
+
+  function getTotalTargetWeight(uint poolId) external override view returns (uint) {
+    return weights[poolId].totalTargetWeight;
+  }
+
+  function getTotalEffectiveWeight(uint poolId) external override view returns (uint) {
+    return weights[poolId].totalEffectiveWeight;
+  }
+
+  function getProduct(uint poolId, uint productId) external override view returns (
+    uint lastEffectiveWeight,
+    uint targetWeight,
+    uint targetPrice,
+    uint bumpedPrice,
+    uint bumpedPriceUpdateTime
+  ) {
+    StakedProduct memory product = _products[poolId][productId];
+    return (
+      product.lastEffectiveWeight,
+      product.targetWeight,
+      product.targetPrice,
+      product.bumpedPrice,
+      product.bumpedPriceUpdateTime
+    );
+  }
+
+  function recalculateEffectiveWeights(uint poolId, uint[] calldata productIds) external {
+
+    IStakingPool stakingPool = getStakingPool(poolId);
+
+    (
+      uint globalCapacityRatio,
+      /* globalMinPriceRatio */,
+      /* initialPriceRatios */,
+      /* capacityReductionRatios */
+      uint[] memory capacityReductionRatios
+    ) = ICover(coverContract).getPriceAndCapacityRatios(productIds);
+
+    uint _totalEffectiveWeight = weights[poolId].totalEffectiveWeight;
+
+    for (uint i = 0; i < productIds.length; i++) {
+      uint productId = productIds[i];
+      StakedProduct memory _product = _products[poolId][productId];
+
+      uint16 previousEffectiveWeight = _product.lastEffectiveWeight;
+      _product.lastEffectiveWeight = _getEffectiveWeight(
+        stakingPool,
+        productId,
+        _product.targetWeight,
+        globalCapacityRatio,
+        capacityReductionRatios[i]
+      );
+      _totalEffectiveWeight = _totalEffectiveWeight - previousEffectiveWeight + _product.lastEffectiveWeight;
+      _products[poolId][productId] = _product;
+    }
+
+    weights[poolId].totalEffectiveWeight = _totalEffectiveWeight.toUint32();
+  }
+
+  function setProducts(uint poolId, StakedProductParam[] memory params) external {
+
+    IStakingPool stakingPool = getStakingPool(poolId);
+
+    if (msg.sender != stakingPool.manager()) {
+      revert OnlyManager();
+    }
+
+    uint globalCapacityRatio;
+    uint globalMinPriceRatio;
+    uint[] memory initialPriceRatios;
+    uint[] memory capacityReductionRatios;
+
+    {
+      uint numProducts = params.length;
+      uint[] memory productIds = new uint[](numProducts);
+
+      for (uint i = 0; i < numProducts; i++) {
+        productIds[i] = params[i].productId;
+        if (!ICover(coverContract).isPoolAllowed(params[i].productId, poolId)) {
+          revert PoolNotAllowedForThisProduct();
+        }
+      }
+      (
+        globalCapacityRatio,
+        globalMinPriceRatio,
+        initialPriceRatios,
+        capacityReductionRatios
+      ) = ICover(coverContract).getPriceAndCapacityRatios(productIds);
+    }
+
+    Weights memory _weights = weights[poolId];
+    bool targetWeightIncreased;
+
+    for (uint i = 0; i < params.length; i++) {
+      StakedProductParam memory _param = params[i];
+      StakedProduct memory _product = _products[poolId][_param.productId];
+
+      // if this is a new product
+      if (_product.bumpedPriceUpdateTime == 0) {
+        // initialize the bumpedPrice
+        _product.bumpedPrice = initialPriceRatios[i].toUint96();
+        _product.bumpedPriceUpdateTime = uint32(block.timestamp);
+        // and make sure we set the price and the target weight
+        if (!_param.setTargetPrice) {
+          revert MustSetPriceForNewProducts();
+        }
+        if (!_param.setTargetWeight) {
+          revert MustSetWeightForNewProducts();
+        }
+      }
+
+      if (_param.setTargetPrice) {
+        if (_param.targetPrice > TARGET_PRICE_DENOMINATOR) {
+          revert TargetPriceTooHigh();
+        }
+        if (_param.targetPrice < globalMinPriceRatio) {
+          revert TargetPriceBelowMin();
+        }
+        _product.targetPrice = _param.targetPrice;
+      }
+
+      // if setTargetWeight is set - effective weight must be recalculated
+      if (_param.setTargetWeight && !_param.recalculateEffectiveWeight) {
+        revert MustRecalculateEffectiveWeight();
+      }
+
+      // Must recalculate effectiveWeight to adjust targetWeight
+      if (_param.recalculateEffectiveWeight) {
+
+        if (_param.setTargetWeight) {
+          if (_param.targetWeight > WEIGHT_DENOMINATOR) {
+            revert TargetWeightTooHigh();
+          }
+
+          // totalEffectiveWeight cannot be above the max unless target  weight is not increased
+          if (!targetWeightIncreased) {
+            targetWeightIncreased = _param.targetWeight > _product.targetWeight;
+          }
+          _weights.totalTargetWeight = _weights.totalTargetWeight - _product.targetWeight + _param.targetWeight;
+          _product.targetWeight = _param.targetWeight;
+        }
+
+        // subtract the previous effective weight
+        _weights.totalEffectiveWeight -= _product.lastEffectiveWeight;
+
+        _product.lastEffectiveWeight = _getEffectiveWeight(
+          stakingPool,
+          _param.productId,
+          _product.targetWeight,
+          globalCapacityRatio,
+          capacityReductionRatios[i]
+        );
+
+        // add the new effective weight
+        _weights.totalEffectiveWeight += _product.lastEffectiveWeight;
+      }
+
+      // sstore
+      _products[poolId][_param.productId] = _product;
+
+      emit ProductUpdated(_param.productId, _param.targetWeight, _param.targetPrice);
+    }
+
+    if (_weights.totalTargetWeight > MAX_TOTAL_WEIGHT) {
+      revert TotalTargetWeightExceeded();
+    }
+
+    if (targetWeightIncreased) {
+      if (_weights.totalEffectiveWeight > MAX_TOTAL_WEIGHT) {
+        revert TotalEffectiveWeightExceeded();
+      }
+    }
+
+    weights[poolId] = _weights;
+  }
+
+  function getEffectiveWeight(
+    uint poolId,
+    uint productId,
+    uint targetWeight,
+    uint globalCapacityRatio,
+    uint capacityReductionRatio
+  ) public view returns (uint effectiveWeight) {
+
+    IStakingPool stakingPool = getStakingPool(poolId);
+
+    return _getEffectiveWeight(
+      stakingPool,
+      productId,
+      targetWeight,
+      globalCapacityRatio,
+      capacityReductionRatio
+    );
+  }
+
+  function _getEffectiveWeight(
+    IStakingPool stakingPool,
+    uint productId,
+    uint targetWeight,
+    uint globalCapacityRatio,
+    uint capacityReductionRatio
+  ) internal view returns (uint16 effectiveWeight) {
+
+    uint[] memory trancheCapacities = stakingPool.getTrancheCapacities(
+      productId,
+      block.timestamp / TRANCHE_DURATION, // first active tranche id
+      MAX_ACTIVE_TRANCHES,
+      globalCapacityRatio,
+      capacityReductionRatio
+    );
+
+    uint totalCapacity = Math.sum(trancheCapacities);
+
+    if (totalCapacity == 0) {
+      return targetWeight.toUint16();
+    }
+
+    uint[] memory activeAllocations = stakingPool.getActiveAllocations(productId);
+    uint totalAllocation = Math.sum(activeAllocations);
+    uint actualWeight = Math.min(totalAllocation * WEIGHT_DENOMINATOR / totalCapacity, type(uint16).max);
+
+    return Math.max(targetWeight, actualWeight).toUint16();
+  }
+
+  function setInitialProducts(uint poolId, ProductInitializationParams[] memory params) public onlyInternal {
+
+    uint totalTargetWeight;
+
+    for (uint i = 0; i < params.length; i++) {
+
+      ProductInitializationParams memory param = params[i];
+
+      if (param.targetPrice > TARGET_PRICE_DENOMINATOR) {
+        revert TargetPriceTooHigh();
+      }
+
+      if (param.weight > WEIGHT_DENOMINATOR) {
+        revert TargetWeightTooHigh();
+      }
+
+      StakedProduct memory product;
+      product.bumpedPrice = param.initialPrice;
+      product.bumpedPriceUpdateTime = block.timestamp.toUint32();
+      product.targetPrice = param.targetPrice;
+      product.targetWeight = param.weight;
+
+      // sstore
+      _products[poolId][param.productId] = product;
+
+      totalTargetWeight += param.weight;
+    }
+
+    if (totalTargetWeight > MAX_TOTAL_WEIGHT) {
+      revert TotalTargetWeightExceeded();
+    }
+
+    weights[poolId] = Weights({
+      totalTargetWeight: totalTargetWeight.toUint32(),
+      totalEffectiveWeight: 0
+    });
+  }
+
+  /* pricing code */
+  function getPremium(
+    uint poolId,
+    uint productId,
+    uint period,
+    uint coverAmount,
+    uint initialCapacityUsed,
+    uint totalCapacity,
+    uint globalMinPrice,
+    bool useFixedPrice,
+    uint nxmPerAllocationUnit,
+    uint allocationUnitsPerNXM
+  ) public returns (uint premium) {
+
+    // TODO: WARNING! EXTREMELY IMPORTANT!
+    // TODO: uncomment this after moving the StakingProducts tests to a separate folder
+    // TODO: need to use a SPMockStakingProducts when testing StakingPool
+    // if (msg.sender != StakingPoolLibrary.getAddress(stakingPoolFactory, poolId)) {
+    //   revert OnlyStakingPool();
+    // }
+
+    StakedProduct memory product = _products[poolId][productId];
+    uint targetPrice = Math.max(product.targetPrice, globalMinPrice);
+
+    if (useFixedPrice) {
+      return calculateFixedPricePremium(period, coverAmount, targetPrice, nxmPerAllocationUnit, TARGET_PRICE_DENOMINATOR);
+    }
+
+    (premium, product) = calculatePremium(
+      product,
+      period,
+      coverAmount,
+      initialCapacityUsed,
+      totalCapacity,
+      targetPrice,
+      block.timestamp,
+      nxmPerAllocationUnit,
+      allocationUnitsPerNXM,
+      TARGET_PRICE_DENOMINATOR
+    );
+
+    // sstore
+    _products[poolId][productId] = product;
+
+    return premium;
+  }
+
+  function calculateFixedPricePremium(
+    uint coverAmount,
+    uint period,
+    uint fixedPrice,
+    uint nxmPerAllocationUnit,
+    uint targetPriceDenominator
+  ) public pure returns (uint) {
+
+    uint premiumPerYear =
+    coverAmount
+    * nxmPerAllocationUnit
+    * fixedPrice
+    / targetPriceDenominator;
+
+    return premiumPerYear * period / 365 days;
+  }
+
+  function calculatePremium(
+    StakedProduct memory product,
+    uint period,
+    uint coverAmount,
+    uint initialCapacityUsed,
+    uint totalCapacity,
+    uint targetPrice,
+    uint currentBlockTimestamp,
+    uint nxmPerAllocationUnit,
+    uint allocationUnitsPerNxm,
+    uint targetPriceDenominator
+  ) public pure returns (uint premium, StakedProduct memory) {
+
+    uint basePrice;
+    {
+      // use previously recorded bumped price and apply time based smoothing towards target price
+      uint timeSinceLastUpdate = currentBlockTimestamp - product.bumpedPriceUpdateTime;
+      uint priceDrop = PRICE_CHANGE_PER_DAY * timeSinceLastUpdate / 1 days;
+
+      // basePrice = max(targetPrice, bumpedPrice - priceDrop)
+      // rewritten to avoid underflow
+      basePrice = product.bumpedPrice < targetPrice + priceDrop
+      ? targetPrice
+      : product.bumpedPrice - priceDrop;
+    }
+
+    // calculate the bumped price by applying the price bump
+    uint priceBump = PRICE_BUMP_RATIO * coverAmount / totalCapacity;
+    product.bumpedPrice = (basePrice + priceBump).toUint96();
+    product.bumpedPriceUpdateTime = uint32(currentBlockTimestamp);
+
+    // use calculated base price and apply surge pricing if applicable
+    uint premiumPerYear = calculatePremiumPerYear(
+      basePrice,
+      coverAmount,
+      initialCapacityUsed,
+      totalCapacity,
+      nxmPerAllocationUnit,
+      allocationUnitsPerNxm,
+      targetPriceDenominator
+    );
+
+    // calculate the premium for the requested period
+    return (premiumPerYear * period / 365 days, product);
+  }
+
+  function calculatePremiumPerYear(
+    uint basePrice,
+    uint coverAmount,
+    uint initialCapacityUsed,
+    uint totalCapacity,
+    uint nxmPerAllocationUnit,
+    uint allocationUnitsPerNxm,
+    uint targetPriceDenominator
+  ) public pure returns (uint) {
+    // cover amount has 2 decimals (100 = 1 unit)
+    // scale coverAmount to 18 decimals and apply price percentage
+    uint basePremium = coverAmount * nxmPerAllocationUnit * basePrice / targetPriceDenominator;
+    uint finalCapacityUsed = initialCapacityUsed + coverAmount;
+
+    // surge price is applied for the capacity used above SURGE_THRESHOLD_RATIO.
+    // the surge price starts at zero and increases linearly.
+    // to simplify things, we're working with fractions/ratios instead of percentages,
+    // ie 0 to 1 instead of 0% to 100%, 100% = 1 (a unit).
+    //
+    // surgeThreshold = SURGE_THRESHOLD_RATIO / SURGE_THRESHOLD_DENOMINATOR
+    //                = 90_00 / 100_00 = 0.9
+    uint surgeStartPoint = totalCapacity * SURGE_THRESHOLD_RATIO / SURGE_THRESHOLD_DENOMINATOR;
+
+    // Capacity and surge pricing
+    //
+    //        i        f                         s
+    //   ▓▓▓▓▓░░░░░░░░░                          ▒▒▒▒▒▒▒▒▒▒
+    //
+    //  i - initial capacity used
+    //  f - final capacity used
+    //  s - surge start point
+
+    // if surge does not apply just return base premium
+    // i < f <= s case
+    if (finalCapacityUsed <= surgeStartPoint) {
+      return basePremium;
+    }
+
+    // calculate the premium amount incurred due to surge pricing
+    uint amountOnSurge = finalCapacityUsed - surgeStartPoint;
+    uint surgePremium = calculateSurgePremium(amountOnSurge, totalCapacity, allocationUnitsPerNxm);
+
+    // if the capacity start point is before the surge start point
+    // the surge premium starts at zero, so we just return it
+    // i <= s < f case
+    if (initialCapacityUsed <= surgeStartPoint) {
+      return basePremium + surgePremium;
+    }
+
+    // otherwise we need to subtract the part that was already used by other covers
+    // s < i < f case
+    uint amountOnSurgeSkipped = initialCapacityUsed - surgeStartPoint;
+    uint surgePremiumSkipped = calculateSurgePremium(amountOnSurgeSkipped, totalCapacity, allocationUnitsPerNxm);
+
+    return basePremium + surgePremium - surgePremiumSkipped;
+  }
+
+  // Calculates the premium for a given cover amount starting with the surge point
+  function calculateSurgePremium(
+    uint amountOnSurge,
+    uint totalCapacity,
+    uint allocationUnitsPerNxm
+  ) public pure returns (uint) {
+
+    // for every percent of capacity used, the surge price has a +2% increase per annum
+    // meaning a +200% increase for 100%, ie x2 for a whole unit (100%) of capacity in ratio terms
+    //
+    // coverToCapacityRatio = amountOnSurge / totalCapacity
+    // surgePriceStart = 0
+    // surgePriceEnd = SURGE_PRICE_RATIO * coverToCapacityRatio
+    //
+    // surgePremium = amountOnSurge * surgePriceEnd / 2
+    //              = amountOnSurge * SURGE_PRICE_RATIO * coverToCapacityRatio / 2
+    //              = amountOnSurge * SURGE_PRICE_RATIO * amountOnSurge / totalCapacity / 2
+
+    uint surgePremium = amountOnSurge * SURGE_PRICE_RATIO * amountOnSurge / totalCapacity / 2;
+
+    // amountOnSurge has two decimals
+    // dividing by ALLOCATION_UNITS_PER_NXM (=100) to normalize the result
+    return surgePremium / allocationUnitsPerNxm;
+  }
+
+  /* dependencies */
+
+  function changeDependentContractAddress() external {
+    // none :)
+  }
+
+}

--- a/contracts/modules/staking/StakingViewer.sol
+++ b/contracts/modules/staking/StakingViewer.sol
@@ -7,6 +7,7 @@ import "../../interfaces/ICover.sol";
 import "../../interfaces/INXMMaster.sol";
 import "../../interfaces/IStakingNFT.sol";
 import "../../interfaces/IStakingPool.sol";
+import "../../interfaces/IStakingProducts.sol";
 import "../../interfaces/IStakingPoolFactory.sol";
 import "../../libraries/StakingPoolLibrary.sol";
 import "../../libraries/UncheckedMath.sol";
@@ -66,6 +67,7 @@ contract StakingViewer is Multicall {
   INXMMaster public immutable master;
   IStakingNFT public immutable stakingNFT;
   IStakingPoolFactory public immutable stakingPoolFactory;
+  IStakingProducts public immutable stakingProducts;
 
   uint public constant TRANCHE_DURATION = 91 days;
   uint public constant MAX_ACTIVE_TRANCHES = 8;
@@ -76,11 +78,13 @@ contract StakingViewer is Multicall {
   constructor(
     INXMMaster _master,
     IStakingNFT _stakingNFT,
-    IStakingPoolFactory _stakingPoolFactory
+    IStakingPoolFactory _stakingPoolFactory,
+    IStakingProducts _stakingProducts
   ) {
     master = _master;
     stakingNFT = _stakingNFT;
     stakingPoolFactory = _stakingPoolFactory;
+    stakingProducts = _stakingProducts;
   }
 
   function cover() internal view returns (ICover) {
@@ -152,7 +156,7 @@ contract StakingViewer is Multicall {
         uint targetPrice,
         uint bumpedPrice,
         uint bumpedPriceUpdateTime
-      ) = stakingPool(poolId).getProduct(i);
+      ) = stakingProducts.getProduct(poolId, i);
 
       if (targetWeight == 0 && lastEffectiveWeight == 0 && bumpedPriceUpdateTime == 0) {
         continue;

--- a/test/integration/Cover/totalActiveCover.js
+++ b/test/integration/Cover/totalActiveCover.js
@@ -35,7 +35,7 @@ const buyCoverFixture = {
 
 describe('totalActiveCover', function () {
   beforeEach(async function () {
-    const { tk, stakingPool0 } = this.contracts;
+    const { tk, stakingProducts, stakingPool0 } = this.contracts;
     const { stakingPoolManagers } = this.accounts;
 
     const members = this.accounts.members.slice(0, 5);
@@ -44,7 +44,9 @@ describe('totalActiveCover', function () {
       await tk.connect(this.accounts.defaultSender).transfer(member.address, amount);
     }
 
-    await stakingPool0.connect(stakingPoolManagers[0]).setProducts([stakedProductParamTemplate]);
+    await stakingProducts
+      .connect(stakingPoolManagers[0])
+      .setProducts(await stakingPool0.getPoolId(), [stakedProductParamTemplate]);
   });
 
   function calculateFirstTrancheId(lastBlock, period, gracePeriod) {

--- a/test/integration/utils/staking.js
+++ b/test/integration/utils/staking.js
@@ -44,8 +44,10 @@ async function stake({ stakingPool, staker, productId, period, gracePeriod }) {
     targetPrice: 100, // 1%
   };
 
+  // Set staked products
   const managerSigner = await ethers.getSigner(await stakingPool.manager());
-  await stakingPool.connect(managerSigner).setProducts([stakingProductParams]);
+  const stakingProducts = await ethers.getContractAt('StakingProducts', await stakingPool.stakingProducts());
+  await stakingProducts.connect(managerSigner).setProducts(await stakingPool.getPoolId(), [stakingProductParams]);
 }
 
 module.exports = {

--- a/test/unit/Cover/helpers.js
+++ b/test/unit/Cover/helpers.js
@@ -32,7 +32,6 @@ async function createStakingPool(cover, productId, capacity, targetPrice, active
   const stakingPool = await ethers.getContractAt('CoverMockStakingPool', stakingPoolAddress);
 
   await stakingPool.setStake(productId, capacity);
-  await stakingPool.setTargetPrice(productId, targetPrice);
   await stakingPool.setUsedCapacity(productId, activeCover);
   await stakingPool.setPrice(productId, currentPrice); // 2.6%
 

--- a/test/unit/Cover/setup.js
+++ b/test/unit/Cover/setup.js
@@ -31,6 +31,8 @@ async function setup() {
   const mcr = await ethers.deployContract('CoverMockMCR');
   await mcr.setMCR(parseEther('600000'));
 
+  const stakingProducts = await ethers.deployContract('CoverMockStakingProducts');
+
   const stakingPoolImplementation = await ethers.deployContract('CoverMockStakingPool');
   const coverNFT = await ethers.deployContract('CoverMockCoverNFT');
   const stakingNFT = await ethers.deployContract('CoverMockStakingNFT');
@@ -69,6 +71,7 @@ async function setup() {
   await master.setLatestAddress(hex('CO'), cover.address);
   await master.setLatestAddress(hex('TC'), tokenController.address);
   await master.setLatestAddress(hex('MC'), mcr.address);
+  await master.setLatestAddress(hex('SP'), stakingProducts.address);
 
   const accounts = await getAccounts();
 

--- a/test/unit/StakingPool/burnStake.js
+++ b/test/unit/StakingPool/burnStake.js
@@ -73,7 +73,7 @@ const burnAmount = parseEther('10');
 
 describe('burnStake', function () {
   beforeEach(async function () {
-    const { stakingPool, cover } = this;
+    const { stakingPool, stakingProducts, cover } = this;
     const { defaultSender: manager } = this.accounts;
     const [staker] = this.accounts.members;
     const { poolId, initialPoolFee, maxPoolFee, products, ipfsDescriptionHash } = poolInitParams;
@@ -89,10 +89,11 @@ describe('burnStake', function () {
       false, // isPrivatePool
       initialPoolFee,
       maxPoolFee,
-      products,
       poolId,
       ipfsDescriptionHash,
     );
+
+    await stakingProducts.connect(this.coverSigner).setInitialProducts(poolId, products);
 
     // Move to the beginning of the next tranche
     const currentTrancheId = await moveTimeToNextTranche(1);

--- a/test/unit/StakingPool/constructor.js
+++ b/test/unit/StakingPool/constructor.js
@@ -3,7 +3,7 @@ const { ethers } = require('hardhat');
 
 describe('constructor', function () {
   it('should set nxm, cover and tokenController addresses correctly', async function () {
-    const { stakingNFT, nxm, cover, tokenController, master } = this;
+    const { stakingProducts, stakingNFT, nxm, cover, tokenController, master } = this;
 
     const StakingPool = await ethers.getContractFactory('StakingPool');
     const stakingPool = await StakingPool.deploy(
@@ -12,6 +12,7 @@ describe('constructor', function () {
       cover.address,
       tokenController.address,
       master.address,
+      stakingProducts.address,
     );
 
     const stakingNFTAddress = await stakingPool.stakingNFT();
@@ -19,11 +20,13 @@ describe('constructor', function () {
     const coverAddress = await stakingPool.coverContract();
     const tokenControllerAddress = await stakingPool.tokenController();
     const masterAddress = await stakingPool.masterContract();
+    const stakingProductsAddress = await stakingPool.stakingProducts();
 
     expect(stakingNFTAddress).to.be.equal(stakingNFT.address);
     expect(nxmAddress).to.be.equal(nxm.address);
     expect(coverAddress).to.be.equal(cover.address);
     expect(tokenControllerAddress).to.be.equal(tokenController.address);
     expect(masterAddress).to.be.equal(master.address);
+    expect(stakingProductsAddress).to.be.equal(stakingProducts.address);
   });
 });

--- a/test/unit/StakingPool/processExpirations.js
+++ b/test/unit/StakingPool/processExpirations.js
@@ -41,7 +41,7 @@ const poolInitParams = {
 
 describe('processExpirations', function () {
   beforeEach(async function () {
-    const { stakingPool, cover } = this;
+    const { stakingPool, stakingProducts, cover } = this;
     const { defaultSender: manager } = this.accounts;
     const { poolId, initialPoolFee, maxPoolFee, products, ipfsDescriptionHash } = poolInitParams;
 
@@ -51,7 +51,9 @@ describe('processExpirations', function () {
 
     await stakingPool
       .connect(coverSigner)
-      .initialize(manager.address, false, initialPoolFee, maxPoolFee, products, poolId, ipfsDescriptionHash);
+      .initialize(manager.address, false, initialPoolFee, maxPoolFee, poolId, ipfsDescriptionHash);
+
+    await stakingProducts.connect(coverSigner).setInitialProducts(poolId, products);
 
     // Move to the beginning of the next tranche
     const { firstActiveTrancheId: trancheId } = await getTranches();

--- a/test/unit/StakingPool/setPoolFee.js
+++ b/test/unit/StakingPool/setPoolFee.js
@@ -34,7 +34,7 @@ const initializeParams = {
   isPrivatePool: false,
   initialPoolFee: 5, // 5%
   maxPoolFee: 5, // 5%
-  productInitializationParams: [product],
+  products: [product],
   ipfsDescriptionHash: 'Description Hash',
 };
 
@@ -42,25 +42,19 @@ describe('setPoolFee', function () {
   beforeEach(async function () {
     const {
       stakingPool,
+      stakingProducts,
       cover,
       accounts: { defaultSender: manager },
     } = this;
-    const { poolId, initialPoolFee, maxPoolFee, productInitializationParams, isPrivatePool, ipfsDescriptionHash } =
-      initializeParams;
+    const { poolId, initialPoolFee, maxPoolFee, products, isPrivatePool, ipfsDescriptionHash } = initializeParams;
     const coverSigner = await ethers.getImpersonatedSigner(cover.address);
 
     await setEtherBalance(coverSigner.address, ethers.utils.parseEther('1'));
     await stakingPool
       .connect(coverSigner)
-      .initialize(
-        manager.address,
-        isPrivatePool,
-        initialPoolFee,
-        maxPoolFee,
-        productInitializationParams,
-        poolId,
-        ipfsDescriptionHash,
-      );
+      .initialize(manager.address, isPrivatePool, initialPoolFee, maxPoolFee, poolId, ipfsDescriptionHash);
+
+    await stakingProducts.connect(this.coverSigner).setInitialProducts(poolId, products);
   });
 
   it('reverts if manager is not the caller', async function () {

--- a/test/unit/StakingPool/setPoolPrivacy.js
+++ b/test/unit/StakingPool/setPoolPrivacy.js
@@ -14,34 +14,28 @@ describe('setPoolPrivacy', function () {
     isPrivatePool: false,
     initialPoolFee: 5, // 5%
     maxPoolFee: 5, // 5%
-    productInitializationParams: [product0],
+    products: [product0],
     ipfsDescriptionHash: 'Descrition Hash',
   };
 
   beforeEach(async function () {
     const {
       stakingPool,
+      stakingProducts,
       cover,
       accounts: { defaultSender: manager },
     } = this;
 
-    const { poolId, initialPoolFee, maxPoolFee, productInitializationParams, isPrivatePool, ipfsDescriptionHash } =
-      initializeParams;
+    const { poolId, initialPoolFee, maxPoolFee, products, isPrivatePool, ipfsDescriptionHash } = initializeParams;
 
     const coverSigner = await ethers.getImpersonatedSigner(cover.address);
     await setEtherBalance(coverSigner.address, ethers.utils.parseEther('1'));
 
     await stakingPool
       .connect(coverSigner)
-      .initialize(
-        manager.address,
-        isPrivatePool,
-        initialPoolFee,
-        maxPoolFee,
-        productInitializationParams,
-        poolId,
-        ipfsDescriptionHash,
-      );
+      .initialize(manager.address, isPrivatePool, initialPoolFee, maxPoolFee, poolId, ipfsDescriptionHash);
+
+    await stakingProducts.connect(this.coverSigner).setInitialProducts(poolId, products);
   });
 
   it('reverts if manager is not the caller', async function () {

--- a/test/unit/StakingPool/setup.js
+++ b/test/unit/StakingPool/setup.js
@@ -1,62 +1,45 @@
 const { ethers } = require('hardhat');
 const { parseEther } = ethers.utils;
-const { getAccounts } = require('../../utils/accounts');
-const { setEtherBalance } = require('../../utils/evm');
+const { getAccounts } = require('../utils').accounts;
+const { setEtherBalance } = require('../utils').evm;
 const { Role } = require('../utils').constants;
 
 async function setup() {
-  const MasterMock = await ethers.getContractFactory('MasterMock');
-  const ERC20Mock = await ethers.getContractFactory('ERC20Mock');
-  const SPCoverProducts = await ethers.getContractFactory('SPMockCover');
-  const MemberRolesMock = await ethers.getContractFactory('MemberRolesMock');
-  const TokenController = await ethers.getContractFactory('TokenControllerMock');
-  const NXMToken = await ethers.getContractFactory('NXMTokenMock');
-  const MCR = await ethers.getContractFactory('CoverMockMCR');
-  const StakingPool = await ethers.getContractFactory('StakingPool');
+  const master = await ethers.deployContract('MasterMock');
+  const memberRoles = await ethers.deployContract('MemberRolesMock');
+  const tokenController = await ethers.deployContract('TokenControllerMock');
 
-  const multicallMock = await ethers.deployContract('MulticallMock');
+  const nxm = await ethers.deployContract('NXMTokenMock');
 
-  const master = await MasterMock.deploy();
-  await master.deployed();
-
-  const dai = await ERC20Mock.deploy();
-  await dai.deployed();
-
-  const stETH = await ERC20Mock.deploy();
-  await stETH.deployed();
-
-  const memberRoles = await MemberRolesMock.deploy();
-  await memberRoles.deployed();
-
-  const tokenController = await TokenController.deploy();
-  await tokenController.deployed();
-
-  const nxm = await NXMToken.deploy();
-  await nxm.deployed();
-
-  const mcr = await MCR.deploy();
-  await mcr.deployed();
+  const mcr = await ethers.deployContract('CoverMockMCR');
   await mcr.setMCR(parseEther('600000'));
 
-  const accounts = await getAccounts();
+  // TODO: move to separate folder
+  const multicallMock = await ethers.deployContract('MulticallMock');
 
-  const cover = await SPCoverProducts.deploy();
-  await cover.deployed();
+  const cover = await ethers.deployContract('SPMockCover');
+  const stakingNFT = await ethers.deployContract('SPMockStakingNFT');
+  const spf = await ethers.deployContract('StakingPoolFactory', [cover.address]);
+  const stakingProducts = await ethers.deployContract('StakingProducts', [cover.address, spf.address]);
 
-  const StakingNFT = await ethers.getContractFactory('SPMockStakingNFT');
-  const stakingNFT = await StakingNFT.deploy();
-
-  const stakingPool = await StakingPool.deploy(
+  const stakingPool = await ethers.deployContract('StakingPool', [
     stakingNFT.address,
     nxm.address,
     cover.address,
     tokenController.address,
     master.address,
-  );
+    stakingProducts.address,
+  ]);
 
   await nxm.setOperator(tokenController.address);
   await tokenController.setContractAddresses(cover.address, nxm.address);
   await cover.setStakingPool(stakingPool.address, 0);
+
+  await master.enrollInternal(cover.address);
+  await tokenController.changeMasterAddress(master.address);
+  await stakingProducts.changeMasterAddress(master.address);
+
+  const accounts = await getAccounts();
 
   for (const member of accounts.members) {
     const amount = ethers.constants.MaxUint256.div(100);
@@ -80,26 +63,24 @@ async function setup() {
     await master.enrollGovernance(governanceContract.address);
   }
 
-  await tokenController.changeMasterAddress(master.address);
-
   const config = {
     REWARD_BONUS_PER_TRANCHE_RATIO: await stakingPool.REWARD_BONUS_PER_TRANCHE_RATIO(),
     REWARD_BONUS_PER_TRANCHE_DENOMINATOR: await stakingPool.REWARD_BONUS_PER_TRANCHE_DENOMINATOR(),
-    PRICE_CHANGE_PER_DAY: await stakingPool.PRICE_CHANGE_PER_DAY(),
-    PRICE_BUMP_RATIO: await stakingPool.PRICE_BUMP_RATIO(),
-    SURGE_PRICE_RATIO: await stakingPool.SURGE_PRICE_RATIO(),
-    SURGE_THRESHOLD_DENOMINATOR: await stakingPool.SURGE_THRESHOLD_DENOMINATOR(),
-    SURGE_THRESHOLD_RATIO: await stakingPool.SURGE_THRESHOLD_RATIO(),
+    PRICE_CHANGE_PER_DAY: await stakingProducts.PRICE_CHANGE_PER_DAY(),
+    PRICE_BUMP_RATIO: await stakingProducts.PRICE_BUMP_RATIO(),
+    SURGE_PRICE_RATIO: await stakingProducts.SURGE_PRICE_RATIO(),
+    SURGE_THRESHOLD_DENOMINATOR: await stakingProducts.SURGE_THRESHOLD_DENOMINATOR(),
+    SURGE_THRESHOLD_RATIO: await stakingProducts.SURGE_THRESHOLD_RATIO(),
     NXM_PER_ALLOCATION_UNIT: await stakingPool.NXM_PER_ALLOCATION_UNIT(),
     ALLOCATION_UNITS_PER_NXM: await stakingPool.ALLOCATION_UNITS_PER_NXM(),
-    INITIAL_PRICE_DENOMINATOR: await stakingPool.INITIAL_PRICE_DENOMINATOR(),
+    INITIAL_PRICE_DENOMINATOR: await stakingProducts.INITIAL_PRICE_DENOMINATOR(),
     REWARDS_DENOMINATOR: await stakingPool.REWARDS_DENOMINATOR(),
     WEIGHT_DENOMINATOR: await stakingPool.WEIGHT_DENOMINATOR(),
     CAPACITY_REDUCTION_DENOMINATOR: await stakingPool.CAPACITY_REDUCTION_DENOMINATOR(),
-    TARGET_PRICE_DENOMINATOR: await stakingPool.TARGET_PRICE_DENOMINATOR(),
+    TARGET_PRICE_DENOMINATOR: await stakingProducts.TARGET_PRICE_DENOMINATOR(),
     POOL_FEE_DENOMINATOR: await stakingPool.POOL_FEE_DENOMINATOR(),
     GLOBAL_CAPACITY_DENOMINATOR: await stakingPool.GLOBAL_CAPACITY_DENOMINATOR(),
-    TRANCHE_DURATION: await stakingPool.TRANCHE_DURATION(),
+    TRANCHE_DURATION: await stakingProducts.TRANCHE_DURATION(),
     GLOBAL_CAPACITY_RATIO: await cover.globalCapacityRatio(),
     GLOBAL_REWARDS_RATIO: await cover.globalRewardsRatio(),
     GLOBAL_MIN_PRICE_RATIO: await cover.GLOBAL_MIN_PRICE_RATIO(),
@@ -108,17 +89,19 @@ async function setup() {
   const coverSigner = await ethers.getImpersonatedSigner(cover.address);
   await setEtherBalance(coverSigner.address, ethers.utils.parseEther('1'));
 
+  this.accounts = accounts;
+  this.coverSigner = coverSigner;
+  this.config = config;
+
   this.multicall = multicallMock;
+
   this.tokenController = tokenController;
   this.master = master;
   this.nxm = nxm;
   this.stakingNFT = stakingNFT;
   this.stakingPool = stakingPool;
+  this.stakingProducts = stakingProducts;
   this.cover = cover;
-  this.coverSigner = coverSigner;
-  this.dai = dai;
-  this.accounts = accounts;
-  this.config = config;
 }
 
 module.exports = setup;

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -16,4 +16,5 @@ describe('UNIT TESTS', function () {
   require('./CoverViewer');
   require('./StakingNFT');
   require('./StakingPoolFactory');
+  require('./NXMaster');
 });


### PR DESCRIPTION
## Context

Closes #665 


## Changes proposed in this pull request
StakingPool size is now `23,724`
Modifiers add around 500 bytes, so if we need a bit more space we can change those to internal functions in the future.

Changes:
-Moved the premium calculation functions and the product management functions to a contract currently named `StakingProducts.sol`. 
-Removed unused/unimplemented view functions
-Made internal functions for duplicate revert checks

## Test plan


## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [x] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
