### PR TITLE
Chore: Use 0 instead of uint256.max as flag to signal minting new nft

### DIFF
--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -200,10 +200,6 @@ interface ICover {
 
   function stakingPoolFactory() external returns (IStakingPoolFactory);
 
-  function transferCovers(address from, address to, uint256[] calldata tokenIds) external;
-
-  function transferStakingPoolTokens(address from, address to, uint256[] calldata tokenIds) external;
-
   function createStakingPool(
     address manager,
     bool isPrivatePool,

--- a/contracts/interfaces/ICoverNFT.sol
+++ b/contracts/interfaces/ICoverNFT.sol
@@ -8,7 +8,9 @@ interface ICoverNFT is IERC721 {
 
   function isApprovedOrOwner(address spender, uint tokenId) external returns (bool);
 
-  function mint(address to, uint tokenId) external;
+  function totalSupply() external view returns (uint);
+
+  function mint(address to) external returns (uint);
 
   function burn(uint tokenId) external;
 

--- a/contracts/interfaces/ICoverNFT.sol
+++ b/contracts/interfaces/ICoverNFT.sol
@@ -12,6 +12,4 @@ interface ICoverNFT is IERC721 {
 
   function mint(address to) external returns (uint);
 
-  function burn(uint tokenId) external;
-
 }

--- a/contracts/interfaces/ICoverNFT.sol
+++ b/contracts/interfaces/ICoverNFT.sol
@@ -14,5 +14,4 @@ interface ICoverNFT is IERC721 {
 
   function burn(uint tokenId) external;
 
-  function operatorTransferFrom(address from, address to, uint256 tokenId) external;
 }

--- a/contracts/interfaces/IERC721Mock.sol
+++ b/contracts/interfaces/IERC721Mock.sol
@@ -5,7 +5,8 @@ pragma solidity >=0.8.0;
 import "@openzeppelin/contracts-v4/token/ERC721/IERC721.sol";
 
 interface IERC721Mock is IERC721 {
-  function mint(address to, uint tokenId) external;
+
+  function mint(address to) external;
 
   function isApprovedOrOwner(address spender, uint tokenId) external returns (bool);
 }

--- a/contracts/interfaces/IStakingNFT.sol
+++ b/contracts/interfaces/IStakingNFT.sol
@@ -10,8 +10,6 @@ interface IStakingNFT is IERC721 {
 
   function mint(uint poolId, address to) external returns (uint tokenId);
 
-  function operatorTransferFrom(address from, address to, uint256 tokenId) external;
-
   function changeOperator(address newOperator) external;
 
   function totalSupply() external returns (uint);

--- a/contracts/interfaces/IStakingPool.sol
+++ b/contracts/interfaces/IStakingPool.sol
@@ -205,8 +205,8 @@ interface IStakingPool {
   error RewardRatioTooHigh();
 
   // Staking NFTs
-  error InvalidTokenId();
   error NotTokenOwnerOrApproved();
+  error TokenDoesNotBelongToPool();
 
   // Tranche & capacity
   error NewTrancheEndsBeforeInitialTranche();

--- a/contracts/mocks/Claims/CLMockCover.sol
+++ b/contracts/mocks/Claims/CLMockCover.sol
@@ -3,12 +3,12 @@
 pragma solidity ^0.8.16;
 
 import "../../interfaces/ICover.sol";
-import "../../interfaces/IERC721Mock.sol";
+import "../../interfaces/ICoverNFT.sol";
 
 
 contract CLMockCover {
 
-  IERC721Mock public immutable coverNFT;
+  ICoverNFT public immutable coverNFT;
 
   struct BurnStakeCalledWith {
     uint coverId;
@@ -24,7 +24,8 @@ contract CLMockCover {
 
   BurnStakeCalledWith public burnStakeCalledWith;
   MigrateCoverFromCalledWith public migrateCoverFromCalledWith;
-  CoverData[] public coverData;
+
+  mapping(uint => CoverData) public coverData;
   mapping(uint => CoverSegment[]) _coverSegments;
   mapping(uint => PoolAllocation[]) stakingPoolsForCover;
 
@@ -60,7 +61,7 @@ contract CLMockCover {
   uint public constant MAX_PRICE_PERCENTAGE = 1e20;
 
   constructor(address coverNFTAddress) {
-    coverNFT = IERC721Mock(coverNFTAddress);
+    coverNFT = ICoverNFT(coverNFTAddress);
   }
 
   function products(uint id) external view returns (Product memory) {
@@ -93,18 +94,17 @@ contract CLMockCover {
     CoverSegment[] memory segments
   ) external payable returns (uint coverId) {
 
-    coverData.push(CoverData(
-        productId,
-        coverAsset,
-        0
-      ));
+    coverId = coverNFT.mint(owner);
+
+    coverData[coverId] = CoverData(
+      productId,
+      coverAsset,
+      0
+    );
 
     for (uint i = 0; i < segments.length; i++) {
-      _coverSegments[coverData.length - 1].push(segments[i]);
+      _coverSegments[coverId].push(segments[i]);
     }
-
-    coverId = coverData.length - 1;
-    coverNFT.mint(owner, coverId);
   }
 
   function addProductType(

--- a/contracts/mocks/Claims/CLMockCoverNFT.sol
+++ b/contracts/mocks/Claims/CLMockCoverNFT.sol
@@ -8,8 +8,8 @@ contract CLMockCoverNFT is ERC721Mock {
 
   constructor() ERC721Mock("", "") {}
 
-  function mint(address to, uint tokenId) external {
-    totalSupply++;
+  function mint(address to) external returns (uint tokenId) {
+    tokenId = ++totalSupply;
     _mint(to, tokenId);
   }
 

--- a/contracts/mocks/Cover/CoverMockCoverNFT.sol
+++ b/contracts/mocks/Cover/CoverMockCoverNFT.sol
@@ -8,8 +8,8 @@ contract CoverMockCoverNFT is ERC721Mock {
 
   constructor() ERC721Mock("", "") {}
 
-  function mint(address to, uint tokenId) external {
-    totalSupply++;
+  function mint(address to) external returns (uint tokenId) {
+    tokenId = ++totalSupply;
     _mint(to, tokenId);
   }
 

--- a/contracts/mocks/Cover/CoverMockStakingNFT.sol
+++ b/contracts/mocks/Cover/CoverMockStakingNFT.sol
@@ -8,8 +8,9 @@ contract CoverMockStakingNFT is ERC721Mock {
 
   constructor() ERC721Mock("", "") {}
 
-  function mint(address to) external {
-    _mint(to, totalSupply++);
+  function mint(address to) external returns (uint tokenId) {
+    tokenId = ++totalSupply;
+    _mint(to, tokenId);
   }
 
 }

--- a/contracts/mocks/Incidents/ICMockCover.sol
+++ b/contracts/mocks/Incidents/ICMockCover.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.16;
 
 import "../../interfaces/ICover.sol";
-import "../../interfaces/IERC721Mock.sol";
+import "../../interfaces/ICoverNFT.sol";
 
 contract ICMockCover {
 
@@ -13,10 +13,10 @@ contract ICMockCover {
     uint amount;
   }
 
-  IERC721Mock public immutable coverNFT;
-
-  CoverData[] public coverData;
+  ICoverNFT public immutable coverNFT;
   BurnStakeCalledWith public burnStakeCalledWith;
+
+  mapping(uint => CoverData) public coverData;
   mapping(uint => CoverSegment[]) _coverSegments;
 
   mapping(uint => PoolAllocation[]) poolAllocations;
@@ -52,7 +52,7 @@ contract ICMockCover {
   uint public constant MAX_PRICE_PERCENTAGE = 1e20;
 
   constructor(address coverNFTAddress) {
-    coverNFT = IERC721Mock(coverNFTAddress);
+    coverNFT = ICoverNFT(coverNFTAddress);
   }
 
   function products(uint id) external view returns (Product memory) {
@@ -72,18 +72,17 @@ contract ICMockCover {
     CoverSegment[] memory segments
   ) external payable returns (uint coverId) {
 
-    coverData.push(CoverData(
-        productId,
-        coverAsset,
-        0
-      ));
+    coverId = coverNFT.mint(owner);
+
+    coverData[coverId] = CoverData(
+      productId,
+      coverAsset,
+      0
+    );
 
     for (uint i = 0; i < segments.length; i++) {
-      _coverSegments[coverData.length - 1].push(segments[i]);
+      _coverSegments[coverId].push(segments[i]);
     }
-
-    coverId = coverData.length - 1;
-    coverNFT.mint(owner, coverId);
   }
 
   function coverSegments(

--- a/contracts/mocks/Incidents/ICMockCoverNFT.sol
+++ b/contracts/mocks/Incidents/ICMockCoverNFT.sol
@@ -8,8 +8,8 @@ contract ICMockCoverNFT is ERC721Mock {
 
   constructor() ERC721Mock("", "") {}
 
-  function mint(address to, uint tokenId) external {
-    totalSupply++;
+  function mint(address to) external returns (uint tokenId) {
+    tokenId = ++totalSupply;
     _mint(to, tokenId);
   }
 

--- a/contracts/mocks/MemberRoles/MRMockCover.sol
+++ b/contracts/mocks/MemberRoles/MRMockCover.sol
@@ -8,6 +8,7 @@ import "../../interfaces/IMemberRoles.sol";
 pragma solidity ^0.8.16;
 
 contract MRMockCover {
+
   ICoverNFT immutable public coverNFT;
   IMemberRoles immutable public memberRoles;
   IStakingNFT immutable public stakingNFT;
@@ -31,7 +32,7 @@ contract MRMockCover {
     }
   }
 
-  function createMockCover(address to, uint tokenId) public {
-    coverNFT.mint(to, tokenId);
+  function createMockCover(address to) public returns (uint tokenId) {
+    return coverNFT.mint(to);
   }
 }

--- a/contracts/mocks/MemberRoles/MRMockCover.sol
+++ b/contracts/mocks/MemberRoles/MRMockCover.sol
@@ -22,13 +22,13 @@ contract MRMockCover {
 
   function transferCovers(address from, address to, uint256[] calldata tokenIds) external {
     for (uint256 i = 0; i < tokenIds.length; i++) {
-      coverNFT.operatorTransferFrom(from, to, tokenIds[i]);
+      coverNFT.transferFrom(from, to, tokenIds[i]);
     }
   }
 
   function transferStakingPoolTokens(address from, address to, uint256[] calldata tokenIds) external {
     for (uint256 i = 0; i < tokenIds.length; i++) {
-      stakingNFT.operatorTransferFrom(from, to, tokenIds[i]);
+      stakingNFT.transferFrom(from, to, tokenIds[i]);
     }
   }
 

--- a/contracts/mocks/MemberRoles/MRMockCoverNFT.sol
+++ b/contracts/mocks/MemberRoles/MRMockCoverNFT.sol
@@ -10,8 +10,8 @@ contract MRMockCoverNFT is ERC721Mock {
     /* noop */
   }
 
-  function mint(address to, uint tokenId) external {
-    totalSupply++;
+  function mint(address to) external returns (uint tokenId) {
+    tokenId = ++totalSupply;
     _mint(to, tokenId);
   }
 

--- a/contracts/mocks/MemberRoles/MRMockStakingNFT.sol
+++ b/contracts/mocks/MemberRoles/MRMockStakingNFT.sol
@@ -11,7 +11,7 @@ contract MRMockStakingNFT is ERC721Mock {
   }
 
   function mint(address to) external {
-    _mint(to, totalSupply++);
+    _mint(to, ++totalSupply);
   }
 
   function operatorTransferFrom(address from, address to, uint256 tokenId) external {

--- a/contracts/mocks/StakingNFT/SNFTMockCover.sol
+++ b/contracts/mocks/StakingNFT/SNFTMockCover.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.16;
 
 import "../../interfaces/IStakingNFT.sol";
 import "../../interfaces/IStakingPool.sol";
-import "../../libraries/StakingPoolLibrary.sol";
 import "../../interfaces/IStakingPoolFactory.sol";
+import "../../libraries/StakingPoolLibrary.sol";
 /**
  * @dev Simple library to derive the staking pool address from the pool id without external calls
  */
@@ -22,9 +22,9 @@ contract SNFTMockCover {
         stakingNFT = IStakingNFT(_stakingNFT);
     }
 
-    function operatorTransferFrom(address from, address to, uint id) external {
-      stakingNFT.operatorTransferFrom(from, to, id);
-        // Get staking nft from factory
+    function transferFrom(address from, address to, uint id) external {
+      // get staking nft from factory
+      stakingNFT.transferFrom(from, to, id);
     }
 
     function stakingPool(uint256 poolId) public view returns (IStakingPool) {

--- a/contracts/mocks/StakingPool/SPMockStakingNFT.sol
+++ b/contracts/mocks/StakingPool/SPMockStakingNFT.sol
@@ -11,7 +11,7 @@ contract SPMockStakingNFT is ERC721Mock {
   mapping(uint => uint) public _stakingPoolOf;
 
   function mint(uint poolId, address to) external returns (uint) {
-    uint tokenId = totalSupply++;
+    uint tokenId = ++totalSupply;
     _mint(to, tokenId);
     _stakingPoolOf[tokenId] = poolId;
     return tokenId;

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -29,7 +29,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
   Product[] internal _products;
   ProductType[] internal _productTypes;
 
-  CoverData[] private _coverData;
+  mapping(uint => CoverData) private _coverData;
 
   // cover id => segment id => pool allocations array
   mapping(uint => mapping(uint => PoolAllocation[])) public coverSegmentAllocations;
@@ -45,7 +45,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
   uint24 public globalRewardsRatio;
 
   // assetId => { lastBucketUpdateId, totalActiveCoverInAsset }
-  mapping (uint => ActiveCover) public activeCover;
+  mapping(uint => ActiveCover) public activeCover;
   // assetId => bucketId => amount
   mapping(uint => mapping(uint => uint)) public activeCoverExpirationBuckets;
 
@@ -157,7 +157,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
       allocationRequest = AllocationRequest(
         params.productId,
         coverId,
-        type(uint).max,
+        0,
         params.period,
         _productTypes[product.productType].gracePeriod,
         product.useFixedPrice,
@@ -173,25 +173,27 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
 
     uint previousSegmentAmount;
 
-    if (params.coverId == type(uint).max) {
+    if (params.coverId == 0) {
 
       // new cover
-      coverId = _coverData.length;
-      _coverData.push(CoverData(params.productId, params.coverAsset, 0 /* amountPaidOut */));
-      coverNFT.mint(params.owner, coverId);
+      coverId = coverNFT.mint(params.owner);
+      _coverData[coverId] = CoverData(params.productId, params.coverAsset, 0 /* amountPaidOut */);
 
     } else {
 
       // existing cover
       coverId = params.coverId;
+
       if (!coverNFT.isApprovedOrOwner(msg.sender, coverId)) {
         revert OnlyOwnerOrApproved();
       }
 
       CoverData memory cover = _coverData[coverId];
+
       if (params.coverAsset != cover.coverAsset) {
         revert UnexpectedCoverAsset();
       }
+
       if (params.productId != cover.productId) {
         revert UnexpectedProductId();
       }
@@ -335,7 +337,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
         allocationRequest.allocationId = previousPoolAllocation.allocationId;
       } else {
         // request new allocation id
-        allocationRequest.allocationId = type(uint).max;
+        allocationRequest.allocationId = 0;
       }
 
       // converting asset amount to nxm and rounding up to the nearest NXM_PER_ALLOCATION_UNIT
@@ -473,11 +475,8 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
       revert CoverOutsideOfTheGracePeriod();
     }
 
-    _coverData.push(
-      CoverData(productId.toUint24(), coverAsset.toUint8(), 0 /* amountPaidOut */)
-    );
-
-    coverId = _coverData.length - 1;
+    coverId = coverNFT.mint(newOwner);
+    _coverData[coverId] = CoverData(productId.toUint24(), coverAsset.toUint8(), 0 /* amountPaidOut */);
 
     _coverSegments[coverId].push(
       CoverSegment(
@@ -490,7 +489,6 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
       )
     );
 
-    coverNFT.mint(newOwner, coverId);
     emit CoverEdited(coverId, productId, 0, msg.sender, "");
 
     return coverId;
@@ -648,7 +646,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
   }
 
   function coverDataCount() external override view returns (uint) {
-    return _coverData.length;
+    return coverNFT.totalSupply();
   }
 
   function products(uint id) external override view returns (Product memory) {

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -494,26 +494,6 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
     return coverId;
   }
 
-  function transferCovers(address from, address to, uint256[] calldata tokenIds) external override {
-    if (msg.sender != address(memberRoles())) {
-      revert OnlyMemberRolesCanOperateTransfer();
-    }
-
-    for (uint256 i = 0; i < tokenIds.length; i++) {
-      ICoverNFT(coverNFT).operatorTransferFrom(from, to, tokenIds[i]);
-    }
-  }
-
-  function transferStakingPoolTokens(address from, address to, uint256[] calldata tokenIds) external override {
-    if (msg.sender != address(memberRoles())) {
-      revert OnlyMemberRolesCanOperateTransfer();
-    }
-
-    for (uint256 i = 0; i < tokenIds.length; i++) {
-      stakingNFT.operatorTransferFrom(from, to, tokenIds[i]);
-    }
-  }
-
   function createStakingPool(
     address manager,
     bool isPrivatePool,

--- a/contracts/modules/cover/CoverNFT.sol
+++ b/contracts/modules/cover/CoverNFT.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.9;
 import "../../interfaces/ICover.sol";
 import "solmate/src/tokens/ERC721.sol";
 
+// TODO: implement ICoverNFT instead
 contract CoverNFT is ERC721 {
 
   uint96 internal _totalSupply;

--- a/contracts/modules/cover/CoverNFT.sol
+++ b/contracts/modules/cover/CoverNFT.sol
@@ -41,30 +41,6 @@ contract CoverNFT is ERC721 {
     _mint(to, tokenId);
   }
 
-  function burn(uint tokenId) external onlyOperator {
-    _burn(tokenId);
-    --_totalSupply;
-  }
-
-  // TODO: the only diff between this and transferFrom is the approval check. We should consider using transferFrom.
-  function operatorTransferFrom(address from, address to, uint256 tokenId) external onlyOperator {
-
-    require(from == _ownerOf[tokenId], "WRONG_FROM");
-    require(to != address(0), "INVALID_RECIPIENT");
-
-    // Underflow of the sender's balance is impossible because we check for
-    // ownership above and the recipient's balance can't realistically overflow.
-    unchecked {
-      _balanceOf[from]--;
-      _balanceOf[to]++;
-    }
-
-    _ownerOf[tokenId] = to;
-    delete getApproved[tokenId];
-
-    emit Transfer(from, to, tokenId);
-  }
-
   function changeOperator(address _newOperator) public onlyOperator returns (bool) {
     require(_newOperator != address(0), "CoverNFT: Invalid newOperator address");
 

--- a/contracts/modules/cover/CoverNFT.sol
+++ b/contracts/modules/cover/CoverNFT.sol
@@ -24,6 +24,8 @@ contract CoverNFT is ERC721 {
     return _totalSupply;
   }
 
+  // TODO: implement change token descriptor function here
+
   function tokenURI(uint256) public pure override returns (string memory) {
     // TODO: implement me
     return "";

--- a/contracts/modules/cover/CoverNFT.sol
+++ b/contracts/modules/cover/CoverNFT.sol
@@ -7,7 +7,7 @@ import "solmate/src/tokens/ERC721.sol";
 
 contract CoverNFT is ERC721 {
 
-  // TODO: consider adding totalSupply()
+  uint96 internal _totalSupply;
 
   address public operator;
 
@@ -20,6 +20,10 @@ contract CoverNFT is ERC721 {
     operator = _operator;
   }
 
+  function totalSupply() public view returns (uint) {
+    return _totalSupply;
+  }
+
   function tokenURI(uint256) public pure override returns (string memory) {
     // TODO: implement me
     return "";
@@ -30,14 +34,17 @@ contract CoverNFT is ERC721 {
     return spender == owner || isApprovedForAll[owner][spender] || spender == getApproved[tokenId];
   }
 
-  function mint(address to, uint tokenId) external onlyOperator {
+  function mint(address to) external onlyOperator returns (uint tokenId) {
+    tokenId = ++_totalSupply;
     _mint(to, tokenId);
   }
 
   function burn(uint tokenId) external onlyOperator {
     _burn(tokenId);
+    --_totalSupply;
   }
 
+  // TODO: the only diff between this and transferFrom is the approval check. We should consider using transferFrom.
   function operatorTransferFrom(address from, address to, uint256 tokenId) external onlyOperator {
 
     require(from == _ownerOf[tokenId], "WRONG_FROM");

--- a/contracts/modules/governance/MemberRoles.sol
+++ b/contracts/modules/governance/MemberRoles.sol
@@ -64,9 +64,7 @@ contract MemberRoles is IMemberRoles, Governed, MasterAwareV2 {
     _;
   }
 
-  constructor(
-    address tokenAddress
-  ) {
+  constructor(address tokenAddress) {
     token = INXMToken(tokenAddress);
   }
 
@@ -241,6 +239,7 @@ contract MemberRoles is IMemberRoles, Governed, MasterAwareV2 {
     uint[] calldata coverIds,
     uint[] calldata stakingTokenIds
   ) external override {
+
     _switchMembership(msg.sender, newAddress);
     token.transferFrom(msg.sender, newAddress, token.balanceOf(msg.sender));
 
@@ -248,12 +247,18 @@ contract MemberRoles is IMemberRoles, Governed, MasterAwareV2 {
 
     // Transfer the cover NFTs to the new address, if any were given
     if (coverIds.length > 0) {
-      _cover.transferCovers(msg.sender, newAddress, coverIds);
+      ICoverNFT coverNFT = _cover.coverNFT();
+      for (uint i = 0; i < coverIds.length; i++) {
+        coverNFT.transferFrom(msg.sender, newAddress, coverIds[i]);
+      }
     }
 
     // Transfer the staking pool NFTs to the new address, if any were given
     if (stakingTokenIds.length > 0) {
-      _cover.transferStakingPoolTokens(msg.sender, newAddress, stakingTokenIds);
+      IStakingNFT stakingNFT = _cover.stakingNFT();
+      for (uint i = 0; i < stakingTokenIds.length; i++) {
+        stakingNFT.transferFrom(msg.sender, newAddress, stakingTokenIds[i]);
+      }
     }
   }
 

--- a/contracts/modules/staking/StakingNFT.sol
+++ b/contracts/modules/staking/StakingNFT.sol
@@ -76,7 +76,7 @@ contract StakingNFT is IStakingNFT {
 
     // counter overflow is incredibly unrealistic
     unchecked {
-      id = _totalSupply++;
+      id = ++_totalSupply;
       _balanceOf[to]++;
     }
 

--- a/contracts/modules/staking/StakingNFT.sol
+++ b/contracts/modules/staking/StakingNFT.sol
@@ -39,23 +39,7 @@ contract StakingNFT is IStakingNFT {
 
   // operator functions
 
-  function operatorTransferFrom(address from, address to, uint id) external {
-    require(msg.sender == operator, "NOT_OPERATOR");
-    require(from == ownerOf(id), "WRONG_FROM");
-    require(to != address(0), "INVALID_RECIPIENT");
-
-    // underflow of the sender's balance is impossible because we check for
-    // ownership above and the recipient's balance can't realistically overflow
-    unchecked {
-      _balanceOf[from]--;
-      _balanceOf[to]++;
-    }
-
-    _tokenInfo[id].owner = to;
-    delete getApproved[id];
-
-    emit Transfer(from, to, id);
-  }
+  // TODO: implement change token descriptor function here
 
   function changeOperator(address newOperator) public {
     require(msg.sender == operator, "NOT_OPERATOR");

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -55,7 +55,7 @@ contract StakingPool is IStakingPool, Multicall {
   uint96 internal rewardPerSecond;
 
   uint40 internal poolId;
-  uint24 internal nextAllocationId;
+  uint24 internal lastAllocationId;
 
   bool public override isPrivatePool;
   bool public override isHalted;
@@ -1684,7 +1684,7 @@ contract StakingPool is IStakingPool, Multicall {
   }
 
   function getNextAllocationId() external override view returns (uint) {
-    return nextAllocationId;
+    return lastAllocationId + 1;
   }
 
   function getTotalTargetWeight() external override view returns (uint) {

--- a/scripts/mocks/buyV2Covers.js
+++ b/scripts/mocks/buyV2Covers.js
@@ -1,6 +1,6 @@
 const { network, ethers } = require('hardhat');
 const { BigNumber } = require('ethers');
-const { AddressZero, MaxUint256 } = ethers.constants;
+const { AddressZero } = ethers.constants;
 const { formatEther, parseEther, formatUnits } = ethers.utils;
 
 const { CONTRACTS_ADDRESSES: Addresses } = require(process.env.CONFIG_FILE);

--- a/scripts/mocks/buyV2Covers.js
+++ b/scripts/mocks/buyV2Covers.js
@@ -92,7 +92,7 @@ async function buyCover(productId, poolId, cover, buyer, amount, period, payment
       commissionRatio: parseEther('0'),
       commissionDestination: AddressZero,
       ipfsData: '',
-      coverId: MaxUint256.toString(), // new cover
+      coverId: 0, // new cover
     },
     [{ poolId, coverAmountInAsset: amount.toString() }],
     { value: premiumWithSlippage },

--- a/scripts/mocks/createStakingPools.js
+++ b/scripts/mocks/createStakingPools.js
@@ -1,7 +1,6 @@
 const { config, network, ethers } = require('hardhat');
 const { CONTRACTS_ADDRESSES: Addresses } = require(process.env.CONFIG_FILE);
 const { BigNumber } = require('ethers');
-const { parseEther } = ethers.utils;
 
 async function main() {
   console.log(`Using network: ${network.name}`);

--- a/scripts/mocks/createStakingPools.js
+++ b/scripts/mocks/createStakingPools.js
@@ -1,6 +1,7 @@
 const { config, network, ethers } = require('hardhat');
 const { CONTRACTS_ADDRESSES: Addresses } = require(process.env.CONFIG_FILE);
 const { BigNumber } = require('ethers');
+const { parseEther } = ethers.utils;
 
 async function main() {
   console.log(`Using network: ${network.name}`);

--- a/test/integration/Cover/createStakingPool.js
+++ b/test/integration/Cover/createStakingPool.js
@@ -1,7 +1,7 @@
 const { ethers } = require('hardhat');
 const { expect } = require('chai');
 
-const { AddressZero, MaxUint256 } = ethers.constants;
+const { AddressZero } = ethers.constants;
 const { parseEther } = ethers.utils;
 
 function calculateTrancheId(currentTime, period, gracePeriod) {
@@ -50,13 +50,13 @@ describe('createStakingPool', function () {
     const managerStakingPoolNFTBalanceBefore = await stakingNFT.balanceOf(manager.address);
     assert.equal(managerStakingPoolNFTBalanceBefore.toNumber(), 0);
 
-    await stakingPool.connect(manager).depositTo(deposit, trancheId, MaxUint256, AddressZero);
+    await stakingPool.connect(manager).depositTo(deposit, trancheId, 0, AddressZero);
 
     const managerStakingPoolNFTBalanceAfter = await stakingNFT.balanceOf(manager.address);
     assert.equal(managerStakingPoolNFTBalanceAfter.toNumber(), 1);
 
     await expect(
-      stakingPool.connect(staker).depositTo(deposit, trancheId, MaxUint256, AddressZero), // new deposit
+      stakingPool.connect(staker).depositTo(deposit, trancheId, 0, AddressZero), // new deposit
     ).to.be.revertedWithCustomError(stakingPool, 'PrivatePool');
   });
 
@@ -88,12 +88,12 @@ describe('createStakingPool', function () {
     const managerStakingPoolNFTBalanceBefore = await stakingNFT.balanceOf(manager.address);
     expect(managerStakingPoolNFTBalanceBefore).to.be.equal(0);
 
-    await stakingPool.connect(manager).depositTo(deposit, trancheId, MaxUint256, AddressZero);
+    await stakingPool.connect(manager).depositTo(deposit, trancheId, 0, AddressZero);
 
     const managerStakingPoolNFTBalanceAfter = await stakingNFT.balanceOf(manager.address);
     expect(managerStakingPoolNFTBalanceAfter).to.be.equal(1);
 
-    await stakingPool.connect(staker).depositTo(deposit, trancheId, MaxUint256, AddressZero);
+    await stakingPool.connect(staker).depositTo(deposit, trancheId, 0, AddressZero);
 
     const stakerStakingPoolNFTBalance = await stakingNFT.balanceOf(staker.address);
     expect(stakerStakingPoolNFTBalance).to.be.equal(1);

--- a/test/integration/Cover/totalActiveCover.js
+++ b/test/integration/Cover/totalActiveCover.js
@@ -4,7 +4,7 @@ const { daysToSeconds } = require('../../../lib/helpers');
 const { mineNextBlock, setNextBlockTime, setEtherBalance } = require('../../utils/evm');
 
 const { parseEther } = ethers.utils;
-const { AddressZero, MaxUint256 } = ethers.constants;
+const { AddressZero } = ethers.constants;
 
 const setTime = async timestamp => {
   await setNextBlockTime(timestamp);
@@ -19,6 +19,7 @@ const stakedProductParamTemplate = {
   setTargetPrice: true,
   targetPrice: 100,
 };
+
 const buyCoverFixture = {
   productId: 2, // ybETH
   coverAsset: 0, // ETH
@@ -26,7 +27,7 @@ const buyCoverFixture = {
   gracePeriod: daysToSeconds(30),
   amount: parseEther('10'),
   priceDenominator: 10000,
-  coverId: 0,
+  coverId: 1,
   segmentId: 0,
   incidentId: 0,
   assessmentId: 0,
@@ -57,8 +58,8 @@ describe('totalActiveCover', function () {
     const firstTrancheId = calculateFirstTrancheId(lastBlock, period, gracePeriod);
 
     // Stake to open up capacity
-    await stakingPool.connect(staker).depositTo(stakingAmount, firstTrancheId, MaxUint256, AddressZero);
-    await stakingPool.connect(staker).depositTo(stakingAmount, firstTrancheId + 1, MaxUint256, AddressZero);
+    await stakingPool.connect(staker).depositTo(stakingAmount, firstTrancheId, 0, AddressZero);
+    await stakingPool.connect(staker).depositTo(stakingAmount, firstTrancheId + 1, 0, AddressZero);
   }
 
   async function transferYieldToken({ tokenOwner, coverBuyer1, ybETH, yc }) {
@@ -80,7 +81,7 @@ describe('totalActiveCover', function () {
 
     await cover.connect(coverBuyer1).buyCover(
       {
-        coverId: MaxUint256,
+        coverId: 0,
         owner: coverBuyer1.address,
         productId,
         coverAsset,

--- a/test/integration/CoverMigrator/migrateAndSubmitClaim.js
+++ b/test/integration/CoverMigrator/migrateAndSubmitClaim.js
@@ -31,7 +31,7 @@ describe('migrateAndSubmitClaim', function () {
       .connect(coverOwner)
       .migrateAndSubmitClaim(v1CoverId, 0, claimAmount, '', { value: parseEther('1') });
 
-    const expectedV2CoverId = 0;
+    const expectedV2CoverId = 1;
     await expect(tx).to.emit(coverNFT, 'Transfer').withArgs(AddressZero, coverOwner.address, expectedV2CoverId);
     await expect(tx).to.emit(coverMigrator, 'CoverMigrated').withArgs(v1CoverId, expectedV2CoverId, coverOwner.address);
 

--- a/test/integration/IndividualClaims/submitClaim.js
+++ b/test/integration/IndividualClaims/submitClaim.js
@@ -56,7 +56,7 @@ describe('submitClaim', function () {
     });
 
     // Submit claim
-    const coverId = 0;
+    const coverId = 1;
     const claimAmount = amount;
     const [deposit] = await ic.getAssessmentDepositAndReward(claimAmount, period, coverAsset);
     await ic.connect(coverBuyer1).submitClaim(coverId, 0, claimAmount, '', {
@@ -106,7 +106,7 @@ describe('submitClaim', function () {
       priceDenominator,
     });
 
-    const coverId = 0;
+    const coverId = 1;
 
     // Submit partial claim - 1/2 of total amount
     const claimAmount = amount.div(2);
@@ -159,7 +159,7 @@ describe('submitClaim', function () {
     });
 
     // Submit claim
-    const coverId = 0;
+    const coverId = 1;
     const claimAmount = amount;
     const [deposit] = await ic.getAssessmentDepositAndReward(claimAmount, period, coverAsset);
     await ic.connect(coverBuyer1).submitClaim(coverId, 0, claimAmount, '', {
@@ -208,7 +208,7 @@ describe('submitClaim', function () {
     });
 
     // Submit claim - 1/2 of total amount
-    const coverId = 0;
+    const coverId = 1;
     const claimAmount = amount.div(2);
     const [deposit] = await ic.getAssessmentDepositAndReward(claimAmount, period, coverAsset);
     await ic.connect(coverBuyer1).submitClaim(coverId, 0, claimAmount, '', {
@@ -260,7 +260,7 @@ describe('submitClaim', function () {
     });
 
     // Submit claim
-    const coverId = 0;
+    const coverId = 1;
     const claimAmount = amount;
     const [deposit] = await ic.getAssessmentDepositAndReward(claimAmount, period, coverAsset);
     await ic.connect(coverBuyer1).submitClaim(coverId, 0, claimAmount, '', {
@@ -313,7 +313,7 @@ describe('submitClaim', function () {
     });
 
     // Submit claim - 1/2 of total amount
-    const coverId = 0;
+    const coverId = 1;
     const claimAmount = amount.div(2);
     const [deposit] = await ic.getAssessmentDepositAndReward(claimAmount, period, coverAsset);
     await ic.connect(coverBuyer1).submitClaim(coverId, 0, claimAmount, '', {
@@ -366,7 +366,7 @@ describe('submitClaim', function () {
     });
 
     // Submit claim
-    const coverId = 0;
+    const coverId = 1;
     const claimAmount = amount;
     const [deposit] = await ic.getAssessmentDepositAndReward(claimAmount, period, coverAsset);
     await ic.connect(coverBuyer1).submitClaim(coverId, 0, claimAmount, '', {
@@ -418,7 +418,7 @@ describe('submitClaim', function () {
     });
 
     // Submit claim - 1/2 of total amount
-    const coverId = 0;
+    const coverId = 1;
     const claimAmount = amount.div(2);
     const [deposit] = await ic.getAssessmentDepositAndReward(claimAmount, period, coverAsset);
     await ic.connect(coverBuyer1).submitClaim(coverId, 0, claimAmount, '', {
@@ -472,7 +472,7 @@ describe('submitClaim', function () {
     });
 
     // Submit claim
-    const coverId = 0;
+    const coverId = 1;
     const claimAmount = amount;
     const [deposit] = await ic.getAssessmentDepositAndReward(claimAmount, period, coverAsset);
     await ic.connect(coverBuyer1).submitClaim(coverId, 0, claimAmount, '', {
@@ -527,7 +527,7 @@ describe('submitClaim', function () {
     });
 
     // Submit claim - 1/2 of total amount
-    const coverId = 0;
+    const coverId = 1;
     const claimAmount = amount.div(2);
     const [deposit] = await ic.getAssessmentDepositAndReward(claimAmount, period, coverAsset);
     await ic.connect(coverBuyer1).submitClaim(coverId, 0, claimAmount, '', {
@@ -582,7 +582,7 @@ describe('submitClaim', function () {
     });
 
     // Submit claim - 1/2 of total amount
-    const coverId = 0;
+    const coverId = 1;
     const claimAmount = amount.div(2);
     const [deposit] = await ic.getAssessmentDepositAndReward(claimAmount, period, coverAsset);
     await ic.connect(coverBuyer1).submitClaim(coverId, 0, claimAmount, '', {
@@ -630,7 +630,7 @@ describe('submitClaim', function () {
       priceDenominator,
     });
 
-    const coverId = 0;
+    const coverId = 1;
 
     // Submit First partial claim - 1/2 of total amount
     {
@@ -755,7 +755,7 @@ describe('submitClaim', function () {
 
     // Submit First partial claim - 1/2 of total amount
     {
-      const coverId = 0;
+      const coverId = 1;
       const claimAmount = amount.div(2);
       const [deposit] = await ic.getAssessmentDepositAndReward(claimAmount, period, coverAsset);
       await ic.connect(coverBuyer1).submitClaim(coverId, 0, claimAmount, '', {
@@ -787,7 +787,7 @@ describe('submitClaim', function () {
 
     // Submit Second partial claim - 1/4 of total amount
     {
-      const coverId = 0;
+      const coverId = 1;
       const claimAmount = amount.div(4);
       const [deposit] = await ic.getAssessmentDepositAndReward(claimAmount, period, coverAsset);
       await ic.connect(coverBuyer1).submitClaim(coverId, 0, claimAmount, '', {
@@ -819,7 +819,7 @@ describe('submitClaim', function () {
 
     // Submit Third partial claim - 1/4 of total amount
     {
-      const coverId = 0;
+      const coverId = 1;
       const claimAmount = amount.div(4);
       const [deposit] = await ic.getAssessmentDepositAndReward(claimAmount, period, coverAsset);
       await ic.connect(coverBuyer1).submitClaim(coverId, 0, claimAmount, '', {
@@ -876,7 +876,7 @@ describe('submitClaim', function () {
 
     // Submit First partial claim - 1/2 of total amount
     {
-      const coverId = 0;
+      const coverId = 1;
       const claimAmount = amount.div(2);
       const [deposit] = await ic.getAssessmentDepositAndReward(claimAmount, period, coverAsset);
       await ic.connect(coverBuyer1).submitClaim(coverId, 0, claimAmount, '', {
@@ -908,7 +908,7 @@ describe('submitClaim', function () {
 
     // Submit Second partial claim - 1/4 of total amount
     {
-      const coverId = 0;
+      const coverId = 1;
       const claimAmount = amount.div(4);
       const [deposit] = await ic.getAssessmentDepositAndReward(claimAmount, period, coverAsset);
       await ic.connect(coverBuyer1).submitClaim(coverId, 0, claimAmount, '', {
@@ -940,7 +940,7 @@ describe('submitClaim', function () {
 
     // Submit Third partial claim - 1/4 of total amount
     {
-      const coverId = 0;
+      const coverId = 1;
       const claimAmount = amount.div(4);
       const [deposit] = await ic.getAssessmentDepositAndReward(claimAmount, period, coverAsset);
       await ic.connect(coverBuyer1).submitClaim(coverId, 0, claimAmount, '', {
@@ -990,7 +990,7 @@ describe('submitClaim', function () {
       priceDenominator,
     });
 
-    const coverId = 0;
+    const coverId = 1;
 
     // Submit First partial claim - 1/2 of total amount
     {

--- a/test/integration/MCR/updateMCR.js
+++ b/test/integration/MCR/updateMCR.js
@@ -2,7 +2,6 @@ const { ethers } = require('hardhat');
 const { assert, expect } = require('chai');
 const { parseEther } = ethers.utils;
 const { BigNumber } = ethers;
-const { MaxUint256 } = ethers.constants;
 const { daysToSeconds } = require('../../../lib/helpers');
 const {
   helpers: { hex },
@@ -187,7 +186,7 @@ describe('updateMCR', function () {
     const expectedPremium = parseEther('1');
     await cover.connect(coverHolder).buyCover(
       {
-        coverId: MaxUint256,
+        coverId: 0,
         owner: coverHolder.address,
         productId,
         coverAsset: 0,

--- a/test/integration/Master/emergency-pause.js
+++ b/test/integration/Master/emergency-pause.js
@@ -7,7 +7,7 @@ const { enrollClaimAssessor } = require('../utils/enroll');
 const { stake } = require('../utils/staking');
 const { BigNumber } = require('ethers');
 const { parseEther, defaultAbiCoder } = ethers.utils;
-const { MaxUint256, AddressZero } = ethers.constants;
+const { AddressZero } = ethers.constants;
 const { acceptClaim } = require('../utils/voteClaim');
 
 const priceDenominator = '10000';
@@ -129,7 +129,7 @@ describe('emergency pause', function () {
       cover.connect(member).buyCover(
         {
           owner: member.address,
-          coverId: MaxUint256,
+          coverId: 0,
           productId,
           coverAsset,
           amount,
@@ -172,7 +172,7 @@ describe('emergency pause', function () {
     await cover.connect(coverBuyer1).buyCover(
       {
         owner: coverBuyer1.address,
-        coverId: MaxUint256,
+        coverId: 0,
         productId,
         coverAsset,
         amount,
@@ -190,7 +190,7 @@ describe('emergency pause', function () {
     );
 
     // Submit claim
-    const coverId = 0;
+    const coverId = 1;
     const claimAmount = amount;
     const [deposit] = await ic.getAssessmentDepositAndReward(claimAmount, period, coverAsset);
     await ic.connect(coverBuyer1).submitClaim(coverId, 0, claimAmount, '', {
@@ -231,7 +231,7 @@ describe('emergency pause', function () {
     await cover.connect(coverBuyer1).buyCover(
       {
         owner: coverBuyer1.address,
-        coverId: MaxUint256,
+        coverId: 0,
         productId,
         coverAsset,
         amount,
@@ -249,7 +249,7 @@ describe('emergency pause', function () {
     );
 
     // Submit claim
-    const coverId = 0;
+    const coverId = 1;
     const claimAmount = amount;
     const [deposit] = await ic.getAssessmentDepositAndReward(claimAmount, period, coverAsset);
     await ic.connect(coverBuyer1).submitClaim(coverId, 0, claimAmount, '', {

--- a/test/integration/MemberRoles/switchMembershipAndAssets.js
+++ b/test/integration/MemberRoles/switchMembershipAndAssets.js
@@ -4,7 +4,7 @@ const { stake } = require('../utils/staking');
 const { Role } = require('../utils').constants;
 const { daysToSeconds } = require('../../../lib/helpers');
 const { parseEther } = ethers.utils;
-const { AddressZero, MaxUint256 } = ethers.constants;
+const { AddressZero } = ethers.constants;
 const { calculateFirstTrancheId } = require('../utils/staking');
 
 describe('switchMembershipAndAssets', function () {
@@ -92,7 +92,7 @@ describe('switchMembershipAndAssets', function () {
       const expectedPremium = parseEther('1');
       await cover.buyCover(
         {
-          coverId: MaxUint256,
+          coverId: 0,
           owner: member.address,
           productId,
           coverAsset: 0,
@@ -111,14 +111,14 @@ describe('switchMembershipAndAssets', function () {
 
     await token.connect(member).approve(memberRoles.address, ethers.constants.MaxUint256);
     {
-      const ownershipArr = await Promise.all([0, 1, 2].map(x => coverNFT.ownerOf(x)));
+      const ownershipArr = await Promise.all([1, 2, 3].map(x => coverNFT.ownerOf(x)));
       assert(ownershipArr.every(x => x === member.address));
     }
 
     const newMemberAddress = nonMember.address;
-    await memberRoles.connect(member).switchMembershipAndAssets(newMemberAddress, [0, 2], [], []);
+    await memberRoles.connect(member).switchMembershipAndAssets(newMemberAddress, [1, 3], [], []);
     {
-      const ownershipArr = await Promise.all([0, 1, 2].map(x => coverNFT.ownerOf(x)));
+      const ownershipArr = await Promise.all([1, 2, 3].map(x => coverNFT.ownerOf(x)));
       assert(ownershipArr[1] === member.address);
       assert(ownershipArr[0] === newMemberAddress);
       assert(ownershipArr[2] === newMemberAddress);

--- a/test/integration/MemberRoles/switchMembershipAndAssets.js
+++ b/test/integration/MemberRoles/switchMembershipAndAssets.js
@@ -110,6 +110,8 @@ describe('switchMembershipAndAssets', function () {
     }
 
     await token.connect(member).approve(memberRoles.address, ethers.constants.MaxUint256);
+    await coverNFT.connect(member).setApprovalForAll(memberRoles.address, true);
+
     {
       const ownershipArr = await Promise.all([1, 2, 3].map(x => coverNFT.ownerOf(x)));
       assert(ownershipArr.every(x => x === member.address));

--- a/test/integration/YieldTokenIncidents/submitClaim.js
+++ b/test/integration/YieldTokenIncidents/submitClaim.js
@@ -93,14 +93,14 @@ describe('submitClaim', function () {
     {
       const ethBalanceBefore = await ethers.provider.getBalance(nonMember1.address);
       await setNextBlockBaseFee('0');
-      await yc.connect(coverBuyer1).redeemPayout(0, 0, 0, parseEther('1'), nonMember1.address, [], { gasPrice: 0 });
+      await yc.connect(coverBuyer1).redeemPayout(0, 1, 0, parseEther('1'), nonMember1.address, [], { gasPrice: 0 });
       const ethBalanceAfter = await ethers.provider.getBalance(nonMember1.address);
       expect(ethBalanceAfter).to.be.equal(ethBalanceBefore.add(parseEther('0.99')));
     }
     {
       const ethBalanceBefore = await ethers.provider.getBalance(nonMember1.address);
       await setNextBlockBaseFee('0');
-      await yc.connect(coverBuyer1).redeemPayout(0, 0, 0, parseEther('1.11'), nonMember1.address, [], { gasPrice: 0 });
+      await yc.connect(coverBuyer1).redeemPayout(0, 1, 0, parseEther('1.11'), nonMember1.address, [], { gasPrice: 0 });
       const ethBalanceAfter = await ethers.provider.getBalance(nonMember1.address);
       expect(ethBalanceAfter).to.be.equal(ethBalanceBefore.add(parseEther('1.0989')));
     }
@@ -108,7 +108,7 @@ describe('submitClaim', function () {
     {
       const ethBalanceBefore = await ethers.provider.getBalance(nonMember1.address);
       await setNextBlockBaseFee('0');
-      await yc.connect(coverBuyer1).redeemPayout(0, 0, 0, parseEther('3'), nonMember1.address, [], { gasPrice: 0 });
+      await yc.connect(coverBuyer1).redeemPayout(0, 1, 0, parseEther('3'), nonMember1.address, [], { gasPrice: 0 });
       const ethBalanceAfter = await ethers.provider.getBalance(nonMember1.address);
       expect(ethBalanceAfter).to.be.equal(ethBalanceBefore.add(parseEther('2.970')));
     }
@@ -162,14 +162,14 @@ describe('submitClaim', function () {
     {
       const daiBalanceBefore = await dai.balanceOf(nonMember1.address);
       await setNextBlockBaseFee('0');
-      await yc.connect(coverBuyer1).redeemPayout(0, 0, 0, parseEther('1'), nonMember1.address, [], { gasPrice: 0 });
+      await yc.connect(coverBuyer1).redeemPayout(0, 1, 0, parseEther('1'), nonMember1.address, [], { gasPrice: 0 });
       const daiBalanceAfter = await dai.balanceOf(nonMember1.address);
       expect(daiBalanceAfter).to.be.equal(daiBalanceBefore.add(parseEther('0.99')));
     }
     {
       const daiBalanceBefore = await dai.balanceOf(nonMember1.address);
       await setNextBlockBaseFee('0');
-      await yc.connect(coverBuyer1).redeemPayout(0, 0, 0, parseEther('1.11'), nonMember1.address, [], { gasPrice: 0 });
+      await yc.connect(coverBuyer1).redeemPayout(0, 1, 0, parseEther('1.11'), nonMember1.address, [], { gasPrice: 0 });
       const daiBalanceAfter = await dai.balanceOf(nonMember1.address);
       expect(daiBalanceAfter).to.be.equal(daiBalanceBefore.add(parseEther('1.0989')));
     }
@@ -177,7 +177,7 @@ describe('submitClaim', function () {
     {
       const ethBalanceBefore = await dai.balanceOf(nonMember1.address);
       await setNextBlockBaseFee('0');
-      await yc.connect(coverBuyer1).redeemPayout(0, 0, 0, parseEther('3'), nonMember1.address, [], { gasPrice: 0 });
+      await yc.connect(coverBuyer1).redeemPayout(0, 1, 0, parseEther('3'), nonMember1.address, [], { gasPrice: 0 });
       const ethBalanceAfter = await dai.balanceOf(nonMember1.address);
       expect(ethBalanceAfter).to.be.equal(ethBalanceBefore.add(parseEther('2.970')));
     }
@@ -228,7 +228,7 @@ describe('submitClaim', function () {
 
     await setNextBlockBaseFee('0');
     await expect(
-      yc.connect(coverBuyer1).redeemPayout(0, 0, 0, parseEther('1'), nonMember1.address, [], { gasPrice: 0 }),
+      yc.connect(coverBuyer1).redeemPayout(0, 1, 0, parseEther('1'), nonMember1.address, [], { gasPrice: 0 }),
     ).to.be.revertedWith('The incident needs to be accepted');
   });
 
@@ -279,7 +279,7 @@ describe('submitClaim', function () {
     }
 
     await expect(
-      yc.connect(coverBuyer1).redeemPayout(0, 0, 0, parseEther('1'), nonMember1.address, []),
+      yc.connect(coverBuyer1).redeemPayout(0, 1, 0, parseEther('1'), nonMember1.address, []),
     ).to.be.revertedWith('The incident needs to be accepted');
   });
 
@@ -330,7 +330,7 @@ describe('submitClaim', function () {
     const exactAmountToRedeemFullCover = parseEther('11.111111111111111112');
     await yc
       .connect(coverBuyer1)
-      .redeemPayout(0, 0, 0, exactAmountToRedeemFullCover, nonMember1.address, [], { gasPrice: 0 });
+      .redeemPayout(0, 1, 0, exactAmountToRedeemFullCover, nonMember1.address, [], { gasPrice: 0 });
     const ethBalanceAfter = await ethers.provider.getBalance(nonMember1.address);
     expect(ethBalanceAfter).to.be.equal(ethBalanceBefore.add(amount));
   });
@@ -382,7 +382,7 @@ describe('submitClaim', function () {
 
     const daiBalanceBefore = await dai.balanceOf(nonMember1.address);
     const exactAmountToRedeemFullCover = parseEther('11.111111111111111112');
-    await yc.connect(coverBuyer1).redeemPayout(0, 0, 0, exactAmountToRedeemFullCover, nonMember1.address, []);
+    await yc.connect(coverBuyer1).redeemPayout(0, 1, 0, exactAmountToRedeemFullCover, nonMember1.address, []);
     const daiBalanceAfter = await dai.balanceOf(nonMember1.address);
     expect(daiBalanceAfter).to.be.equal(daiBalanceBefore.add(amount));
   });
@@ -465,7 +465,7 @@ describe('submitClaim', function () {
     {
       const ethBalanceBefore = await ethers.provider.getBalance(nonMember1.address);
 
-      await yc.connect(coverBuyer1).redeemPayout(0, 0, 0, exactAmountToRedeemFullCover, nonMember1.address, []);
+      await yc.connect(coverBuyer1).redeemPayout(0, 1, 0, exactAmountToRedeemFullCover, nonMember1.address, []);
 
       const ethBalanceAfter = await ethers.provider.getBalance(nonMember1.address);
 
@@ -476,7 +476,7 @@ describe('submitClaim', function () {
     {
       const ethBalanceBefore = await ethers.provider.getBalance(nonMember2.address);
 
-      await yc.connect(coverBuyer2).redeemPayout(0, 1, 0, exactAmountToRedeemFullCover, nonMember2.address, []);
+      await yc.connect(coverBuyer2).redeemPayout(0, 2, 0, exactAmountToRedeemFullCover, nonMember2.address, []);
 
       const ethBalanceAfter = await ethers.provider.getBalance(nonMember2.address);
 
@@ -487,7 +487,7 @@ describe('submitClaim', function () {
     {
       const ethBalanceBefore = await ethers.provider.getBalance(nonMember3.address);
 
-      await yc.connect(coverBuyer3).redeemPayout(0, 2, 0, exactAmountToRedeemFullCover, nonMember3.address, []);
+      await yc.connect(coverBuyer3).redeemPayout(0, 3, 0, exactAmountToRedeemFullCover, nonMember3.address, []);
 
       const ethBalanceAfter = await ethers.provider.getBalance(nonMember3.address);
 
@@ -580,14 +580,14 @@ describe('submitClaim', function () {
       await setNextBlockBaseFee('0');
       await yc
         .connect(coverBuyer1)
-        .redeemPayout(0, 0, 0, exactAmountToRedeemFullCover, nonMember1.address, [], { gasPrice: 0 });
+        .redeemPayout(0, 1, 0, exactAmountToRedeemFullCover, nonMember1.address, [], { gasPrice: 0 });
       const ethBalanceAfter = await ethers.provider.getBalance(nonMember1.address);
       expect(ethBalanceAfter).to.be.equal(ethBalanceBefore.add(amount));
     }
 
     {
       const daiBalanceBefore = await dai.balanceOf(nonMember2.address);
-      await yc.connect(coverBuyer2).redeemPayout(1, 1, 0, exactAmountToRedeemFullCover, nonMember2.address, []);
+      await yc.connect(coverBuyer2).redeemPayout(1, 2, 0, exactAmountToRedeemFullCover, nonMember2.address, []);
       const daiBalanceAfter = await dai.balanceOf(nonMember2.address);
       expect(daiBalanceAfter).to.be.equal(daiBalanceBefore.add(amount));
     }
@@ -640,7 +640,7 @@ describe('submitClaim', function () {
     }
 
     const usdcBalanceBefore = await usdc.balanceOf(nonMember.address);
-    await yc.connect(coverBuyer).redeemPayout(0, 0, 0, parseUnits('1', usdcDecimals), nonMember.address, []);
+    await yc.connect(coverBuyer).redeemPayout(0, 1, 0, parseUnits('1', usdcDecimals), nonMember.address, []);
     const usdcBalanceAfter = await usdc.balanceOf(nonMember.address);
     expect(usdcBalanceAfter).to.be.equal(usdcBalanceBefore.add(parseUnits('0.9', usdcDecimals)));
   });
@@ -694,7 +694,7 @@ describe('submitClaim', function () {
 
     const usdcBalanceBefore = await usdc.balanceOf(nonMember1.address);
     const exactAmountToRedeemFullCover = parseUnits('11.111112', usdcDecimals);
-    await yc.connect(coverBuyer1).redeemPayout(0, 0, 0, exactAmountToRedeemFullCover, nonMember1.address, []);
+    await yc.connect(coverBuyer1).redeemPayout(0, 1, 0, exactAmountToRedeemFullCover, nonMember1.address, []);
     const usdcBalanceAfter = await usdc.balanceOf(nonMember1.address);
     expect(usdcBalanceAfter).to.be.equal(usdcBalanceBefore.add(amount));
   });

--- a/test/integration/utils/cover.js
+++ b/test/integration/utils/cover.js
@@ -1,7 +1,7 @@
 const { ethers } = require('hardhat');
 
 const { parseEther, parseUnits } = ethers.utils;
-const { AddressZero, MaxUint256 } = ethers.constants;
+const { AddressZero } = ethers.constants;
 
 const ETH_ASSET_ID = 0;
 const DAI_ASSET_ID = 1;
@@ -16,7 +16,7 @@ async function buyCover({ amount, productId, coverAsset, period, cover, coverBuy
   await cover.connect(coverBuyer).buyCover(
     {
       owner: coverBuyer.address,
-      coverId: MaxUint256,
+      coverId: 0,
       productId,
       coverAsset,
       amount,

--- a/test/integration/utils/staking.js
+++ b/test/integration/utils/staking.js
@@ -1,5 +1,5 @@
 const { ethers } = require('hardhat');
-const { AddressZero, MaxUint256 } = ethers.constants;
+const { AddressZero } = ethers.constants;
 const { parseEther } = ethers.utils;
 
 function calculateFirstTrancheId(lastBlock, period, gracePeriod) {
@@ -16,7 +16,7 @@ async function stake({ stakingPool, staker, productId, period, gracePeriod }) {
   await stakingPool.connect(staker).depositTo(
     stakingAmount,
     firstTrancheId,
-    MaxUint256, // new position
+    0, // new position
     AddressZero, // destination
   );
 

--- a/test/unit/Cover/burnStake.js
+++ b/test/unit/Cover/burnStake.js
@@ -2,7 +2,6 @@ const { ethers } = require('hardhat');
 const { assertCoverFields, buyCoverOnOnePool, buyCoverOnMultiplePools, createStakingPool } = require('./helpers');
 const { expect } = require('chai');
 
-const { MaxUint256 } = ethers.constants;
 const { parseEther } = ethers.utils;
 
 const gracePeriod = 120 * 24 * 3600; // 120 days
@@ -10,7 +9,7 @@ const GLOBAL_CAPACITY_DENOMINATOR = 10000;
 
 describe('burnStake', function () {
   const coverBuyFixture = {
-    coverId: MaxUint256,
+    coverId: 0,
     productId: 0,
     coverAsset: 0, // ETH
     period: 3600 * 24 * 30, // 30 days

--- a/test/unit/Cover/buyCover.js
+++ b/test/unit/Cover/buyCover.js
@@ -6,7 +6,7 @@ const { setEtherBalance } = require('../utils').evm;
 const { daysToSeconds } = require('../utils').helpers;
 
 const { parseEther } = ethers.utils;
-const { AddressZero, MaxUint256 } = ethers.constants;
+const { AddressZero } = ethers.constants;
 
 const gracePeriod = 120 * 24 * 3600; // 120 days
 const NXM_ASSET_ID = 255;
@@ -54,9 +54,10 @@ describe('buyCover', function () {
     const { amount, productId, coverAsset, period, expectedPremium } = buyCoverFixture;
 
     const poolEthBalanceBefore = await ethers.provider.getBalance(pool.address);
+
     await cover.connect(coverBuyer).buyCover(
       {
-        coverId: MaxUint256,
+        coverId: 0,
         owner: coverBuyer.address,
         productId,
         coverAsset,
@@ -76,7 +77,8 @@ describe('buyCover', function () {
     expect(await ethers.provider.getBalance(cover.address)).to.be.equal(0);
     const premium = expectedPremium.mul(period).div(daysToSeconds(365));
     expect(await ethers.provider.getBalance(pool.address)).to.equal(poolEthBalanceBefore.add(premium));
-    const coverId = (await cover.coverDataCount()).sub(1);
+    const coverId = await cover.coverDataCount();
+
     await assertCoverFields(cover, coverId, {
       productId,
       coverAsset,
@@ -99,7 +101,7 @@ describe('buyCover', function () {
 
     await cover.connect(coverBuyer).buyCover(
       {
-        coverId: MaxUint256,
+        coverId: 0,
         owner: coverBuyer.address,
         productId,
         coverAsset,
@@ -119,7 +121,7 @@ describe('buyCover', function () {
     expect(await ethers.provider.getBalance(cover.address)).to.be.equal(0);
     const premium = expectedPremium.mul(period).div(daysToSeconds(365));
     expect(await ethers.provider.getBalance(pool.address)).to.equal(poolEthBalanceBefore.add(premium));
-    const coverId = (await cover.coverDataCount()).sub(1);
+    const coverId = await cover.coverDataCount();
 
     await assertCoverFields(cover, coverId, {
       productId,
@@ -151,7 +153,7 @@ describe('buyCover', function () {
 
     await cover.connect(coverBuyer).buyCover(
       {
-        coverId: MaxUint256,
+        coverId: 0,
         owner: coverBuyer.address,
         productId,
         coverAsset,
@@ -173,7 +175,7 @@ describe('buyCover', function () {
     const expectedPremiumPerPool = expectedPremium.div(2).mul(period).div(daysToSeconds(365));
     expect(await ethers.provider.getBalance(pool.address)).to.equal(expectedPremiumPerPool.mul(2));
 
-    const coverId = (await cover.coverDataCount()).sub(1);
+    const coverId = await cover.coverDataCount();
     await assertCoverFields(cover, coverId, {
       productId,
       coverAsset,
@@ -208,7 +210,7 @@ describe('buyCover', function () {
     await expect(
       cover.connect(coverBuyer).buyCover(
         {
-          coverId: MaxUint256,
+          coverId: 0,
           owner: coverBuyer.address,
           productId,
           coverAsset,
@@ -240,7 +242,7 @@ describe('buyCover', function () {
     const commissionDifference = commissionNxmBalanceAfter.sub(commissionNxmBalanceBefore);
     expect(commissionDifference).to.be.equal(expectedCommission);
 
-    const coverId = (await cover.coverDataCount()).sub(1);
+    const coverId = await cover.coverDataCount();
     await assertCoverFields(cover, coverId, {
       productId,
       coverAsset,
@@ -282,7 +284,7 @@ describe('buyCover', function () {
 
     await cover.connect(coverBuyer).buyCover(
       {
-        coverId: MaxUint256,
+        coverId: 0,
         owner: coverBuyer.address,
         productId,
         coverAsset,
@@ -310,7 +312,7 @@ describe('buyCover', function () {
     const commissionDifference = commissionDaiBalanceAfter.sub(commissionDaiBalanceBefore);
     expect(commissionDifference).to.be.equal(expectedCommission);
 
-    const coverId = (await cover.coverDataCount()).sub(1);
+    const coverId = await cover.coverDataCount();
     await assertCoverFields(cover, coverId, {
       productId,
       coverAsset,
@@ -352,7 +354,7 @@ describe('buyCover', function () {
     await expect(
       cover.connect(coverBuyer).buyCover(
         {
-          coverId: MaxUint256,
+          coverId: 0,
           owner: coverBuyer.address,
           productId,
           coverAsset,
@@ -381,7 +383,7 @@ describe('buyCover', function () {
     const commissionDifference = commissionDaiBalanceAfter.sub(commissionDaiBalanceBefore);
     expect(commissionDifference).to.be.equal(expectedCommission);
 
-    const coverId = (await cover.coverDataCount()).sub(1);
+    const coverId = await cover.coverDataCount();
     await assertCoverFields(cover, coverId, {
       productId,
       coverAsset,
@@ -401,7 +403,7 @@ describe('buyCover', function () {
     await expect(
       cover.connect(coverBuyer).buyCover(
         {
-          coverId: MaxUint256,
+          coverId: 0,
           owner: coverBuyer.address,
           productId,
           coverAsset,
@@ -428,7 +430,7 @@ describe('buyCover', function () {
     await expect(
       cover.connect(coverBuyer).buyCover(
         {
-          coverId: MaxUint256,
+          coverId: 0,
           owner: coverBuyer.address,
           productId,
           coverAsset,
@@ -455,7 +457,7 @@ describe('buyCover', function () {
     await expect(
       cover.connect(coverBuyer).buyCover(
         {
-          coverId: MaxUint256,
+          coverId: 0,
           owner: coverBuyer.address,
           productId: 2,
           coverAsset,
@@ -483,7 +485,7 @@ describe('buyCover', function () {
     await expect(
       cover.connect(coverBuyer).buyCover(
         {
-          coverId: MaxUint256,
+          coverId: 0,
           owner: coverBuyer.address,
           productId,
           coverAsset,
@@ -510,7 +512,7 @@ describe('buyCover', function () {
     await expect(
       cover.connect(coverBuyer).buyCover(
         {
-          coverId: MaxUint256,
+          coverId: 0,
           owner: coverBuyer.address,
           productId,
           coverAsset,
@@ -536,7 +538,7 @@ describe('buyCover', function () {
     await expect(
       cover.connect(coverBuyer).buyCover(
         {
-          coverId: MaxUint256,
+          coverId: 0,
           owner: coverBuyer.address,
           productId,
           coverAsset,
@@ -564,7 +566,7 @@ describe('buyCover', function () {
     await expect(
       cover.connect(coverBuyer).buyCover(
         {
-          coverId: MaxUint256,
+          coverId: 0,
           owner: coverBuyer.address,
           productId,
           coverAsset,
@@ -597,7 +599,7 @@ describe('buyCover', function () {
     await expect(
       cover.connect(member1).buyCover(
         {
-          coverId: MaxUint256,
+          coverId: 0,
           owner: coverBuyer1.address,
           productId,
           coverAsset,
@@ -625,7 +627,7 @@ describe('buyCover', function () {
     await expect(
       cover.connect(coverBuyer).buyCover(
         {
-          coverId: MaxUint256,
+          coverId: 0,
           owner: coverBuyer.address,
           productId,
           coverAsset,
@@ -655,7 +657,7 @@ describe('buyCover', function () {
     await expect(
       cover.connect(nonMember).buyCover(
         {
-          coverId: MaxUint256,
+          coverId: 0,
           owner: nonMember.address,
           productId,
           coverAsset,
@@ -681,7 +683,7 @@ describe('buyCover', function () {
     await expect(
       cover.connect(coverBuyer).buyCover(
         {
-          coverId: MaxUint256,
+          coverId: 0,
           owner: AddressZero,
           productId,
           coverAsset,
@@ -710,7 +712,7 @@ describe('buyCover', function () {
     await expect(
       cover.connect(coverBuyer).buyCover(
         {
-          coverId: MaxUint256,
+          coverId: 0,
           owner: coverBuyer.address,
           productId,
           coverAsset,
@@ -741,7 +743,7 @@ describe('buyCover', function () {
     await expect(
       cover.connect(coverBuyer).buyCover(
         {
-          coverId: MaxUint256,
+          coverId: 0,
           owner: coverBuyer.address,
           productId,
           coverAsset,
@@ -772,7 +774,7 @@ describe('buyCover', function () {
     await expect(
       cover.connect(coverBuyer).buyCover(
         {
-          coverId: MaxUint256,
+          coverId: 0,
           owner: coverBuyer.address,
           productId,
           coverAsset,
@@ -803,7 +805,7 @@ describe('buyCover', function () {
     await expect(
       cover.connect(coverBuyer).buyCover(
         {
-          coverId: MaxUint256,
+          coverId: 0,
           owner: coverBuyer.address,
           productId,
           coverAsset,
@@ -834,7 +836,7 @@ describe('buyCover', function () {
     await expect(
       cover.connect(coverBuyer).buyCover(
         {
-          coverId: MaxUint256,
+          coverId: 0,
           owner: coverBuyer.address,
           productId,
           coverAsset,
@@ -860,7 +862,7 @@ describe('buyCover', function () {
     await expect(
       cover.connect(coverBuyer).buyCover(
         {
-          coverId: MaxUint256,
+          coverId: 0,
           owner: coverBuyer.address,
           productId,
           coverAsset,
@@ -886,7 +888,7 @@ describe('buyCover', function () {
     await expect(
       cover.connect(coverBuyer).buyCover(
         {
-          coverId: MaxUint256,
+          coverId: 0,
           owner: coverBuyer.address,
           productId,
           coverAsset,
@@ -928,7 +930,7 @@ describe('buyCover', function () {
 
     await cover.connect(coverBuyer).buyCover(
       {
-        coverId: MaxUint256,
+        coverId: 0,
         owner: coverReceiver.address,
         productId,
         coverAsset,
@@ -965,7 +967,7 @@ describe('buyCover', function () {
 
     await cover.connect(coverBuyer).buyCover(
       {
-        coverId: MaxUint256,
+        coverId: 0,
         owner: coverBuyer.address,
         productId,
         coverAsset,
@@ -984,7 +986,7 @@ describe('buyCover', function () {
     const globalRewardsRatio = await cover.globalRewardsRatio();
     const { timestamp } = await ethers.provider.getBlock('latest');
 
-    const coverId = (await cover.coverDataCount()).sub(1);
+    const coverId = await cover.coverDataCount();
     const storedCoverData = await cover.coverData(coverId);
     expect(storedCoverData.productId).to.be.equal(productId);
     expect(storedCoverData.coverAsset).to.be.equal(coverAsset);
@@ -1020,7 +1022,7 @@ describe('buyCover', function () {
 
     await cover.connect(coverBuyer).buyCover(
       {
-        coverId: MaxUint256,
+        coverId: 0,
         owner: coverReceiver.address,
         productId,
         coverAsset,
@@ -1039,7 +1041,7 @@ describe('buyCover', function () {
     const nftBalanceAfter = await coverNFT.balanceOf(coverReceiver.address);
     expect(nftBalanceAfter).to.be.equal(1);
 
-    const coverId = (await cover.coverDataCount()).sub(1);
+    const coverId = await cover.coverDataCount();
     const ownerOfCoverId = await coverNFT.ownerOf(coverId);
     expect(ownerOfCoverId).to.be.equal(coverReceiver.address);
   });
@@ -1059,7 +1061,7 @@ describe('buyCover', function () {
 
     await cover.connect(coverBuyer).buyCover(
       {
-        coverId: MaxUint256,
+        coverId: 0,
         owner: nonMemberCoverReceiver.address,
         productId,
         coverAsset,
@@ -1078,7 +1080,7 @@ describe('buyCover', function () {
     const nftBalanceAfter = await coverNFT.balanceOf(nonMemberCoverReceiver.address);
     expect(nftBalanceAfter).to.be.equal(1);
 
-    const coverId = (await cover.coverDataCount()).sub(1);
+    const coverId = await cover.coverDataCount();
     const ownerOfCoverId = await coverNFT.ownerOf(coverId);
     expect(ownerOfCoverId).to.be.equal(nonMemberCoverReceiver.address);
   });
@@ -1112,7 +1114,7 @@ describe('buyCover', function () {
 
     await cover.connect(coverBuyer).buyCover(
       {
-        coverId: MaxUint256,
+        coverId: 0,
         owner: coverReceiver.address,
         productId,
         coverAsset,
@@ -1193,7 +1195,7 @@ describe('buyCover', function () {
 
     await cover.connect(coverBuyer).buyCover(
       {
-        coverId: MaxUint256,
+        coverId: 0,
         owner: coverReceiver.address,
         productId,
         coverAsset,
@@ -1222,7 +1224,7 @@ describe('buyCover', function () {
     expect(stakingPool2After.rewards).to.be.equal(stakingPool2Before.rewards.add(expectedRewardPerPool));
     expect(stakingPool3After.rewards).to.be.equal(stakingPool3Before.rewards.add(expectedRewardPerPool));
 
-    const coverId = (await cover.coverDataCount()).sub(1);
+    const coverId = await cover.coverDataCount();
 
     for (let i = 0; i < 3; i++) {
       const segmentAllocation = await cover.coverSegmentAllocations(coverId, segmentId, i);
@@ -1255,7 +1257,7 @@ describe('buyCover', function () {
 
     const txData = await cover.connect(coverBuyer).populateTransaction.buyCover(
       {
-        coverId: MaxUint256,
+        coverId: 0,
         owner: coverReceiver.address,
         productId,
         coverAsset,
@@ -1284,7 +1286,7 @@ describe('buyCover', function () {
     await expect(
       cover.connect(coverBuyer).buyCover(
         {
-          coverId: MaxUint256,
+          coverId: 0,
           owner: coverReceiver.address,
           productId,
           coverAsset,
@@ -1320,7 +1322,7 @@ describe('buyCover', function () {
 
     await cover.connect(coverBuyer1).buyCover(
       {
-        coverId: MaxUint256,
+        coverId: 0,
         owner: coverBuyer1.address,
         productId,
         coverAsset,
@@ -1338,7 +1340,7 @@ describe('buyCover', function () {
 
     await cover.connect(coverBuyer2).buyCover(
       {
-        coverId: MaxUint256,
+        coverId: 0,
         owner: coverBuyer2.address,
         productId,
         coverAsset,
@@ -1358,7 +1360,7 @@ describe('buyCover', function () {
     const { timestamp } = await ethers.provider.getBlock('latest');
 
     // Validate data for second cover
-    const coverId = (await cover.coverDataCount()).sub(1);
+    const coverId = await cover.coverDataCount();
     const storedCoverData = await cover.coverData(coverId);
     expect(storedCoverData.productId).to.be.equal(productId);
     expect(storedCoverData.coverAsset).to.be.equal(coverAsset);

--- a/test/unit/Cover/helpers.js
+++ b/test/unit/Cover/helpers.js
@@ -2,7 +2,7 @@ const { ethers } = require('hardhat');
 const { expect } = require('chai');
 
 const { parseEther } = ethers.utils;
-const { AddressZero, MaxUint256 } = ethers.constants;
+const { AddressZero } = ethers.constants;
 
 const DEFAULT_POOL_FEE = '5';
 const DEFAULT_PRODUCTS = [{ productId: 0, weight: 100 }];
@@ -97,7 +97,7 @@ async function buyCoverOnMultiplePools({
   const tx = await cover.connect(coverBuyer).buyCover(
     {
       owner: coverBuyer.address,
-      coverId: MaxUint256,
+      coverId: 0,
       productId,
       coverAsset,
       amount,

--- a/test/unit/Cover/setProducts.js
+++ b/test/unit/Cover/setProducts.js
@@ -26,7 +26,7 @@ describe('setProducts', function () {
   // Cover.BuyCoverParams
   const buyCoverTemplate = {
     owner: AddressZero,
-    coverId: MaxUint256,
+    coverId: 0,
     productId: 0,
     coverAsset: 0,
     amount,
@@ -339,7 +339,7 @@ describe('setProducts', function () {
     const deprecateProductParams = { ...productParamsTemplate, productId, product };
     await cover.connect(advisoryBoardMember0).setProducts([deprecateProductParams]);
 
-    const coverId = (await cover.coverDataCount()).sub(1);
+    const coverId = await cover.coverDataCount();
     const editCoverParams = { ...buyCoverParams, coverId };
 
     // edit cover

--- a/test/unit/Cover/totalActiveCoverInAsset.js
+++ b/test/unit/Cover/totalActiveCoverInAsset.js
@@ -7,7 +7,7 @@ const { buyCoverOnOnePool } = require('./helpers');
 
 const { BigNumber } = ethers;
 const { parseEther } = ethers.utils;
-const { AddressZero, MaxUint256 } = ethers.constants;
+const { AddressZero } = ethers.constants;
 
 const ETH_ASSET_ID = 0b00;
 const DAI_ASSET_ID = 0b01;
@@ -102,10 +102,11 @@ describe('totalActiveCoverInAsset', function () {
     await increaseTime(BUCKET_SIZE.toNumber());
 
     // Edit cover
+    const coverId = await cover.coverDataCount();
     await cover.connect(member).buyCover(
       {
         owner: member.address,
-        coverId: 0,
+        coverId,
         productId,
         coverAsset,
         amount,
@@ -134,7 +135,7 @@ describe('totalActiveCoverInAsset', function () {
       await cover.connect(member).buyCover(
         {
           owner: member.address,
-          coverId: MaxUint256,
+          coverId: 0,
           productId,
           coverAsset,
           amount,
@@ -166,7 +167,8 @@ describe('totalActiveCoverInAsset', function () {
     const { coverAsset, amount } = daiCoverBuyFixture;
 
     await buyCoverOnOnePool.call(this, daiCoverBuyFixture);
-    await cover.connect(internalContract).burnStake(0, 0, amount);
+    const coverId = await cover.coverDataCount();
+    await cover.connect(internalContract).burnStake(coverId, 0, amount);
     expect(await cover.totalActiveCoverInAsset(coverAsset)).to.be.equal(0);
   });
 
@@ -177,7 +179,8 @@ describe('totalActiveCoverInAsset', function () {
     const { coverAsset, amount } = daiCoverBuyFixture;
 
     await buyCoverOnOnePool.call(this, daiCoverBuyFixture);
-    await cover.connect(internalContract).burnStake(0, 0, 1);
+    const coverId = await cover.coverDataCount();
+    await cover.connect(internalContract).burnStake(coverId, 0, 1);
     expect(await cover.totalActiveCoverInAsset(coverAsset)).to.be.equal(amount.sub(1));
   });
 
@@ -192,7 +195,8 @@ describe('totalActiveCoverInAsset', function () {
 
     // cover 0
     await buyCoverOnOnePool.call(this, daiCoverBuyFixture);
-    await cover.connect(internalContract).burnStake(0, 0, amount);
+    const coverId = await cover.coverDataCount();
+    await cover.connect(internalContract).burnStake(coverId, 0, amount);
 
     const timeBetweenPurchases = daysToSeconds(2);
     expect(members.length * timeBetweenPurchases < daiCoverBuyFixture.period);
@@ -206,7 +210,7 @@ describe('totalActiveCoverInAsset', function () {
       await cover.connect(member).buyCover(
         {
           owner: member.address,
-          coverId: MaxUint256,
+          coverId: 0,
           productId,
           coverAsset,
           amount,
@@ -220,7 +224,7 @@ describe('totalActiveCoverInAsset', function () {
         [{ poolId: 0, coverAmountInAsset: amount }],
       );
       // Burn first segment of coverId == i
-      await cover.connect(internalContract).burnStake(i, 0, amount.div(2));
+      await cover.connect(internalContract).burnStake(i + 1, 0, amount.div(2));
       expect(await cover.totalActiveCoverInAsset(coverAsset)).to.be.equal(expectedActiveCover);
     }
 

--- a/test/unit/CoverNFT/coverNFT.js
+++ b/test/unit/CoverNFT/coverNFT.js
@@ -16,67 +16,67 @@ describe('CoverNFT', function () {
 
   it('should fail to mint - onlyOperator()', async function () {
     const { coverNFT } = this;
-    await expect(coverNFT.mint(coverNFT.address, 10)).to.be.revertedWith('CoverNFT: Not operator');
+    await expect(coverNFT.mint(coverNFT.address)).to.be.revertedWith('CoverNFT: Not operator');
   });
 
   it('should successfully mint', async function () {
     const { coverNFT } = this;
     const [operator, nftOwner] = this.accounts.members;
-    await coverNFT.connect(operator).mint(nftOwner.address, 0);
-    expect(await coverNFT.ownerOf(0)).to.be.equal(nftOwner.address);
+    await coverNFT.connect(operator).mint(nftOwner.address);
+    expect(await coverNFT.ownerOf(1)).to.be.equal(nftOwner.address);
   });
 
   it('should fail to burn - onlyOperator()', async function () {
     const { coverNFT } = this;
-    await expect(coverNFT.burn(0)).to.be.revertedWith('CoverNFT: Not operator');
+    await expect(coverNFT.burn(1)).to.be.revertedWith('CoverNFT: Not operator');
   });
 
   it('should successfully burn', async function () {
     const { coverNFT } = this;
     const [operator, nftOwner] = this.accounts.members;
-    await coverNFT.connect(operator).mint(nftOwner.address, 0);
-    await coverNFT.connect(operator).burn(0);
-    await expect(coverNFT.ownerOf(0)).to.be.revertedWith('NOT_MINTED');
+    await coverNFT.connect(operator).mint(nftOwner.address);
+    await coverNFT.connect(operator).burn(1);
+    await expect(coverNFT.ownerOf(1)).to.be.revertedWith('NOT_MINTED');
   });
 
   it('should return success for isApproveOrOwner() - owner == sender', async function () {
     const { coverNFT } = this;
     const [operator, nftOwner] = this.accounts.members;
-    await coverNFT.connect(operator).mint(nftOwner.address, 0);
-    expect(await coverNFT.isApprovedOrOwner(nftOwner.address, 0)).to.be.equal(true);
-    expect(await coverNFT.isApprovedOrOwner(operator.address, 0)).to.be.equal(false);
+    await coverNFT.connect(operator).mint(nftOwner.address);
+    expect(await coverNFT.isApprovedOrOwner(nftOwner.address, 1)).to.be.equal(true);
+    expect(await coverNFT.isApprovedOrOwner(operator.address, 1)).to.be.equal(false);
   });
 
   it('should return success for isApproveOrOwner() - isApprovedForAll', async function () {
     const { coverNFT } = this;
     const [operator, nftOwner] = this.accounts.members;
     const [randomAccount] = this.accounts.generalPurpose;
-    await coverNFT.connect(operator).mint(nftOwner.address, 0);
+    await coverNFT.connect(operator).mint(nftOwner.address);
     await coverNFT.connect(nftOwner).setApprovalForAll(randomAccount.address, true);
-    expect(await coverNFT.isApprovedOrOwner(randomAccount.address, 0)).to.be.equal(true);
-    expect(await coverNFT.isApprovedOrOwner(nftOwner.address, 0)).to.be.equal(true);
+    expect(await coverNFT.isApprovedOrOwner(randomAccount.address, 1)).to.be.equal(true);
+    expect(await coverNFT.isApprovedOrOwner(nftOwner.address, 1)).to.be.equal(true);
   });
 
   it('should return success for isApproveOrOwner() - isApproved', async function () {
     const { coverNFT } = this;
     const [operator, nftOwner] = this.accounts.members;
     const [randomAccount] = this.accounts.generalPurpose;
-    await coverNFT.connect(operator).mint(nftOwner.address, 0);
-    await coverNFT.connect(nftOwner).approve(randomAccount.address, 0);
-    expect(await coverNFT.isApprovedOrOwner(randomAccount.address, 0)).to.be.equal(true);
-    expect(await coverNFT.isApprovedOrOwner(nftOwner.address, 0)).to.be.equal(true);
+    await coverNFT.connect(operator).mint(nftOwner.address);
+    await coverNFT.connect(nftOwner).approve(randomAccount.address, 1);
+    expect(await coverNFT.isApprovedOrOwner(randomAccount.address, 1)).to.be.equal(true);
+    expect(await coverNFT.isApprovedOrOwner(nftOwner.address, 1)).to.be.equal(true);
   });
 
   it('should revert when calling isApproveOrOwner() for non-existing tokenId', async function () {
     const { coverNFT } = this;
     const [, account] = this.accounts.members;
-    await expect(coverNFT.isApprovedOrOwner(account.address, 0)).to.be.revertedWith('NOT_MINTED');
+    await expect(coverNFT.isApprovedOrOwner(account.address, 1)).to.be.revertedWith('NOT_MINTED');
   });
 
   it('should fail to transfer from operator - onlyOperator()', async function () {
     const { coverNFT } = this;
     const [account] = this.accounts.members;
-    await expect(coverNFT.operatorTransferFrom(coverNFT.address, account.address, 0)).to.be.revertedWith(
+    await expect(coverNFT.operatorTransferFrom(coverNFT.address, account.address, 1)).to.be.revertedWith(
       'CoverNFT: Not operator',
     );
   });
@@ -84,17 +84,17 @@ describe('CoverNFT', function () {
   it('should fail to transfer from operator - wrong from address', async function () {
     const { coverNFT } = this;
     const [operator, nftOwner, otherAddress] = this.accounts.members;
-    await coverNFT.connect(operator).mint(nftOwner.address, 0);
+    await coverNFT.connect(operator).mint(nftOwner.address);
     await expect(
-      coverNFT.connect(operator).operatorTransferFrom(otherAddress.address, operator.address, 0),
+      coverNFT.connect(operator).operatorTransferFrom(otherAddress.address, operator.address, 1),
     ).to.be.revertedWith('WRONG_FROM');
   });
 
   it('should fail to transfer from operator - send to 0 address', async function () {
     const { coverNFT } = this;
     const [operator, nftOwner] = this.accounts.members;
-    await coverNFT.connect(operator).mint(nftOwner.address, 0);
-    await expect(coverNFT.connect(operator).operatorTransferFrom(nftOwner.address, AddressZero, 0)).to.be.revertedWith(
+    await coverNFT.connect(operator).mint(nftOwner.address);
+    await expect(coverNFT.connect(operator).operatorTransferFrom(nftOwner.address, AddressZero, 1)).to.be.revertedWith(
       'INVALID_RECIPIENT',
     );
   });
@@ -102,9 +102,9 @@ describe('CoverNFT', function () {
   it('should successfully transfer from the operator', async function () {
     const { coverNFT } = this;
     const [operator, coverNFTReceiver] = this.accounts.members;
-    await coverNFT.connect(operator).mint(coverNFTReceiver.address, 0);
-    await coverNFT.connect(operator).operatorTransferFrom(coverNFTReceiver.address, operator.address, 0);
-    expect(await coverNFT.ownerOf(0)).to.be.equal(operator.address);
+    await coverNFT.connect(operator).mint(coverNFTReceiver.address);
+    await coverNFT.connect(operator).operatorTransferFrom(coverNFTReceiver.address, operator.address, 1);
+    expect(await coverNFT.ownerOf(1)).to.be.equal(operator.address);
   });
 
   it('should revert if caller is not operator', async function () {
@@ -129,5 +129,19 @@ describe('CoverNFT', function () {
     expect(await coverNFT.operator()).to.not.be.equal(newOperator.address);
     await coverNFT.connect(oldOperator).changeOperator(newOperator.address);
     expect(await coverNFT.operator()).to.be.equal(newOperator.address);
+  });
+
+  it('should increment and decrement totalSupply', async function () {
+    const { coverNFT } = this;
+    const [operator, nftOwner] = this.accounts.members;
+    const tokenId = 1;
+
+    expect(await coverNFT.totalSupply()).to.be.equal(0);
+    await expect(coverNFT.connect(operator).mint(nftOwner.address))
+      .to.emit(coverNFT, 'Transfer')
+      .withArgs(AddressZero, nftOwner.address, tokenId);
+
+    expect(await coverNFT.totalSupply()).to.be.equal(1);
+    await coverNFT.connect(operator).burn(tokenId);
   });
 });

--- a/test/unit/CoverNFT/coverNFT.js
+++ b/test/unit/CoverNFT/coverNFT.js
@@ -31,14 +31,6 @@ describe('CoverNFT', function () {
     await expect(coverNFT.burn(1)).to.be.revertedWith('CoverNFT: Not operator');
   });
 
-  it('should successfully burn', async function () {
-    const { coverNFT } = this;
-    const [operator, nftOwner] = this.accounts.members;
-    await coverNFT.connect(operator).mint(nftOwner.address);
-    await coverNFT.connect(operator).burn(1);
-    await expect(coverNFT.ownerOf(1)).to.be.revertedWith('NOT_MINTED');
-  });
-
   it('should return success for isApproveOrOwner() - owner == sender', async function () {
     const { coverNFT } = this;
     const [operator, nftOwner] = this.accounts.members;
@@ -71,40 +63,6 @@ describe('CoverNFT', function () {
     const { coverNFT } = this;
     const [, account] = this.accounts.members;
     await expect(coverNFT.isApprovedOrOwner(account.address, 1)).to.be.revertedWith('NOT_MINTED');
-  });
-
-  it('should fail to transfer from operator - onlyOperator()', async function () {
-    const { coverNFT } = this;
-    const [account] = this.accounts.members;
-    await expect(coverNFT.operatorTransferFrom(coverNFT.address, account.address, 1)).to.be.revertedWith(
-      'CoverNFT: Not operator',
-    );
-  });
-
-  it('should fail to transfer from operator - wrong from address', async function () {
-    const { coverNFT } = this;
-    const [operator, nftOwner, otherAddress] = this.accounts.members;
-    await coverNFT.connect(operator).mint(nftOwner.address);
-    await expect(
-      coverNFT.connect(operator).operatorTransferFrom(otherAddress.address, operator.address, 1),
-    ).to.be.revertedWith('WRONG_FROM');
-  });
-
-  it('should fail to transfer from operator - send to 0 address', async function () {
-    const { coverNFT } = this;
-    const [operator, nftOwner] = this.accounts.members;
-    await coverNFT.connect(operator).mint(nftOwner.address);
-    await expect(coverNFT.connect(operator).operatorTransferFrom(nftOwner.address, AddressZero, 1)).to.be.revertedWith(
-      'INVALID_RECIPIENT',
-    );
-  });
-
-  it('should successfully transfer from the operator', async function () {
-    const { coverNFT } = this;
-    const [operator, coverNFTReceiver] = this.accounts.members;
-    await coverNFT.connect(operator).mint(coverNFTReceiver.address);
-    await coverNFT.connect(operator).operatorTransferFrom(coverNFTReceiver.address, operator.address, 1);
-    expect(await coverNFT.ownerOf(1)).to.be.equal(operator.address);
   });
 
   it('should revert if caller is not operator', async function () {

--- a/test/unit/CoverNFT/coverNFT.js
+++ b/test/unit/CoverNFT/coverNFT.js
@@ -26,11 +26,6 @@ describe('CoverNFT', function () {
     expect(await coverNFT.ownerOf(1)).to.be.equal(nftOwner.address);
   });
 
-  it('should fail to burn - onlyOperator()', async function () {
-    const { coverNFT } = this;
-    await expect(coverNFT.burn(1)).to.be.revertedWith('CoverNFT: Not operator');
-  });
-
   it('should return success for isApproveOrOwner() - owner == sender', async function () {
     const { coverNFT } = this;
     const [operator, nftOwner] = this.accounts.members;
@@ -89,7 +84,7 @@ describe('CoverNFT', function () {
     expect(await coverNFT.operator()).to.be.equal(newOperator.address);
   });
 
-  it('should increment and decrement totalSupply', async function () {
+  it('should increment totalSupply', async function () {
     const { coverNFT } = this;
     const [operator, nftOwner] = this.accounts.members;
     const tokenId = 1;
@@ -100,6 +95,5 @@ describe('CoverNFT', function () {
       .withArgs(AddressZero, nftOwner.address, tokenId);
 
     expect(await coverNFT.totalSupply()).to.be.equal(1);
-    await coverNFT.connect(operator).burn(tokenId);
   });
 });

--- a/test/unit/IndividualClaims/getClaimsCount.js
+++ b/test/unit/IndividualClaims/getClaimsCount.js
@@ -41,7 +41,7 @@ describe('getClaimsCount', function () {
       expect(count).to.be.equal(0);
     }
 
-    await submitClaim(this)({ coverId: 0, sender: coverOwner });
+    await submitClaim(this)({ coverId: 1, sender: coverOwner });
 
     {
       const count = await individualClaims.getClaimsCount();
@@ -51,7 +51,7 @@ describe('getClaimsCount', function () {
     for (let i = 0; i < 6; i++) {
       const latestBlock = await ethers.provider.getBlock('latest');
       await setTime(latestBlock.timestamp + daysToSeconds(30));
-      await submitClaim(this)({ coverId: 0, sender: coverOwner });
+      await submitClaim(this)({ coverId: 1, sender: coverOwner });
     }
 
     {

--- a/test/unit/IndividualClaims/getClaimsToDisplay.js
+++ b/test/unit/IndividualClaims/getClaimsToDisplay.js
@@ -21,16 +21,16 @@ describe('getClaimsToDisplay', function () {
     segment.period = daysToSeconds('66');
     const expectedProductIds = ['1', '0', '1', '0', '1'];
     const expectedClaimIds = ['0', '1', '2', '3', '4'];
-    const expectedCoverIds = ['3', '1', '2', '0', '4'];
+    const expectedCoverIds = ['4', '2', '3', '1', '5'];
     const expectedAssessmentIds = ['0', '1', '2', '3', '4'];
-    const expectedAssetSymbols = ['MOCK', 'MOCK', 'ETH', 'ETH', 'MOCK']; // MOCk is the symbol for the DAI mock
+    const expectedAssetSymbols = ['MOCK', 'MOCK', 'ETH', 'ETH', 'MOCK']; // MOCK is the symbol for the DAI mock
     const expectedAssetIndexes = ['1', '1', '0', '0', '1'];
     const expectedAmounts = [parseEther('10'), parseEther('20'), parseEther('30'), parseEther('40'), parseEther('40')];
     const expectedCoverStarts = [];
     const expectedPollStarts = [];
 
     {
-      // 0
+      // 1
       const { timestamp } = await ethers.provider.getBlock('latest');
       segment.start = timestamp + 1;
       await cover.createMockCover(
@@ -44,7 +44,7 @@ describe('getClaimsToDisplay', function () {
     }
 
     {
-      // 1
+      // 2
       const { timestamp } = await ethers.provider.getBlock('latest');
       segment.start = timestamp + 1;
       await cover.createMockCover(
@@ -58,7 +58,7 @@ describe('getClaimsToDisplay', function () {
     }
 
     {
-      // 2
+      // 3
       const { timestamp } = await ethers.provider.getBlock('latest');
       segment.start = timestamp + 1;
       await cover.createMockCover(
@@ -72,7 +72,7 @@ describe('getClaimsToDisplay', function () {
     }
 
     {
-      // 3
+      // 4
       const { timestamp } = await ethers.provider.getBlock('latest');
       segment.start = timestamp + 1;
       await cover.createMockCover(
@@ -86,7 +86,7 @@ describe('getClaimsToDisplay', function () {
     }
 
     {
-      // 4
+      // 5
       const { timestamp } = await ethers.provider.getBlock('latest');
       segment.start = timestamp + 1;
       await cover.createMockCover(
@@ -104,7 +104,7 @@ describe('getClaimsToDisplay', function () {
         segment.period,
         ASSET.DAI,
       );
-      await individualClaims.connect(coverOwner).submitClaim(3, 0, expectedAmounts[0], '', {
+      await individualClaims.connect(coverOwner).submitClaim(4, 0, expectedAmounts[0], '', {
         value: deposit,
       });
       const latestBlock = await ethers.provider.getBlock('latest');
@@ -117,7 +117,7 @@ describe('getClaimsToDisplay', function () {
         segment.period,
         ASSET.DAI,
       );
-      await individualClaims.connect(coverOwner).submitClaim(1, 0, expectedAmounts[1], '', {
+      await individualClaims.connect(coverOwner).submitClaim(2, 0, expectedAmounts[1], '', {
         value: deposit,
       });
       const latestBlock = await ethers.provider.getBlock('latest');
@@ -130,7 +130,7 @@ describe('getClaimsToDisplay', function () {
         segment.period,
         ASSET.ETH,
       );
-      await individualClaims.connect(coverOwner).submitClaim(2, 0, expectedAmounts[2], '', {
+      await individualClaims.connect(coverOwner).submitClaim(3, 0, expectedAmounts[2], '', {
         value: deposit,
       });
       const latestBlock = await ethers.provider.getBlock('latest');
@@ -143,7 +143,7 @@ describe('getClaimsToDisplay', function () {
         segment.period,
         ASSET.ETH,
       );
-      await individualClaims.connect(coverOwner).submitClaim(0, 0, expectedAmounts[3], '', {
+      await individualClaims.connect(coverOwner).submitClaim(1, 0, expectedAmounts[3], '', {
         value: deposit,
       });
       const latestBlock = await ethers.provider.getBlock('latest');
@@ -156,7 +156,7 @@ describe('getClaimsToDisplay', function () {
         segment.period,
         ASSET.ETH,
       );
-      await individualClaims.connect(coverOwner).submitClaim(4, 0, expectedAmounts[4], '', {
+      await individualClaims.connect(coverOwner).submitClaim(5, 0, expectedAmounts[4], '', {
         value: deposit,
       });
       const latestBlock = await ethers.provider.getBlock('latest');

--- a/test/unit/IndividualClaims/redeemClaimPayout.js
+++ b/test/unit/IndividualClaims/redeemClaimPayout.js
@@ -26,7 +26,7 @@ describe('redeemClaimPayout', function () {
     );
 
     {
-      await submitClaim(this)({ coverId: 0, sender: coverOwner });
+      await submitClaim(this)({ coverId: 1, sender: coverOwner });
       const { payoutCooldownInDays } = await assessment.config();
       const { poll } = await assessment.assessments(0);
       await setTime(poll.end + daysToSeconds(payoutCooldownInDays));
@@ -34,7 +34,7 @@ describe('redeemClaimPayout', function () {
     }
 
     {
-      await submitClaim(this)({ coverId: 0, sender: coverOwner });
+      await submitClaim(this)({ coverId: 1, sender: coverOwner });
       const { payoutCooldownInDays } = await assessment.config();
       const { poll } = await assessment.assessments(1);
       await assessment.castVote(1, true, parseEther('1'));
@@ -44,7 +44,7 @@ describe('redeemClaimPayout', function () {
     }
 
     {
-      await submitClaim(this)({ coverId: 0, sender: coverOwner });
+      await submitClaim(this)({ coverId: 1, sender: coverOwner });
       const { payoutCooldownInDays } = await assessment.config();
       const { poll } = await assessment.assessments(2);
       await assessment.castVote(2, true, parseEther('1'));
@@ -65,7 +65,7 @@ describe('redeemClaimPayout', function () {
       [segment],
     );
 
-    await submitClaim(this)({ coverId: 0, sender: coverOwner });
+    await submitClaim(this)({ coverId: 1, sender: coverOwner });
 
     {
       const { poll } = await assessment.assessments(0);
@@ -101,7 +101,7 @@ describe('redeemClaimPayout', function () {
       [segment],
     );
 
-    await submitClaim(this)({ coverId: 0, sender: coverOwner });
+    await submitClaim(this)({ coverId: 1, sender: coverOwner });
 
     await assessment.castVote(0, true, parseEther('1'));
     const { poll } = await assessment.assessments(0);
@@ -125,7 +125,7 @@ describe('redeemClaimPayout', function () {
       [segment],
     );
 
-    await submitClaim(this)({ coverId: 0, sender: coverOwner });
+    await submitClaim(this)({ coverId: 1, sender: coverOwner });
     await assessment.castVote(0, true, parseEther('1'));
     const { poll } = await assessment.assessments(0);
     const { payoutCooldownInDays } = await assessment.config();
@@ -148,7 +148,7 @@ describe('redeemClaimPayout', function () {
       [segment],
     );
 
-    await submitClaim(this)({ coverId: 0, sender: coverOwner });
+    await submitClaim(this)({ coverId: 1, sender: coverOwner });
     await assessment.castVote(0, true, parseEther('1'));
     const { poll } = await assessment.assessments(0);
     const { payoutCooldownInDays } = await assessment.config();
@@ -171,7 +171,7 @@ describe('redeemClaimPayout', function () {
       [segment],
     );
 
-    await submitClaim(this)({ coverId: 0, sender: coverOwner });
+    await submitClaim(this)({ coverId: 1, sender: coverOwner });
     await assessment.castVote(0, true, parseEther('1'));
     const { poll } = await assessment.assessments(0);
     const { payoutCooldownInDays } = await assessment.config();
@@ -194,7 +194,7 @@ describe('redeemClaimPayout', function () {
       [segment],
     );
 
-    await submitClaim(this)({ coverId: 0, sender: coverOwner });
+    await submitClaim(this)({ coverId: 1, sender: coverOwner });
     await assessment.castVote(0, true, parseEther('1'));
     const { poll } = await assessment.assessments(0);
     const { payoutCooldownInDays } = await assessment.config();
@@ -202,7 +202,7 @@ describe('redeemClaimPayout', function () {
 
     await expect(individualClaims.connect(coverOwner).redeemClaimPayout(0))
       .to.emit(individualClaims, 'ClaimPayoutRedeemed')
-      .withArgs(coverOwner.address, parseEther('1'), 0, 0);
+      .withArgs(coverOwner.address, parseEther('1'), 0, 1);
   });
 
   it("sets the claim's payoutRedeemed property to true", async function () {
@@ -216,7 +216,7 @@ describe('redeemClaimPayout', function () {
       ASSET.ETH,
       [segment],
     );
-    await submitClaim(this)({ coverId: 0, sender: coverOwner });
+    await submitClaim(this)({ coverId: 1, sender: coverOwner });
     await assessment.castVote(0, true, parseEther('1'));
     const { poll } = await assessment.assessments(0);
     const { payoutCooldownInDays } = await assessment.config();
@@ -240,7 +240,7 @@ describe('redeemClaimPayout', function () {
     );
 
     const ethBalanceBefore = await ethers.provider.getBalance(originalOwner.address);
-    const coverId = 0;
+    const coverId = 1;
     const assessmentId = 0;
     const claimId = 0;
     const [deposit] = await individualClaims.getAssessmentDepositAndReward(segment.amount, segment.period, ASSET.ETH);
@@ -281,7 +281,7 @@ describe('redeemClaimPayout', function () {
         ],
       );
 
-      const coverId = 1;
+      const coverId = 2;
       const assessmentId = 1;
       const claimId = 1;
       const [deposit] = await individualClaims.getAssessmentDepositAndReward(segment.amount, segment.period, ASSET.ETH);
@@ -311,7 +311,7 @@ describe('redeemClaimPayout', function () {
 
     const ethBalanceBefore = await ethers.provider.getBalance(originalOwner.address);
     const daiBalanceBefore = await dai.balanceOf(originalOwner.address);
-    const coverId = 0;
+    const coverId = 1;
     const [deposit] = await individualClaims.getAssessmentDepositAndReward(segment.amount, segment.period, ASSET.DAI);
     await setNextBlockBaseFee('0');
     await individualClaims
@@ -336,7 +336,7 @@ describe('redeemClaimPayout', function () {
 
       const ethBalanceBefore = await ethers.provider.getBalance(newOwner.address);
       const daiBalanceBefore = await dai.balanceOf(newOwner.address);
-      const coverId = 1;
+      const coverId = 2;
       const segmentId = 0;
       const assessmentId = 1;
       const claimId = 1;

--- a/test/unit/IndividualClaims/setup.js
+++ b/test/unit/IndividualClaims/setup.js
@@ -65,9 +65,33 @@ async function setup() {
   await cover.addProductType('0', '90', '5000');
   await cover.addProductType('1', '30', '5000');
 
-  await cover.addProduct(['0', '0x1111111111111111111111111111111111111111', '1', '0', '0']);
-  await cover.addProduct(['1', '0x2222222222222222222222222222222222222222', '1', '0', '0']);
-  await cover.addProduct(['2', '0x3333333333333333333333333333333333333333', '1', '0', '0']);
+  const productTemplate = {
+    productType: '0',
+    yieldTokenAddress: '0x1111111111111111111111111111111111111111',
+    coverAssets: '1',
+    initialPriceRatio: '0',
+    capacityReductionRatio: '0',
+    isDeprecated: false,
+    useFixedPrice: false,
+  };
+
+  await cover.addProduct({
+    ...productTemplate,
+    productType: '0',
+    yieldTokenAddress: '0x1111111111111111111111111111111111111111',
+  });
+
+  await cover.addProduct({
+    ...productTemplate,
+    productType: '1',
+    yieldTokenAddress: '0x2222222222222222222222222222222222222222',
+  });
+
+  await cover.addProduct({
+    ...productTemplate,
+    productType: '2',
+    yieldTokenAddress: '0x3333333333333333333333333333333333333333',
+  });
 
   await individualClaims.changeMasterAddress(master.address);
   await individualClaims.changeDependentContractAddress();

--- a/test/unit/IndividualClaims/submitClaim.js
+++ b/test/unit/IndividualClaims/submitClaim.js
@@ -24,7 +24,7 @@ describe('submitClaim', function () {
       ASSET.ETH,
       [segment],
     );
-    const coverId = 0;
+    const coverId = 1;
     await expect(
       individualClaims.connect(coverOwner).submitClaim(coverId, 0, segment.amount, '', {
         value: ethers.constants.Zero,
@@ -42,12 +42,12 @@ describe('submitClaim', function () {
       ASSET.ETH,
       [segment],
     );
-    await submitClaim(this)({ coverId: 0, sender: coverOwner });
+    await submitClaim(this)({ coverId: 1, sender: coverOwner });
     await assessment.castVote(0, true, parseEther('1'));
     const { poll } = await assessment.assessments(0);
     const { payoutCooldownInDays } = await assessment.config();
     await setTime(poll.end + daysToSeconds(payoutCooldownInDays));
-    await expect(submitClaim(this)({ coverId: 0, sender: coverOwner })).to.be.revertedWith(
+    await expect(submitClaim(this)({ coverId: 1, sender: coverOwner })).to.be.revertedWith(
       'A payout can still be redeemed',
     );
   });
@@ -62,14 +62,14 @@ describe('submitClaim', function () {
       ASSET.ETH,
       [segment],
     );
-    await submitClaim(this)({ coverId: 0, sender: coverOwner });
-    await expect(submitClaim(this)({ coverId: 0, sender: coverOwner })).to.be.revertedWith(
+    await submitClaim(this)({ coverId: 1, sender: coverOwner });
+    await expect(submitClaim(this)({ coverId: 1, sender: coverOwner })).to.be.revertedWith(
       'A claim is already being assessed',
     );
     await assessment.castVote(0, true, parseEther('1'));
     const { poll } = await assessment.assessments(0);
     await setTime(poll.end + daysToSeconds(poll.end));
-    await expect(submitClaim(this)({ coverId: 0, sender: coverOwner })).not.to.be.revertedWith(
+    await expect(submitClaim(this)({ coverId: 1, sender: coverOwner })).not.to.be.revertedWith(
       'A claim is already being assessed',
     );
   });
@@ -84,7 +84,7 @@ describe('submitClaim', function () {
       ASSET.ETH,
       [segment],
     );
-    await expect(submitClaim(this)({ coverId: 0, sender: coverOwner })).to.be.revertedWith(
+    await expect(submitClaim(this)({ coverId: 1, sender: coverOwner })).to.be.revertedWith(
       'Invalid claim method for this product type',
     );
     {
@@ -97,7 +97,7 @@ describe('submitClaim', function () {
         [segment],
       );
     }
-    await expect(submitClaim(this)({ coverId: 1, sender: coverOwner })).not.to.be.revertedWith(
+    await expect(submitClaim(this)({ coverId: 2, sender: coverOwner })).not.to.be.revertedWith(
       'Invalid claim method for this product type',
     );
     {
@@ -110,7 +110,7 @@ describe('submitClaim', function () {
         [segment],
       );
     }
-    await expect(submitClaim(this)({ coverId: 2, sender: coverOwner })).not.to.be.revertedWith('Invalid redeem method');
+    await expect(submitClaim(this)({ coverId: 3, sender: coverOwner })).not.to.be.revertedWith('Invalid redeem method');
   });
 
   it('allows claim submission if an accepted claim is not redeemed during the redemption period', async function () {
@@ -123,13 +123,13 @@ describe('submitClaim', function () {
       ASSET.ETH,
       [segment],
     );
-    await submitClaim(this)({ coverId: 0, sender: coverOwner });
+    await submitClaim(this)({ coverId: 1, sender: coverOwner });
     await assessment.castVote(0, true, parseEther('1'));
     const { poll } = await assessment.assessments(0);
     const { payoutCooldownInDays } = await assessment.config();
     const { payoutRedemptionPeriodInDays } = await individualClaims.config();
     await setTime(poll.end + daysToSeconds(payoutCooldownInDays) + daysToSeconds(payoutRedemptionPeriodInDays));
-    await expect(submitClaim(this)({ coverId: 0, sender: coverOwner })).not.to.be.reverted;
+    await expect(submitClaim(this)({ coverId: 1, sender: coverOwner })).not.to.be.reverted;
   });
 
   it('reverts if the submission deposit is less than the expected amount', async function () {
@@ -144,7 +144,7 @@ describe('submitClaim', function () {
       ASSET.ETH,
       [segment],
     );
-    const coverId = 0;
+    const coverId = 1;
 
     const [deposit] = await individualClaims.getAssessmentDepositAndReward(segment.amount, segment.period, coverAsset);
     await expect(
@@ -172,7 +172,8 @@ describe('submitClaim', function () {
     await setNextBlockBaseFee('0');
     await individualClaims
       .connect(coverOwner)
-      .submitClaim(0, 0, segment.amount, '', { value: deposit.mul('2'), gasPrice: 0 });
+      .submitClaim(1, 0, segment.amount, '', { value: deposit.mul('2'), gasPrice: 0 });
+
     const balanceAfter = await ethers.provider.getBalance(coverOwner.address);
     expect(balanceAfter).to.be.equal(balanceBefore.sub(deposit));
 
@@ -189,7 +190,8 @@ describe('submitClaim', function () {
       await setNextBlockBaseFee('0');
       await individualClaims
         .connect(coverOwner)
-        .submitClaim(1, 0, segment.amount, '', { value: deposit.mul('3'), gasPrice: 0 });
+        .submitClaim(2, 0, segment.amount, '', { value: deposit.mul('3'), gasPrice: 0 });
+
       const balanceAfter = await ethers.provider.getBalance(coverOwner.address);
       expect(balanceAfter).to.be.equal(balanceBefore.sub(deposit));
     }
@@ -207,7 +209,8 @@ describe('submitClaim', function () {
       await setNextBlockBaseFee('0');
       await individualClaims
         .connect(coverOwner)
-        .submitClaim(2, 0, segment.amount, '', { value: deposit.mul('10'), gasPrice: 0 });
+        .submitClaim(3, 0, segment.amount, '', { value: deposit.mul('10'), gasPrice: 0 });
+
       const balanceAfter = await ethers.provider.getBalance(coverOwner.address);
       expect(balanceAfter).to.be.equal(balanceBefore.sub(deposit));
     }
@@ -227,7 +230,7 @@ describe('submitClaim', function () {
       ASSET.ETH,
       [segment0, segment1],
     );
-    const coverId = 0;
+    const coverId = 1;
 
     const [deposit] = await individualClaims.getAssessmentDepositAndReward(
       segment0.amount,
@@ -257,7 +260,7 @@ describe('submitClaim', function () {
       ASSET.ETH,
       [segment0, segment1],
     );
-    const coverId = 0;
+    const coverId = 1;
 
     const [deposit] = await individualClaims.getAssessmentDepositAndReward(
       segment0.amount,
@@ -297,7 +300,7 @@ describe('submitClaim', function () {
     const latestBlock = await ethers.provider.getBlock('latest');
     const currentTime = latestBlock.timestamp;
     await setTime(currentTime + segment0.period + gracePeriod + 1);
-    const coverId = 0;
+    const coverId = 1;
 
     const [deposit] = await individualClaims.getAssessmentDepositAndReward(
       segment0.amount,
@@ -342,7 +345,7 @@ describe('submitClaim', function () {
     const latestBlock = await ethers.provider.getBlock('latest');
     const currentTime = latestBlock.timestamp;
     await setTime(currentTime + segment0.period + gracePeriod + 1);
-    const coverId = 0;
+    const coverId = 1;
 
     const [deposit] = await individualClaims.getAssessmentDepositAndReward(
       segment0.amount,
@@ -375,7 +378,7 @@ describe('submitClaim', function () {
       [segment],
     );
 
-    const coverId = 0;
+    const coverId = 1;
 
     const [expectedDeposit, expectedTotalReward] = await individualClaims.getAssessmentDepositAndReward(
       segment.amount,
@@ -407,7 +410,7 @@ describe('submitClaim', function () {
       ASSET.ETH,
       [segment],
     );
-    const coverId = 0;
+    const coverId = 1;
     coverNFT.connect(coverOwner).transferFrom(coverOwner.address, nonMemberOwner.address, coverId);
     await expect(submitClaim(this)({ coverId, sender: nonMemberOwner })).to.be.revertedWith('Caller is not a member');
   });
@@ -423,7 +426,7 @@ describe('submitClaim', function () {
       ASSET.ETH,
       [segment],
     );
-    const coverId = 0;
+    const coverId = 1;
     await expect(submitClaim(this)({ coverId, sender: otherMember })).to.be.revertedWith(
       'Only the owner or approved addresses can submit a claim',
     );
@@ -460,7 +463,7 @@ describe('submitClaim', function () {
       ASSET.ETH,
       [segment],
     );
-    const coverId = 0;
+    const coverId = 1;
     await expect(submitClaim(this)({ coverId, ipfsMetadata, sender: coverOwner }))
       .to.emit(individualClaims, 'MetadataSubmitted')
       .withArgs(0, ipfsMetadata);
@@ -476,7 +479,7 @@ describe('submitClaim', function () {
       ASSET.ETH,
       [segment],
     );
-    const coverId = 0;
+    const coverId = 1;
     await expect(submitClaim(this)({ coverId, sender: coverOwner })).not.to.emit(individualClaims, 'MetadataSubmitted');
   });
 
@@ -489,7 +492,7 @@ describe('submitClaim', function () {
       ASSET.ETH,
       [await getCoverSegment()],
     );
-    const firstCoverId = 0;
+    const firstCoverId = 1;
 
     {
       const [claimId, exists] = await individualClaims.lastClaimSubmissionOnCover(firstCoverId);
@@ -510,7 +513,7 @@ describe('submitClaim', function () {
       ASSET.ETH,
       [await getCoverSegment()],
     );
-    const secondCoverId = 1;
+    const secondCoverId = 2;
 
     {
       const [claimId, exists] = await individualClaims.lastClaimSubmissionOnCover(secondCoverId);
@@ -540,7 +543,7 @@ describe('submitClaim', function () {
       [segment],
     );
 
-    const coverId = 0;
+    const coverId = 1;
     const [deposit] = await individualClaims.getAssessmentDepositAndReward(segment.amount, segment.period, ASSET.ETH);
     await expect(
       individualClaims.connect(coverOwner).submitClaim(coverId, 0, segment.amount, '', { value: deposit }),
@@ -559,7 +562,7 @@ describe('submitClaim', function () {
       [segment],
     );
 
-    const coverId = 0;
+    const coverId = 1;
     const [deposit] = await individualClaims.getAssessmentDepositAndReward(segment.amount, segment.period, ASSET.ETH);
     await expect(
       individualClaims.connect(coverNonOwner).submitClaim(coverId, 0, segment.amount, '', { value: deposit }),
@@ -580,7 +583,7 @@ describe('submitClaim', function () {
 
     const balanceBefore = await ethers.provider.getBalance(pool.address);
 
-    const coverId = 0;
+    const coverId = 1;
     const [deposit] = await individualClaims.getAssessmentDepositAndReward(segment.amount, segment.period, ASSET.ETH);
     await individualClaims.connect(coverOwner).submitClaim(coverId, 0, segment.amount, '', { value: deposit });
     await expect(await ethers.provider.getBalance(pool.address)).to.be.equal(balanceBefore.add(deposit));
@@ -598,7 +601,7 @@ describe('submitClaim', function () {
       [segment],
     );
 
-    const coverId = 0;
+    const coverId = 1;
     const [deposit] = await individualClaims.getAssessmentDepositAndReward(segment.amount, segment.period, ASSET.ETH);
     await expect(individualClaims.connect(coverOwner).submitClaim(coverId, 0, segment.amount, '', { value: deposit }))
       .to.emit(individualClaims, 'ClaimSubmitted')
@@ -628,7 +631,7 @@ describe('submitClaim', function () {
     await expect(
       individualClaims
         .connect(fallbackWillFailSigner)
-        .submitClaim(0, 0, segment.amount, '', { value: deposit.mul('2') }),
+        .submitClaim(1, 0, segment.amount, '', { value: deposit.mul('2') }),
     ).to.be.revertedWith('Assessment deposit excess refund failed');
   });
 
@@ -654,7 +657,7 @@ describe('submitClaim', function () {
     );
 
     await expect(
-      individualClaims.connect(coverOwner).submitClaim(0, 0, segment.amount, '', { value: deposit }),
+      individualClaims.connect(coverOwner).submitClaim(1, 0, segment.amount, '', { value: deposit }),
     ).to.be.revertedWith('Assessment deposit transfer to pool failed');
   });
 });

--- a/test/unit/MemberRoles/switchMembershipAndAssets.js
+++ b/test/unit/MemberRoles/switchMembershipAndAssets.js
@@ -101,6 +101,8 @@ describe('switchMembershipAndAssets', function () {
     }
 
     await nxm.connect(member).approve(memberRoles.address, ethers.constants.MaxUint256);
+    await coverNFT.connect(member).setApprovalForAll(memberRoles.address, true);
+
     {
       const ownershipArr = await Promise.all([1, 2, 3].map(x => coverNFT.ownerOf(x)));
       expect(ownershipArr[0]).to.be.equal(member.address);
@@ -128,6 +130,7 @@ describe('switchMembershipAndAssets', function () {
     await stakingNFT.mint(member.address);
 
     await nxm.connect(member).approve(memberRoles.address, ethers.constants.MaxUint256);
+    await stakingNFT.connect(member).setApprovalForAll(memberRoles.address, true);
 
     const coverIds = [];
     const stakingNFTIds = [1, 3];
@@ -148,6 +151,7 @@ describe('switchMembershipAndAssets', function () {
     await stakingNFT.mint(otherMember.address);
 
     await nxm.connect(member).approve(memberRoles.address, ethers.constants.MaxUint256);
+    await stakingNFT.connect(member).setApprovalForAll(memberRoles.address, true);
 
     const newMemberAddress = nonMember.address;
     const coverIds = [];

--- a/test/unit/StakingNFT/stakingNFT.js
+++ b/test/unit/StakingNFT/stakingNFT.js
@@ -105,29 +105,6 @@ describe('StakingNFT', function () {
     await expect(stakingNFT.balanceOf(ethers.constants.AddressZero)).to.be.revertedWith('ZERO_ADDRESS');
   });
 
-  it('should revert if a non operator tries to call operatorTransfer - NOT_OPERATOR', async function () {
-    const { stakingNFT } = this;
-    const [member] = this.accounts.members;
-    await stakingNFT.connect(this.stakingPoolSigner).mint(this.poolId, member.address);
-    await expect(stakingNFT.operatorTransferFrom(member.address, member.address, 1)).to.be.revertedWith('NOT_OPERATOR');
-  });
-
-  it('should revert if trying to operatorTransfer a token from a non-owner - WRONG_FROM', async function () {
-    const { stakingNFT, cover } = this;
-    const [nonOwner, owner] = this.accounts.members;
-    await stakingNFT.connect(this.stakingPoolSigner).mint(this.poolId, owner.address);
-    await expect(cover.operatorTransferFrom(nonOwner.address, owner.address, 1)).to.be.revertedWith('WRONG_FROM');
-  });
-
-  it('should revert if trying to operatorTransfer a token to a zero address - ZERO_ADDRESS', async function () {
-    const { stakingNFT, cover } = this;
-    const [owner] = this.accounts.members;
-    await stakingNFT.connect(this.stakingPoolSigner).mint(this.poolId, owner.address);
-    await expect(cover.operatorTransferFrom(owner.address, ethers.constants.AddressZero, 1)).to.be.revertedWith(
-      'INVALID_RECIPIENT',
-    );
-  });
-
   it('should revert if trying to transferFrom a token from a non-owner - WRONG_FROM', async function () {
     const { stakingNFT } = this;
     const [nonOwner, owner] = this.accounts.members;

--- a/test/unit/StakingNFT/stakingNFT.js
+++ b/test/unit/StakingNFT/stakingNFT.js
@@ -97,9 +97,7 @@ describe('StakingNFT', function () {
     const { stakingNFT } = this;
     const [owner, nonOwner] = this.accounts.members;
     await stakingNFT.connect(this.stakingPoolSigner).mint(this.poolId, owner.address);
-    await expect(
-      stakingNFT.connect(nonOwner).approve(nonOwner.address, 1),
-    ).to.be.revertedWith('NOT_AUTHORIZED');
+    await expect(stakingNFT.connect(nonOwner).approve(nonOwner.address, 1)).to.be.revertedWith('NOT_AUTHORIZED');
   });
 
   it('should revert if reading balance of 0 address - ZERO_ADDRESS', async function () {
@@ -189,7 +187,7 @@ describe('StakingNFT', function () {
     await expect(
       stakingNFT
         .connect(owner)
-        ['safeTransferFrom(address,address,uint256)'](owner.address, cover.address, BigNumber.from(0)),
+        ['safeTransferFrom(address,address,uint256)'](owner.address, cover.address, BigNumber.from(1)),
     ).to.be.revertedWithoutReason();
   });
 

--- a/test/unit/StakingPool/burnStake.js
+++ b/test/unit/StakingPool/burnStake.js
@@ -68,7 +68,7 @@ describe('burnStake', function () {
 
     // Deposit into pool
     const { firstActiveTrancheId } = await getTranches(DEFAULT_PERIOD, DEFAULT_GRACE_PERIOD);
-    await stakingPool.connect(manager).depositTo(stakedNxmAmount, firstActiveTrancheId + 1, MaxUint256, AddressZero);
+    await stakingPool.connect(manager).depositTo(stakedNxmAmount, firstActiveTrancheId + 1, 0, AddressZero);
 
     // Move to the beginning of the next tranche
     const { firstActiveTrancheId: trancheId } = await getTranches();
@@ -93,7 +93,7 @@ describe('burnStake', function () {
 
     // depositTo and extendDeposit should revert
     await expect(
-      stakingPool.connect(member).depositTo(stakedNxmAmount, firstActiveTrancheId, MaxUint256, AddressZero),
+      stakingPool.connect(member).depositTo(stakedNxmAmount, firstActiveTrancheId, 0, AddressZero),
     ).to.be.revertedWithCustomError(stakingPool, 'PoolHalted');
     await expect(stakingPool.connect(member).extendDeposit(0, 0, 0, 0)).to.be.revertedWithCustomError(
       stakingPool,
@@ -113,15 +113,15 @@ describe('burnStake', function () {
 
     // deposit should work
     const { firstActiveTrancheId } = await getTranches(DEFAULT_PERIOD, DEFAULT_GRACE_PERIOD);
-    await expect(stakingPool.connect(member).depositTo(stakedNxmAmount, firstActiveTrancheId, MaxUint256, AddressZero))
-      .to.not.be.reverted;
+    await expect(stakingPool.connect(member).depositTo(stakedNxmAmount, firstActiveTrancheId, 0, AddressZero)).to.not.be
+      .reverted;
 
     // Burn all activeStake
     await stakingPool.connect(this.coverSigner).burnStake(stakedNxmAmount.add(1));
 
     // deposit should fail
     await expect(
-      stakingPool.connect(member).depositTo(stakedNxmAmount, firstActiveTrancheId, MaxUint256, AddressZero),
+      stakingPool.connect(member).depositTo(stakedNxmAmount, firstActiveTrancheId, 0, AddressZero),
     ).to.be.revertedWithCustomError(stakingPool, 'PoolHalted');
   });
 });

--- a/test/unit/StakingPool/depositTo.js
+++ b/test/unit/StakingPool/depositTo.js
@@ -7,13 +7,13 @@ const { daysToSeconds } = require('../utils').helpers;
 const { DIVISION_BY_ZERO } = require('../utils').errors;
 
 const { BigNumber } = ethers;
-const { AddressZero, MaxUint256 } = ethers.constants;
+const { AddressZero } = ethers.constants;
 const { parseEther } = ethers.utils;
 
 const depositToFixture = {
   amount: parseEther('100'),
   trancheId: 0,
-  tokenId: MaxUint256,
+  tokenId: 0,
   destination: AddressZero,
 };
 
@@ -32,7 +32,7 @@ const poolInitParams = {
   ipfsDescriptionHash: 'Description Hash',
 };
 
-const managerDepositId = MaxUint256;
+const managerDepositId = 0;
 
 const DEFAULT_PERIOD = daysToSeconds(30);
 const DEFAULT_GRACE_PERIOD = daysToSeconds(30);
@@ -148,7 +148,7 @@ describe('depositTo', function () {
     const { firstActiveTrancheId } = await getTranches(DEFAULT_PERIOD, DEFAULT_GRACE_PERIOD);
     const tx = await stakingPool.connect(user).depositTo(amount, firstActiveTrancheId, tokenId, destination);
 
-    const expectedMintedTokenId = 0;
+    const expectedMintedTokenId = 1;
     await expect(tx).to.emit(stakingNFT, 'Transfer').withArgs(AddressZero, user.address, expectedMintedTokenId);
 
     const totalSupplyAfter = await stakingNFT.totalSupply();
@@ -170,7 +170,7 @@ describe('depositTo', function () {
 
     const tx = await stakingPool.connect(user1).depositTo(amount, firstActiveTrancheId, tokenId, user2.address);
 
-    const expectedMintedTokenId = 0;
+    const expectedMintedTokenId = 1;
     await expect(tx).to.emit(stakingNFT, 'Transfer').withArgs(AddressZero, user2.address, expectedMintedTokenId);
 
     const totalSupplyAfter = await stakingNFT.totalSupply();
@@ -188,7 +188,7 @@ describe('depositTo', function () {
     const { firstActiveTrancheId } = await getTranches(DEFAULT_PERIOD, DEFAULT_GRACE_PERIOD);
     const newStakeShares = await estimateStakeShares({ amount, stakingPool });
 
-    const expectedTokenId = 0;
+    const expectedTokenId = 1;
     const tx = await stakingPool.connect(user).depositTo(amount, firstActiveTrancheId, tokenId, destination);
     await expect(tx).to.emit(stakingNFT, 'Transfer').withArgs(AddressZero, user.address, expectedTokenId);
 
@@ -216,7 +216,7 @@ describe('depositTo', function () {
     // first deposit
     const tx = await stakingPool.connect(user).depositTo(amount, firstActiveTrancheId, tokenId, destination);
 
-    const expectedTokenId = 0;
+    const expectedTokenId = 1;
     await expect(tx).to.emit(stakingNFT, 'Transfer').withArgs(AddressZero, user.address, expectedTokenId);
 
     const firstDepositData = await stakingPool.deposits(expectedTokenId, firstActiveTrancheId);
@@ -247,8 +247,8 @@ describe('depositTo', function () {
     // Generate rewards
     const allocationRequest = {
       productId: 0,
-      coverId: MaxUint256,
-      allocationId: MaxUint256,
+      coverId: 0,
+      allocationId: 0,
       period: daysToSeconds(30),
       gracePeriod: daysToSeconds(30),
       previousStart: 0,
@@ -264,7 +264,7 @@ describe('depositTo', function () {
     const { firstActiveTrancheId } = await getTranches(allocationRequest.period, allocationRequest.gracePeriod);
 
     // first deposit
-    const expectedTokenId = 0;
+    const expectedTokenId = 1;
     await stakingPool.connect(user).depositTo(amount, firstActiveTrancheId, tokenId, destination);
     const depositData = await stakingPool.deposits(expectedTokenId, firstActiveTrancheId);
 
@@ -312,8 +312,8 @@ describe('depositTo', function () {
 
     const allocationRequest = {
       productId: 0,
-      coverId: MaxUint256,
-      allocationId: MaxUint256,
+      coverId: 0,
+      allocationId: 0,
       period: daysToSeconds(30),
       gracePeriod: daysToSeconds(30),
       previousStart: 0,
@@ -369,8 +369,8 @@ describe('depositTo', function () {
 
     const allocationRequest = {
       productId: 0,
-      coverId: MaxUint256,
-      allocationId: MaxUint256,
+      coverId: 0,
+      allocationId: 0,
       period: daysToSeconds(30),
       gracePeriod: daysToSeconds(30),
       previousStart: 0,
@@ -418,7 +418,7 @@ describe('depositTo', function () {
     await stakingPool.connect(user).depositTo(amount, firstActiveTrancheId, tokenId, destination);
 
     {
-      const expectedTokenId = 0;
+      const expectedTokenId = 1;
       const userDeposit = await stakingPool.deposits(expectedTokenId, firstActiveTrancheId);
       const managerDeposit = await stakingPool.deposits(managerDepositId, firstActiveTrancheId);
 
@@ -449,7 +449,7 @@ describe('depositTo', function () {
     await stakingPool.connect(user).depositTo(amount, firstActiveTrancheId, tokenId, destination);
 
     {
-      const expectedTokenId = 0;
+      const expectedTokenId = 1;
       const userDeposit = await stakingPool.deposits(expectedTokenId, firstActiveTrancheId);
       const managerDeposit = await stakingPool.deposits(managerDepositId, firstActiveTrancheId);
 
@@ -475,7 +475,7 @@ describe('depositTo', function () {
     await stakingPool.connect(user).depositTo(amount, firstActiveTrancheId, tokenId, destination);
 
     {
-      const expectedTokenId = 0;
+      const expectedTokenId = 1;
       const userDeposit = await stakingPool.deposits(expectedTokenId, firstActiveTrancheId);
       const managerDeposit = await stakingPool.deposits(managerDepositId, firstActiveTrancheId);
 
@@ -535,8 +535,8 @@ describe('depositTo', function () {
     let totalStakeShares = BigNumber.from(0);
     let stakedAmount = BigNumber.from(0);
 
-    for (let tokenId = 0; tokenId < tranches.length; tokenId++) {
-      const trancheId = tranches[tokenId];
+    for (let tokenId = 1; tokenId < tranches.length; tokenId++) {
+      const trancheId = tranches[tokenId - 1];
       const deposit = await stakingPool.deposits(tokenId, trancheId);
 
       const newRewardShares = await getNewRewardShares({
@@ -548,7 +548,7 @@ describe('depositTo', function () {
       });
 
       const newStakeShares =
-        tokenId === 0
+        tokenId === 1
           ? Math.sqrt(amount) // first deposit uses sqrt(amount)
           : amount.mul(totalStakeShares).div(stakedAmount);
 
@@ -579,7 +579,7 @@ describe('depositTo', function () {
 
     const { firstActiveTrancheId } = await getTranches(DEFAULT_PERIOD, DEFAULT_GRACE_PERIOD);
 
-    const expectedTokenId = 0;
+    const expectedTokenId = 1;
     await expect(stakingPool.connect(user).depositTo(amount, firstActiveTrancheId, tokenId, destination))
       .to.emit(stakingPool, 'StakeDeposited')
       .withArgs(user.address, amount, firstActiveTrancheId, expectedTokenId);
@@ -643,5 +643,38 @@ describe('depositTo', function () {
       stakingPool,
       'NxmIsLockedForGovernanceVote',
     );
+  });
+
+  it('should revert if trying to deposit with token from other pool', async function () {
+    const { stakingPool, nxm, stakingNFT, cover, tokenController, master } = this;
+    const [user, manager] = this.accounts.members;
+
+    const { amount, tokenId, destination } = depositToFixture;
+    const { poolId, initialPoolFee, maxPoolFee, products, ipfsDescriptionHash } = poolInitParams;
+
+    const { firstActiveTrancheId } = await getTranches(DEFAULT_PERIOD, DEFAULT_GRACE_PERIOD);
+    const otherStakingPool = await ethers.deployContract('StakingPool', [
+      stakingNFT.address,
+      nxm.address,
+      cover.address,
+      tokenController.address,
+      master.address,
+    ]);
+    await stakingPool.connect(this.coverSigner).initialize(
+      manager.address,
+      false, // isPrivatePool
+      initialPoolFee,
+      maxPoolFee,
+      products,
+      poolId + 1,
+      ipfsDescriptionHash,
+    );
+    await nxm.mint(user.address, amount.mul(2));
+    await nxm.approve(stakingPool.address, amount);
+    await nxm.approve(otherStakingPool.address, amount);
+    await stakingPool.connect(user).depositTo(amount, firstActiveTrancheId, tokenId, destination);
+    await expect(
+      otherStakingPool.connect(user).depositTo(amount, firstActiveTrancheId, 1, destination),
+    ).to.be.revertedWithCustomError(otherStakingPool, 'TokenDoesNotBelongToPool');
   });
 });

--- a/test/unit/StakingPool/extendDeposit.js
+++ b/test/unit/StakingPool/extendDeposit.js
@@ -3,13 +3,13 @@ const { expect } = require('chai');
 const { getTranches, getNewRewardShares, TRANCHE_DURATION, generateRewards, setTime } = require('./helpers');
 const { setEtherBalance, increaseTime } = require('../utils').evm;
 
-const { AddressZero, MaxUint256 } = ethers.constants;
+const { AddressZero } = ethers.constants;
 const { parseEther } = ethers.utils;
 
 const depositToFixture = {
   amount: parseEther('100'),
   trancheId: 0,
-  tokenId: MaxUint256,
+  tokenId: 0,
   destination: AddressZero,
 };
 
@@ -28,8 +28,8 @@ const poolInitParams = {
   ipfsDescriptionHash: 'Description Hash',
 };
 
-const depositNftId = 0;
-const managerDepositId = MaxUint256;
+const depositNftId = 1;
+const managerDepositId = 0;
 
 describe('extendDeposit', function () {
   beforeEach(async function () {
@@ -72,7 +72,7 @@ describe('extendDeposit', function () {
     ).to.be.revertedWith('System is paused');
   });
 
-  it('reverts if token id is max uint', async function () {
+  it('reverts if token id is 0', async function () {
     const { stakingPool } = this;
     const { firstActiveTrancheId, maxTranche } = await getTranches();
 
@@ -80,8 +80,8 @@ describe('extendDeposit', function () {
     const managerSigner = await ethers.getImpersonatedSigner(managerAddress);
 
     await expect(
-      stakingPool.connect(managerSigner).extendDeposit(MaxUint256, firstActiveTrancheId, maxTranche, 0),
-    ).to.be.revertedWithCustomError(stakingPool, 'InvalidTokenId');
+      stakingPool.connect(managerSigner).extendDeposit(0, firstActiveTrancheId, maxTranche, 0),
+    ).to.be.revertedWith('NOT_MINTED');
   });
 
   it('reverts if new tranche ends before the initial tranche', async function () {

--- a/test/unit/StakingPool/helpers.js
+++ b/test/unit/StakingPool/helpers.js
@@ -6,7 +6,6 @@ const { daysToSeconds } = require('../utils').helpers;
 
 const { parseEther } = ethers.utils;
 const { BigNumber } = ethers;
-const { MaxUint256 } = ethers.constants;
 
 const TRANCHE_DURATION = daysToSeconds(91);
 const BUCKET_DURATION = daysToSeconds(28);
@@ -182,7 +181,7 @@ async function generateRewards(
   const allocationRequest = {
     productId: 0,
     coverId: 0,
-    allocationId: MaxUint256,
+    allocationId: 0,
     period,
     gracePeriod,
     previousStart: 0,

--- a/test/unit/StakingPool/processExpirations.js
+++ b/test/unit/StakingPool/processExpirations.js
@@ -13,14 +13,14 @@ const {
   MAX_ACTIVE_TRANCHES,
 } = require('./helpers');
 
-const { AddressZero, MaxUint256 } = ethers.constants;
+const { AddressZero } = ethers.constants;
 const { parseEther } = ethers.utils;
 const { BigNumber } = ethers;
 
 const depositToFixture = {
   amount: parseEther('100'),
   trancheId: 0,
-  tokenId: MaxUint256,
+  tokenId: 0,
   destination: AddressZero,
 };
 
@@ -126,7 +126,7 @@ describe('processExpirations', function () {
     for (let i = 0; i < tranches.length; i++) {
       const tranche = tranches[i];
       await stakingPool.connect(user).depositTo(amount, tranche, tokenId, destination);
-      const nftId = i;
+      const nftId = i + 1;
       const deposit = await stakingPool.deposits(nftId, tranche);
 
       const feesRewardShares = deposit.rewardsShares.mul(initialPoolFee).div(POOL_FEE_DENOMINATOR.sub(initialPoolFee));

--- a/test/unit/StakingPool/requestAllocation.js
+++ b/test/unit/StakingPool/requestAllocation.js
@@ -558,8 +558,6 @@ describe('requestAllocation', function () {
       expect(coverTrancheAllocations).to.equal(0);
     }
 
-    const nextAllocationId = await stakingPool.getNextAllocationId();
-
     // Allocate
     await stakingPool.connect(this.coverSigner).requestAllocation(amount, previousPremium, allocationRequestParams);
 

--- a/test/unit/StakingPool/requestAllocation.js
+++ b/test/unit/StakingPool/requestAllocation.js
@@ -17,7 +17,7 @@ const {
 const { increaseTime } = require('../utils').evm;
 const { daysToSeconds } = require('../utils').helpers;
 
-const { AddressZero, MaxUint256, Two } = ethers.constants;
+const { AddressZero, Two } = ethers.constants;
 const { parseEther } = ethers.utils;
 const { BigNumber } = ethers;
 
@@ -41,7 +41,7 @@ const LAST_BUCKET_ID_MASK = MaxUint16;
 const allocationRequestParams = {
   productId: 0,
   coverId: 0,
-  allocationId: MaxUint256,
+  allocationId: 0,
   period: daysToSeconds(10),
   gracePeriod: daysToSeconds(10),
   previousStart: 0,
@@ -56,7 +56,7 @@ const allocationRequestParams = {
 
 const buyCoverParamsTemplate = {
   owner: AddressZero,
-  coverId: MaxUint256,
+  coverId: 0,
   productId: 0,
   coverAsset: 0, // ETH
   amount: parseEther('4800'),
@@ -131,7 +131,7 @@ describe('requestAllocation', function () {
 
     // Deposit into pool
     const amount = stakedNxmAmount;
-    await stakingPool.connect(staker).depositTo(amount, trancheId, MaxUint256, staker.address);
+    await stakingPool.connect(staker).depositTo(amount, trancheId, 0, staker.address);
   });
 
   it('should allocate the amount for tranches and generate new allocation Id', async function () {
@@ -143,7 +143,7 @@ describe('requestAllocation', function () {
     const nextAllocationIdBefore = await stakingPool.getNextAllocationId();
     const activeTrancheCapacitiesBefore = await stakingPool.getActiveAllocations(buyCoverParamsTemplate.productId);
 
-    await cover.allocateCapacity(buyCoverParams, coverId, MaxUint256, stakingPool.address);
+    await cover.allocateCapacity(buyCoverParams, coverId, 0, stakingPool.address);
 
     const nextAllocationIdAfter = await stakingPool.getNextAllocationId();
     const activeTrancheCapacitiesAfter = await stakingPool.getActiveAllocations(buyCoverParamsTemplate.productId);
@@ -164,7 +164,7 @@ describe('requestAllocation', function () {
       // AllocationRequest struct
       productId: buyCoverParamsTemplate.productId,
       coverId: buyCoverParamsTemplate.coverId,
-      allocationId: MaxUint256,
+      allocationId: 0,
       period: buyCoverParamsTemplate.period,
       gracePeriod: daysToSeconds(7),
       useFixedPrice: coverProductTemplate.useFixedPrice,
@@ -215,7 +215,7 @@ describe('requestAllocation', function () {
 
     // buy cover and check premium + new price
     const buyCoverParams = { ...buyCoverParamsTemplate, period: daysToSeconds(365) };
-    await cover.allocateCapacity(buyCoverParams, coverId, MaxUint256, stakingPool.address);
+    await cover.allocateCapacity(buyCoverParams, coverId, 0, stakingPool.address);
 
     const updatedProduct = await stakingPool.products(productId);
     expect(await cover.lastPremium()).to.be.equal(expectedPremium);
@@ -239,7 +239,7 @@ describe('requestAllocation', function () {
     {
       // buy cover and check premium + new price
       const buyCoverParams = { ...buyCoverParamsTemplate, amount };
-      await cover.allocateCapacity(buyCoverParams, coverId, MaxUint256, stakingPool.address);
+      await cover.allocateCapacity(buyCoverParams, coverId, 0, stakingPool.address);
 
       const product = await stakingPool.products(productId);
 
@@ -280,7 +280,7 @@ describe('requestAllocation', function () {
 
     {
       // buy cover and check premium + new price
-      await cover.allocateCapacity({ ...buyCoverParamsTemplate }, coverId, MaxUint256, stakingPool.address);
+      await cover.allocateCapacity({ ...buyCoverParamsTemplate }, coverId, 0, stakingPool.address);
 
       const product = await stakingPool.products(productId);
       expect(await cover.lastPremium()).to.be.equal(expectedPremium);
@@ -295,7 +295,7 @@ describe('requestAllocation', function () {
     const daysForward = 1;
     const expectedPrice = initialPrice - PRICE_CHANGE_PER_DAY * daysForward;
     await increaseTime(daysToSeconds(daysForward));
-    await cover.allocateCapacity({ ...buyCoverParamsTemplate }, coverId, MaxUint256, stakingPool.address);
+    await cover.allocateCapacity({ ...buyCoverParamsTemplate }, coverId, 0, stakingPool.address);
     const expectedPremium = buyCoverParamsTemplate.amount
       .mul(expectedPrice)
       .div(INITIAL_PRICE_DENOMINATOR)
@@ -305,7 +305,7 @@ describe('requestAllocation', function () {
       const product = await stakingPool.products(productId);
       const daysForward = 50;
       await increaseTime(daysToSeconds(daysForward));
-      await cover.allocateCapacity({ ...buyCoverParamsTemplate }, coverId, MaxUint256, stakingPool.address);
+      await cover.allocateCapacity({ ...buyCoverParamsTemplate }, coverId, 0, stakingPool.address);
       const expectedPremium = buyCoverParamsTemplate.amount
         .mul(product.targetPrice)
         .div(INITIAL_PRICE_DENOMINATOR)
@@ -321,7 +321,7 @@ describe('requestAllocation', function () {
     const daysForward = 1;
     const expectedPrice = initialPrice - PRICE_CHANGE_PER_DAY * daysForward;
     await increaseTime(daysToSeconds(daysForward));
-    await cover.allocateCapacity({ ...buyCoverParamsTemplate }, coverId, MaxUint256, stakingPool.address);
+    await cover.allocateCapacity({ ...buyCoverParamsTemplate }, coverId, 0, stakingPool.address);
     const expectedPremium = buyCoverParamsTemplate.amount
       .mul(expectedPrice)
       .div(INITIAL_PRICE_DENOMINATOR)
@@ -331,7 +331,7 @@ describe('requestAllocation', function () {
       const product = await stakingPool.products(productId);
       const daysForward = 100;
       await increaseTime(daysToSeconds(daysForward));
-      await cover.allocateCapacity({ ...buyCoverParamsTemplate }, coverId, MaxUint256, stakingPool.address);
+      await cover.allocateCapacity({ ...buyCoverParamsTemplate }, coverId, 0, stakingPool.address);
       const expectedPremium = buyCoverParamsTemplate.amount
         .mul(product.targetPrice)
         .div(INITIAL_PRICE_DENOMINATOR)
@@ -382,7 +382,7 @@ describe('requestAllocation', function () {
     expect(actualPremium.premium).to.be.equal(expectedPremium);
     expect(expectedSurgePremiumSkipped).to.be.equal(0);
 
-    await cover.connect(coverBuyer).allocateCapacity(buyCoverParams, coverId, MaxUint256, stakingPool.address);
+    await cover.connect(coverBuyer).allocateCapacity(buyCoverParams, coverId, 0, stakingPool.address);
 
     // get active allocations
     const activeAllocations = await stakingPool.getActiveAllocations(productId);
@@ -409,7 +409,7 @@ describe('requestAllocation', function () {
     );
 
     await expect(
-      cover.connect(coverBuyer).allocateCapacity(buyCoverParams, coverId, MaxUint256, stakingPool.address),
+      cover.connect(coverBuyer).allocateCapacity(buyCoverParams, coverId, 0, stakingPool.address),
     ).to.be.revertedWith("SafeCast: value doesn't fit in 32 bits");
   });
 
@@ -432,7 +432,7 @@ describe('requestAllocation', function () {
     const { NXM_PER_ALLOCATION_UNIT } = this.config;
 
     const currentTrancheId = await moveTimeToNextTranche(1);
-    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId, MaxUint256, AddressZero);
+    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId, 0, AddressZero);
 
     const amount = parseEther('100');
     const previousPremium = 0;
@@ -463,7 +463,7 @@ describe('requestAllocation', function () {
     const [user] = this.accounts.members;
 
     const currentTrancheId = await moveTimeToNextTranche(1);
-    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId, MaxUint256, AddressZero);
+    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId, 0, AddressZero);
 
     const amount = parseEther('100');
     const previousPremium = 0;
@@ -495,7 +495,7 @@ describe('requestAllocation', function () {
     const { NXM_PER_ALLOCATION_UNIT } = this.config;
 
     const currentTrancheId = await moveTimeToNextTranche(1);
-    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId, MaxUint256, AddressZero);
+    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId, 0, AddressZero);
 
     const amount = parseEther('100');
     const previousPremium = 0;
@@ -529,7 +529,7 @@ describe('requestAllocation', function () {
     const { NXM_PER_ALLOCATION_UNIT } = this.config;
 
     const currentTrancheId = await moveTimeToNextTranche(1);
-    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId, MaxUint256, AddressZero);
+    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId, 0, AddressZero);
 
     const amount = parseEther('100');
     const previousPremium = 0;
@@ -584,7 +584,7 @@ describe('requestAllocation', function () {
     // set amount = 0 to only deallocate
     await stakingPool.connect(this.coverSigner).requestAllocation(0, previousPremium, {
       ...allocationRequestParams,
-      allocationId: nextAllocationId,
+      allocationId,
       previousStart: lastBlock.timestamp,
       previousExpiration: lastBlock.timestamp + period,
     });
@@ -629,7 +629,7 @@ describe('requestAllocation', function () {
     const { productId } = allocationRequestParams;
 
     for (let i = 0; i < tranches.length; i++) {
-      await stakingPool.connect(user).depositTo(depositPerTranche, tranches[i], MaxUint256, AddressZero);
+      await stakingPool.connect(user).depositTo(depositPerTranche, tranches[i], 0, AddressZero);
     }
 
     const previousActiveAllocations = await stakingPool.getActiveAllocations(productId);
@@ -652,7 +652,7 @@ describe('requestAllocation', function () {
 
     // double capacity
     for (let i = 0; i < tranches.length; i++) {
-      await stakingPool.connect(user).depositTo(depositPerTranche, tranches[i], MaxUint256, AddressZero);
+      await stakingPool.connect(user).depositTo(depositPerTranche, tranches[i], 0, AddressZero);
     }
 
     // double allocation
@@ -680,9 +680,9 @@ describe('requestAllocation', function () {
     const depositAmount = parseEther('10');
 
     // add capacity to three tranches
-    await stakingPool.connect(user).depositTo(parseEther('10'), currentTrancheId, MaxUint256, AddressZero);
-    await stakingPool.connect(user).depositTo(parseEther('10'), currentTrancheId + 1, MaxUint256, AddressZero);
-    await stakingPool.connect(user).depositTo(parseEther('10'), currentTrancheId + 2, MaxUint256, AddressZero);
+    await stakingPool.connect(user).depositTo(parseEther('10'), currentTrancheId, 0, AddressZero);
+    await stakingPool.connect(user).depositTo(parseEther('10'), currentTrancheId + 1, 0, AddressZero);
+    await stakingPool.connect(user).depositTo(parseEther('10'), currentTrancheId + 2, 0, AddressZero);
 
     const allocationAmount = depositAmount.mul(3);
     const allocationAmountInNXMUnit = allocationAmount.div(NXM_PER_ALLOCATION_UNIT);
@@ -754,7 +754,7 @@ describe('requestAllocation', function () {
     const { NXM_PER_ALLOCATION_UNIT } = this.config;
 
     const currentTrancheId = await moveTimeToNextTranche(1);
-    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId, MaxUint256, AddressZero);
+    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId, 0, AddressZero);
 
     const amountProduct1 = parseEther('10');
     const amountProduct2 = parseEther('20');
@@ -819,7 +819,7 @@ describe('requestAllocation', function () {
     const [user] = this.accounts.members;
 
     const currentTrancheId = await moveTimeToNextTranche(1);
-    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId, MaxUint256, AddressZero);
+    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId, 0, AddressZero);
 
     const amount = parseEther('100');
     const previousPremium = 0;
@@ -846,7 +846,7 @@ describe('requestAllocation', function () {
     const { rewardRatio } = allocationRequestParams;
 
     const currentTrancheId = await moveTimeToNextTranche(1);
-    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId, MaxUint256, AddressZero);
+    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId, 0, AddressZero);
 
     const amount = parseEther('100');
     const previousPremium = 0;
@@ -923,7 +923,7 @@ describe('requestAllocation', function () {
     const { rewardRatio } = allocationRequestParams;
 
     const currentTrancheId = await moveTimeToNextTranche(1);
-    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId, MaxUint256, AddressZero);
+    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId, 0, AddressZero);
 
     const amount = parseEther('100');
     const previousPremium = 0;
@@ -1003,9 +1003,9 @@ describe('requestAllocation', function () {
     const depositAmount = parseEther('10');
 
     // add capacity to three tranches
-    await stakingPool.connect(user).depositTo(depositAmount, currentTrancheId, MaxUint256, AddressZero);
-    await stakingPool.connect(user).depositTo(depositAmount, currentTrancheId + 1, MaxUint256, AddressZero);
-    await stakingPool.connect(user).depositTo(depositAmount, currentTrancheId + 2, MaxUint256, AddressZero);
+    await stakingPool.connect(user).depositTo(depositAmount, currentTrancheId, 0, AddressZero);
+    await stakingPool.connect(user).depositTo(depositAmount, currentTrancheId + 1, 0, AddressZero);
+    await stakingPool.connect(user).depositTo(depositAmount, currentTrancheId + 2, 0, AddressZero);
 
     let maxAllocationAmount = depositAmount.mul(6);
     const previousPremium = 0;
@@ -1074,7 +1074,7 @@ describe('requestAllocation', function () {
     const { NXM_PER_ALLOCATION_UNIT } = this.config;
 
     const currentTrancheId = await moveTimeToNextTranche(1);
-    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId, MaxUint256, AddressZero);
+    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId, 0, AddressZero);
 
     const amount = parseEther('10');
     const previousPremium = 0;
@@ -1160,9 +1160,9 @@ describe('requestAllocation', function () {
 
     const currentTrancheId = await moveTimeToNextTranche(8);
 
-    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId, MaxUint256, AddressZero);
-    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId + 1, MaxUint256, AddressZero);
-    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId + 2, MaxUint256, AddressZero);
+    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId, 0, AddressZero);
+    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId + 1, 0, AddressZero);
+    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId + 2, 0, AddressZero);
 
     const amount = parseEther('200');
     const previousPremium = 0;
@@ -1262,9 +1262,9 @@ describe('requestAllocation', function () {
 
     const currentTrancheId = await moveTimeToNextTranche(8);
 
-    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId, MaxUint256, AddressZero);
-    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId + 1, MaxUint256, AddressZero);
-    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId + 2, MaxUint256, AddressZero);
+    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId, 0, AddressZero);
+    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId + 1, 0, AddressZero);
+    await stakingPool.connect(user).depositTo(parseEther('100'), currentTrancheId + 2, 0, AddressZero);
 
     const amount = parseEther('200');
     const previousPremium = 0;
@@ -1372,7 +1372,7 @@ describe('requestAllocation', function () {
     const depositAmount = parseEther('100');
 
     // add capacity to three tranches
-    await stakingPool.connect(user).depositTo(depositAmount, currentTrancheId, MaxUint256, AddressZero);
+    await stakingPool.connect(user).depositTo(depositAmount, currentTrancheId, 0, AddressZero);
 
     let maxAllocationAmount = depositAmount.mul(GLOBAL_CAPACITY_RATIO).div(GLOBAL_CAPACITY_DENOMINATOR);
     const previousPremium = 0;
@@ -1416,7 +1416,7 @@ describe('requestAllocation', function () {
     const depositAmount = parseEther('100');
 
     // add capacity to three tranches
-    await stakingPool.connect(user).depositTo(depositAmount, currentTrancheId, MaxUint256, AddressZero);
+    await stakingPool.connect(user).depositTo(depositAmount, currentTrancheId, 0, AddressZero);
 
     const maxAllocationAmountProduct1 = depositAmount
       .mul(GLOBAL_CAPACITY_RATIO)
@@ -1460,7 +1460,7 @@ describe('requestAllocation', function () {
     const capacityReductionRatio = 1000;
 
     // add capacity to three tranches
-    await stakingPool.connect(user).depositTo(depositAmount, currentTrancheId, MaxUint256, AddressZero);
+    await stakingPool.connect(user).depositTo(depositAmount, currentTrancheId, 0, AddressZero);
 
     const maxAllocationAmount = depositAmount
       .mul(GLOBAL_CAPACITY_RATIO)

--- a/test/unit/StakingPool/setPoolFee.js
+++ b/test/unit/StakingPool/setPoolFee.js
@@ -1,5 +1,5 @@
 const { ethers, expect } = require('hardhat');
-const { MaxUint256, AddressZero } = ethers.constants;
+const { AddressZero } = ethers.constants;
 const { parseEther } = ethers.utils;
 
 const { daysToSeconds } = require('../utils').helpers;
@@ -8,8 +8,8 @@ const { getTranches } = require('./helpers');
 
 const allocationRequestTemplate = {
   productId: 0,
-  coverId: MaxUint256,
-  allocationId: MaxUint256,
+  coverId: 0,
+  allocationId: 0,
   period: daysToSeconds(30),
   gracePeriod: daysToSeconds(30),
   previousStart: 0,
@@ -124,8 +124,8 @@ describe('setPoolFee', function () {
     const trancheId = firstActiveTrancheId + 1;
 
     const depositAmount = parseEther('100');
-    const tokenId = MaxUint256; // new deposit
-    const managerDepositId = MaxUint256; // manager position id
+    const tokenId = 0; // new deposit
+    const managerDepositId = 0; // manager position id
     const { initialPoolFee } = initializeParams;
     const newPoolFee = initialPoolFee - 2;
 

--- a/test/unit/StakingPool/setProducts.js
+++ b/test/unit/StakingPool/setProducts.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const { ethers } = require('hardhat');
 const { getCurrentTrancheId } = require('./helpers');
-const { AddressZero, MaxUint256 } = ethers.constants;
+const { AddressZero } = ethers.constants;
 const { parseEther } = ethers.utils;
 const daysToSeconds = days => days * 24 * 60 * 60;
 
@@ -39,7 +39,7 @@ const newProductTemplate = {
 
 const buyCoverParamsTemplate = {
   owner: AddressZero,
-  coverId: MaxUint256,
+  coverId: 0,
   productId: 0,
   coverAsset: 0, // ETH
   amount: parseEther('100'),
@@ -472,7 +472,7 @@ describe('setProducts unit tests', function () {
     // Get capacity in staking pool
     await nxm.connect(staker).approve(tokenController.address, amount);
     const trancheId = (await getCurrentTrancheId()) + 2;
-    await stakingPool.connect(staker).depositTo(amount, trancheId, /* token id: */ MaxUint256, staker.address);
+    await stakingPool.connect(staker).depositTo(amount, trancheId, /* token id: */ 0, staker.address);
 
     let i = 0;
     const coverId = 1;
@@ -501,7 +501,7 @@ describe('setProducts unit tests', function () {
 
     await Promise.all(
       coverBuyParams.map(cb => {
-        return cover.allocateCapacity(cb, coverId, MaxUint256, stakingPool.address);
+        return cover.allocateCapacity(cb, coverId, 0, stakingPool.address);
       }),
     );
 
@@ -544,7 +544,7 @@ describe('setProducts unit tests', function () {
     // Get capacity in staking pool
     await nxm.connect(staker).approve(tokenController.address, amount);
     const trancheId = (await getCurrentTrancheId()) + 2;
-    await stakingPool.connect(staker).depositTo(amount, trancheId, /* token id: */ MaxUint256, manager.address);
+    await stakingPool.connect(staker).depositTo(amount, trancheId, /* token id: */ 0, manager.address);
 
     const ratio = await cover.getPriceAndCapacityRatios([0]);
     const { totalCapacity } = await stakingPool.getActiveTrancheCapacities(
@@ -563,7 +563,7 @@ describe('setProducts unit tests', function () {
       });
     await Promise.all(
       coverBuyParams.map(cb => {
-        return cover.connect(coverBuyer).allocateCapacity(cb, coverId, MaxUint256, stakingPool.address);
+        return cover.connect(coverBuyer).allocateCapacity(cb, coverId, 0, stakingPool.address);
       }),
     );
 
@@ -614,7 +614,7 @@ describe('setProducts unit tests', function () {
     // Get capacity in staking pool
     await nxm.connect(staker).approve(tokenController.address, amount);
     const trancheId = (await getCurrentTrancheId()) + 2;
-    await stakingPool.connect(staker).depositTo(amount, trancheId, /* token id: */ MaxUint256, manager.address);
+    await stakingPool.connect(staker).depositTo(amount, trancheId, /* token id: */ 0, manager.address);
 
     // Initialize Products and CoverBuy requests
     const coverBuyParams = Array(20)
@@ -630,7 +630,7 @@ describe('setProducts unit tests', function () {
     const coverId = 1;
     await Promise.all(
       coverBuyParams.map(cb => {
-        return cover.connect(coverBuyer).allocateCapacity(cb, coverId, MaxUint256, stakingPool.address);
+        return cover.connect(coverBuyer).allocateCapacity(cb, coverId, 0, stakingPool.address);
       }),
     );
 

--- a/test/unit/StakingPool/withdraw.js
+++ b/test/unit/StakingPool/withdraw.js
@@ -11,7 +11,6 @@ const {
 } = require('./helpers');
 
 const { BigNumber } = ethers;
-const { MaxUint256 } = ethers.constants;
 const { parseEther } = ethers.utils;
 
 const product0 = {
@@ -34,7 +33,7 @@ const withdrawFixture = {
   ...initializeParams,
   amount: parseEther('100'),
   trancheId: 0,
-  tokenId: 0,
+  tokenId: 1,
   destination: ethers.constants.AddressZero,
 };
 
@@ -90,7 +89,7 @@ describe('withdraw', function () {
     await stakingPool.connect(user).depositTo(
       amount,
       firstActiveTrancheId,
-      MaxUint256, // new position,
+      0, // new position,
       destination,
     );
 
@@ -118,7 +117,7 @@ describe('withdraw', function () {
     await stakingPool.connect(user).depositTo(
       depositAmount,
       firstActiveTrancheId,
-      MaxUint256, // new position
+      0, // new position
       destination,
     );
 
@@ -158,7 +157,7 @@ describe('withdraw', function () {
     await stakingPool.connect(user).depositTo(
       amount,
       firstActiveTrancheId,
-      MaxUint256, // new position,
+      0, // new position,
       destination,
     );
 
@@ -201,7 +200,7 @@ describe('withdraw', function () {
     await stakingPool.connect(user).depositTo(
       amount,
       firstActiveTrancheId,
-      MaxUint256, // new position
+      0, // new position
       destination,
     );
 
@@ -222,7 +221,7 @@ describe('withdraw', function () {
     const managerBalanceBefore = await nxm.balanceOf(manager.address);
     const tcBalanceBefore = await nxm.balanceOf(tokenController.address);
 
-    const managerTokenId = MaxUint256;
+    const managerTokenId = 0;
     const managerDepositBefore = await stakingPool.deposits(managerTokenId, firstActiveTrancheId);
 
     await increaseTime(TRANCHE_DURATION);
@@ -283,7 +282,7 @@ describe('withdraw', function () {
     await stakingPool.connect(user).depositTo(
       amount,
       firstActiveTrancheId,
-      MaxUint256, // new position
+      0, // new position
       destination,
     );
 
@@ -325,7 +324,7 @@ describe('withdraw', function () {
       await stakingPool.connect(user).depositTo(
         amount,
         currentTranche,
-        i === 0 ? MaxUint256 : tokenId, // Only create new position for the first tranche
+        i === 0 ? 0 : tokenId, // Only create new position for the first tranche
         destination,
       );
 
@@ -380,7 +379,7 @@ describe('withdraw', function () {
     await stakingPool.connect(user).depositTo(
       amount,
       firstActiveTrancheId,
-      MaxUint256, // new position,
+      0, // new position,
       destination,
     );
 
@@ -426,7 +425,7 @@ describe('withdraw', function () {
     await stakingPool.connect(user).depositTo(
       amount,
       firstActiveTrancheId,
-      MaxUint256, // new position
+      0, // new position
       destination,
     );
 
@@ -472,7 +471,7 @@ describe('withdraw', function () {
       await stakingPool.connect(user).depositTo(
         amount.mul(i * 5 + 1),
         currentTranche,
-        i === 0 ? MaxUint256 : tokenId, // Only create new position for the first tranche
+        i === 0 ? 0 : tokenId, // Only create new position for the first tranche
         destination,
       );
 
@@ -527,7 +526,7 @@ describe('withdraw', function () {
       [parseEther('13'), parseEther('100'), parseEther('100')],
     ];
 
-    const tokenIds = [0, 1, 2];
+    const tokenIds = [1, 2, 3];
     const TRANCHE_COUNT = 5;
     const trancheIds = [];
 
@@ -553,7 +552,7 @@ describe('withdraw', function () {
         await stakingPool.connect(user).depositTo(
           amount,
           currentTranche + t,
-          t === 0 ? MaxUint256 : tokenIds[uid], // Only create new position for the first tranche
+          t === 0 ? 0 : tokenIds[uid], // Only create new position for the first tranche
           destination,
         );
 
@@ -625,7 +624,7 @@ describe('withdraw', function () {
     }
 
     // withdraw manager rewards
-    const managerTokenId = MaxUint256;
+    const managerTokenId = 0;
     const managerDepositsBeforeWithdraw = {};
     for (let t = 0; t < TRANCHE_COUNT; t++) {
       const tranche = trancheIds[t];

--- a/test/unit/YieldTokenIncidents/redeemPayout.js
+++ b/test/unit/YieldTokenIncidents/redeemPayout.js
@@ -57,27 +57,27 @@ describe('redeemPayout', function () {
     }
 
     await expect(
-      yieldTokenIncidents.connect(coverOwner).redeemPayout(0, 0, 0, parseEther('100'), coverOwner.address, []),
-    ).not.to.be.revertedWith('Only the cover owner or approved addresses can redeem');
-
-    await expect(
-      yieldTokenIncidents.connect(nonCoverOwner).redeemPayout(0, 1, 0, parseEther('100'), coverOwner.address, []),
-    ).to.be.revertedWith('Only the cover owner or approved addresses can redeem');
-
-    await coverNFT.connect(coverOwner).approve(nonCoverOwner.address, 1);
-
-    await expect(
-      yieldTokenIncidents.connect(nonCoverOwner).redeemPayout(0, 1, 0, parseEther('100'), coverOwner.address, []),
+      yieldTokenIncidents.connect(coverOwner).redeemPayout(0, 1, 0, parseEther('100'), coverOwner.address, []),
     ).not.to.be.revertedWith('Only the cover owner or approved addresses can redeem');
 
     await expect(
       yieldTokenIncidents.connect(nonCoverOwner).redeemPayout(0, 2, 0, parseEther('100'), coverOwner.address, []),
+    ).to.be.revertedWith('Only the cover owner or approved addresses can redeem');
+
+    await coverNFT.connect(coverOwner).approve(nonCoverOwner.address, 2);
+
+    await expect(
+      yieldTokenIncidents.connect(nonCoverOwner).redeemPayout(0, 2, 0, parseEther('100'), coverOwner.address, []),
+    ).not.to.be.revertedWith('Only the cover owner or approved addresses can redeem');
+
+    await expect(
+      yieldTokenIncidents.connect(nonCoverOwner).redeemPayout(0, 3, 0, parseEther('100'), coverOwner.address, []),
     ).to.be.revertedWith('Only the cover owner or approved addresses can redeem');
 
     await coverNFT.connect(coverOwner).setApprovalForAll(nonCoverOwner.address, true);
 
     await expect(
-      yieldTokenIncidents.connect(nonCoverOwner).redeemPayout(0, 2, 0, parseEther('100'), coverOwner.address, []),
+      yieldTokenIncidents.connect(nonCoverOwner).redeemPayout(0, 4, 0, parseEther('100'), coverOwner.address, []),
     ).not.to.be.revertedWith('Only the cover owner or approved addresses can redeem');
   });
 
@@ -98,7 +98,7 @@ describe('redeemPayout', function () {
     }
 
     await expect(
-      yieldTokenIncidents.connect(member1).redeemPayout(0, 0, 0, parseEther('1'), member1.address, []),
+      yieldTokenIncidents.connect(member1).redeemPayout(0, 1, 0, parseEther('1'), member1.address, []),
     ).to.be.revertedWith('The incident needs to be accepted');
 
     await assessment.connect(member1).castVote(0, true, parseEther('100'));
@@ -110,7 +110,7 @@ describe('redeemPayout', function () {
     }
 
     await expect(
-      yieldTokenIncidents.connect(member1).redeemPayout(0, 0, 0, parseEther('1'), member1.address, []),
+      yieldTokenIncidents.connect(member1).redeemPayout(0, 1, 0, parseEther('1'), member1.address, []),
     ).to.be.revertedWith('The incident needs to be accepted');
 
     {
@@ -119,7 +119,7 @@ describe('redeemPayout', function () {
     }
 
     await expect(
-      yieldTokenIncidents.connect(member1).redeemPayout(0, 0, 0, parseEther('1'), member1.address, []),
+      yieldTokenIncidents.connect(member1).redeemPayout(0, 1, 0, parseEther('1'), member1.address, []),
     ).to.be.revertedWith('The incident needs to be accepted');
   });
 
@@ -147,14 +147,14 @@ describe('redeemPayout', function () {
     }
 
     await expect(
-      yieldTokenIncidents.connect(member1).redeemPayout(0, 0, 0, parseEther('1'), member1.address, []),
+      yieldTokenIncidents.connect(member1).redeemPayout(0, 1, 0, parseEther('1'), member1.address, []),
     ).to.be.revertedWith('The voting and cooldown periods must end');
 
     const { end } = await assessment.getPoll(0);
     await setTime(end);
 
     await expect(
-      yieldTokenIncidents.connect(member1).redeemPayout(0, 0, 0, parseEther('1'), member1.address, []),
+      yieldTokenIncidents.connect(member1).redeemPayout(0, 1, 0, parseEther('1'), member1.address, []),
     ).to.be.revertedWith('The voting and cooldown periods must end');
 
     {
@@ -190,7 +190,7 @@ describe('redeemPayout', function () {
     }
 
     await expect(
-      yieldTokenIncidents.connect(member1).redeemPayout(0, 0, 0, parseEther('1'), member1.address, []),
+      yieldTokenIncidents.connect(member1).redeemPayout(0, 1, 0, parseEther('1'), member1.address, []),
     ).to.be.revertedWith('The redemption period has expired');
   });
 
@@ -222,11 +222,11 @@ describe('redeemPayout', function () {
     }
 
     await expect(
-      yieldTokenIncidents.connect(member1).redeemPayout(0, 0, 0, parseEther('101.011'), member1.address, []),
+      yieldTokenIncidents.connect(member1).redeemPayout(0, 1, 0, parseEther('101.011'), member1.address, []),
     ).to.be.revertedWith('Payout exceeds covered amount');
 
     await expect(
-      yieldTokenIncidents.connect(member1).redeemPayout(0, 0, 0, parseEther('101.01'), member1.address, []),
+      yieldTokenIncidents.connect(member1).redeemPayout(0, 1, 0, parseEther('101.01'), member1.address, []),
     ).not.to.be.revertedWith('Payout exceeds covered amount');
   });
 
@@ -262,10 +262,10 @@ describe('redeemPayout', function () {
     }
 
     await expect(
-      yieldTokenIncidents.connect(member1).redeemPayout(0, 0, 0, parseEther('100'), member1.address, []),
+      yieldTokenIncidents.connect(member1).redeemPayout(0, 1, 0, parseEther('100'), member1.address, []),
     ).to.be.revertedWith('Cover ended before the incident');
     await expect(
-      yieldTokenIncidents.connect(member1).redeemPayout(0, 0, 1, parseEther('100'), member1.address, []),
+      yieldTokenIncidents.connect(member1).redeemPayout(0, 1, 1, parseEther('100'), member1.address, []),
     ).not.to.be.revertedWith('Cover ended before the incident');
   });
 
@@ -311,13 +311,13 @@ describe('redeemPayout', function () {
     }
 
     await expect(
-      yieldTokenIncidents.connect(member1).redeemPayout(0, 0, 1, parseEther('100'), member1.address, []),
+      yieldTokenIncidents.connect(member1).redeemPayout(0, 1, 1, parseEther('100'), member1.address, []),
+    ).to.be.revertedWith('Cover started after the incident');
+    await expect(
+      yieldTokenIncidents.connect(member1).redeemPayout(0, 2, 0, parseEther('100'), member1.address, []),
     ).to.be.revertedWith('Cover started after the incident');
     await expect(
       yieldTokenIncidents.connect(member1).redeemPayout(0, 1, 0, parseEther('100'), member1.address, []),
-    ).to.be.revertedWith('Cover started after the incident');
-    await expect(
-      yieldTokenIncidents.connect(member1).redeemPayout(0, 0, 0, parseEther('100'), member1.address, []),
     ).not.to.be.revertedWith('Cover started after the incident');
   });
 
@@ -348,10 +348,10 @@ describe('redeemPayout', function () {
     }
 
     await expect(
-      yieldTokenIncidents.connect(member1).redeemPayout(0, 0, 0, parseEther('100'), member1.address, []),
+      yieldTokenIncidents.connect(member1).redeemPayout(0, 1, 0, parseEther('100'), member1.address, []),
     ).to.be.revertedWith('Grace period has expired');
     await expect(
-      yieldTokenIncidents.connect(member1).redeemPayout(0, 1, 0, parseEther('100'), member1.address, []),
+      yieldTokenIncidents.connect(member1).redeemPayout(0, 2, 0, parseEther('100'), member1.address, []),
     ).not.to.be.revertedWith('Grace period has expired');
   });
 
@@ -387,10 +387,10 @@ describe('redeemPayout', function () {
     await setTime(end + daysToSeconds(payoutCooldownInDays));
 
     await expect(
-      yieldTokenIncidents.connect(member1).redeemPayout(0, 0, 0, parseEther('100'), member1.address, []),
+      yieldTokenIncidents.connect(member1).redeemPayout(0, 1, 0, parseEther('100'), member1.address, []),
     ).to.be.revertedWith('Grace period has expired');
     await expect(
-      yieldTokenIncidents.connect(member1).redeemPayout(0, 1, 0, parseEther('100'), member1.address, []),
+      yieldTokenIncidents.connect(member1).redeemPayout(0, 2, 0, parseEther('100'), member1.address, []),
     ).to.not.be.revertedWith('Grace period has expired');
   });
 
@@ -442,19 +442,19 @@ describe('redeemPayout', function () {
     }
 
     await expect(
-      yieldTokenIncidents.connect(member1).redeemPayout(0, 0, 0, parseEther('100'), member1.address, []),
-    ).to.be.revertedWith('Product id mismatch');
-
-    await expect(
       yieldTokenIncidents.connect(member1).redeemPayout(0, 1, 0, parseEther('100'), member1.address, []),
     ).to.be.revertedWith('Product id mismatch');
 
     await expect(
       yieldTokenIncidents.connect(member1).redeemPayout(0, 2, 0, parseEther('100'), member1.address, []),
-    ).not.to.be.revertedWith('Product id mismatch');
+    ).to.be.revertedWith('Product id mismatch');
 
     await expect(
       yieldTokenIncidents.connect(member1).redeemPayout(0, 3, 0, parseEther('100'), member1.address, []),
+    ).not.to.be.revertedWith('Product id mismatch');
+
+    await expect(
+      yieldTokenIncidents.connect(member1).redeemPayout(0, 4, 0, parseEther('100'), member1.address, []),
     ).to.be.revertedWith('Product id mismatch');
   });
 
@@ -497,7 +497,7 @@ describe('redeemPayout', function () {
       await setNextBlockBaseFee('0');
       await yieldTokenIncidents
         .connect(member1)
-        .redeemPayout(0, 0, 0, claimedAmount, member1.address, [], { gasPrice: 0 });
+        .redeemPayout(0, 1, 0, claimedAmount, member1.address, [], { gasPrice: 0 });
       const ethBalanceAfter = await ethers.provider.getBalance(member1.address);
       expect(ethBalanceAfter).to.be.equal(
         ethBalanceBefore.add(
@@ -512,7 +512,7 @@ describe('redeemPayout', function () {
       await setNextBlockBaseFee('0');
       await yieldTokenIncidents
         .connect(member1)
-        .redeemPayout(0, 0, 0, claimedAmount, nonMember1.address, [], { gasPrice: 0 });
+        .redeemPayout(0, 1, 0, claimedAmount, nonMember1.address, [], { gasPrice: 0 });
       const ethBalanceAfter = await ethers.provider.getBalance(nonMember1.address);
       expect(ethBalanceAfter).to.be.equal(
         ethBalanceBefore.add(
@@ -527,7 +527,7 @@ describe('redeemPayout', function () {
       await setNextBlockBaseFee('0');
       await yieldTokenIncidents
         .connect(member1)
-        .redeemPayout(0, 0, 0, claimedAmount, nonMember2.address, [], { gasPrice: 0 });
+        .redeemPayout(0, 1, 0, claimedAmount, nonMember2.address, [], { gasPrice: 0 });
       const ethBalanceAfter = await ethers.provider.getBalance(nonMember2.address);
       expect(ethBalanceAfter).to.be.equal(
         ethBalanceBefore.add(
@@ -576,7 +576,7 @@ describe('redeemPayout', function () {
       await setNextBlockBaseFee('0');
       await yieldTokenIncidents
         .connect(member1)
-        .redeemPayout(0, 0, 0, claimedAmount, nonMember1.address, [], { gasPrice: 0 });
+        .redeemPayout(0, 1, 0, claimedAmount, nonMember1.address, [], { gasPrice: 0 });
       const daiBalanceAfter = await dai.balanceOf(nonMember1.address);
       expect(daiBalanceAfter).to.be.equal(
         daiBalanceBefore.add(
@@ -591,7 +591,7 @@ describe('redeemPayout', function () {
       await setNextBlockBaseFee('0');
       await yieldTokenIncidents
         .connect(member1)
-        .redeemPayout(0, 0, 0, claimedAmount, nonMember1.address, [], { gasPrice: 0 });
+        .redeemPayout(0, 1, 0, claimedAmount, nonMember1.address, [], { gasPrice: 0 });
       const daiBalanceAfter = await dai.balanceOf(nonMember1.address);
       expect(daiBalanceAfter).to.be.equal(
         daiBalanceBefore.add(
@@ -606,7 +606,7 @@ describe('redeemPayout', function () {
       await setNextBlockBaseFee('0');
       await yieldTokenIncidents
         .connect(member1)
-        .redeemPayout(0, 0, 0, claimedAmount, nonMember2.address, [], { gasPrice: 0 });
+        .redeemPayout(0, 1, 0, claimedAmount, nonMember2.address, [], { gasPrice: 0 });
       const daiBalanceAfter = await dai.balanceOf(nonMember2.address);
       expect(daiBalanceAfter).to.be.equal(
         daiBalanceBefore.add(
@@ -672,7 +672,7 @@ describe('redeemPayout', function () {
     await setNextBlockBaseFee('0');
     await yieldTokenIncidents.connect(member1).redeemPayout(
       0,
-      0,
+      1,
       0,
       parseEther('3000'),
       nonMember.address,
@@ -721,17 +721,17 @@ describe('redeemPayout', function () {
 
     await ybEth.connect(coverOwner1).approve(yieldTokenIncidents.address, parseEther('10000'));
     await expect(
-      yieldTokenIncidents.connect(coverOwner1).redeemPayout(0, 0, 0, parseEther('100'), coverOwner1.address, []),
+      yieldTokenIncidents.connect(coverOwner1).redeemPayout(0, 1, 0, parseEther('100'), coverOwner1.address, []),
     )
       .to.emit(yieldTokenIncidents, 'IncidentPayoutRedeemed')
-      .withArgs(coverOwner1.address, parseEther('90'), 0, 0);
+      .withArgs(coverOwner1.address, parseEther('90'), 0, 1);
 
     await ybDai.connect(coverOwner2).approve(yieldTokenIncidents.address, parseEther('10000'));
     await expect(
-      yieldTokenIncidents.connect(coverOwner2).redeemPayout(1, 2, 0, parseEther('100'), coverOwner2.address, []),
+      yieldTokenIncidents.connect(coverOwner2).redeemPayout(1, 3, 0, parseEther('100'), coverOwner2.address, []),
     )
       .to.emit(yieldTokenIncidents, 'IncidentPayoutRedeemed')
-      .withArgs(coverOwner2.address, parseEther('90'), 1, 2);
+      .withArgs(coverOwner2.address, parseEther('90'), 1, 3);
   });
 
   it('reverts if system is paused', async function () {
@@ -758,7 +758,7 @@ describe('redeemPayout', function () {
 
     await ybEth.connect(coverOwner1).approve(yieldTokenIncidents.address, parseEther('10000'));
     await expect(
-      yieldTokenIncidents.connect(coverOwner1).redeemPayout(0, 0, 0, parseEther('100'), coverOwner1.address, []),
+      yieldTokenIncidents.connect(coverOwner1).redeemPayout(0, 1, 0, parseEther('100'), coverOwner1.address, []),
     ).to.be.revertedWith('System is paused');
   });
 
@@ -786,7 +786,7 @@ describe('redeemPayout', function () {
 
     await ybEth.connect(coverOwner1).approve(yieldTokenIncidents.address, parseEther('10000'));
     await expect(
-      yieldTokenIncidents.connect(nonMember).redeemPayout(0, 0, 0, parseEther('100'), coverOwner1.address, []),
+      yieldTokenIncidents.connect(nonMember).redeemPayout(0, 1, 0, parseEther('100'), coverOwner1.address, []),
     ).to.be.revertedWith('Caller is not a member');
   });
 
@@ -819,7 +819,7 @@ describe('redeemPayout', function () {
     await setNextBlockBaseFee('0');
     await yieldTokenIncidents
       .connect(member1)
-      .redeemPayout(0, 0, 0, depeggedTokensAmount, member1.address, [], { gasPrice: 0 });
+      .redeemPayout(0, 1, 0, depeggedTokensAmount, member1.address, [], { gasPrice: 0 });
     const ybEthContractBalanceAfter = await ybEth.balanceOf(yieldTokenIncidents.address);
     const ybEthMemberBalanceAfter = await ybEth.balanceOf(member1.address);
 
@@ -858,7 +858,7 @@ describe('redeemPayout', function () {
     await setNextBlockBaseFee('0');
     await yieldTokenIncidents
       .connect(member1)
-      .redeemPayout(0, 0, 0, depeggedTokensAmount, member1.address, [], { gasPrice: 0 });
+      .redeemPayout(0, 1, 0, depeggedTokensAmount, member1.address, [], { gasPrice: 0 });
 
     const { amount } = await cover.burnStakeCalledWith();
 


### PR DESCRIPTION
## Context
Closes #619 


## Changes proposed in this pull request

This PR replaces the flag to mint a new NFT from uint256.max to 0 for CoverNFT and StakingNFT contracts.
TokenId 0 no longer exists, except as a reference for the staking pool manager
Added totalSupply( ) to CoverNFT
Also allocationID now also uses 0 to signal a new ID


## Test plan



## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [x] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
