### PR TITLE
Feat/start staking pools at one

### DIFF
--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -602,7 +602,8 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
         payoutAmountInNXM
       );
 
-      stakingPool(i).burnStake(burnAmountInNxm, params);
+      uint poolId = allocations[i].poolId;
+      stakingPool(poolId).burnStake(burnAmountInNxm, params);
     }
 
     return coverNFT.ownerOf(coverId);

--- a/contracts/modules/staking/StakingPoolFactory.sol
+++ b/contracts/modules/staking/StakingPoolFactory.sol
@@ -32,7 +32,7 @@ contract StakingPoolFactory is IStakingPoolFactory {
     require(msg.sender == operator, "StakingPoolFactory: Not operator");
 
     beacon = _beacon;
-    poolId = _stakingPoolCount++;
+    poolId = ++_stakingPoolCount;
 
     stakingPoolAddress = address(
       new MinimalBeaconProxy{salt : bytes32(poolId)}()

--- a/test/integration/Cover/createStakingPool.js
+++ b/test/integration/Cover/createStakingPool.js
@@ -44,7 +44,7 @@ describe('createStakingPool', function () {
     const stakingPoolCountAfter = await spf.stakingPoolCount();
     expect(stakingPoolCountAfter).to.be.equal(stakingPoolCountBefore.add(1));
 
-    const stakingPoolAddress = await cover.stakingPool(stakingPoolCountAfter.sub(1));
+    const stakingPoolAddress = await cover.stakingPool(stakingPoolCountAfter);
     const stakingPool = await ethers.getContractAt('StakingPool', stakingPoolAddress);
 
     const managerStakingPoolNFTBalanceBefore = await stakingNFT.balanceOf(manager.address);
@@ -82,7 +82,7 @@ describe('createStakingPool', function () {
     const stakingPoolCountAfter = await spf.stakingPoolCount();
     expect(stakingPoolCountAfter).to.be.equal(stakingPoolCountBefore.add(1));
 
-    const stakingPoolAddress = await cover.stakingPool(stakingPoolCountAfter.sub(1));
+    const stakingPoolAddress = await cover.stakingPool(stakingPoolCountAfter);
     const stakingPool = await ethers.getContractAt('StakingPool', stakingPoolAddress);
 
     const managerStakingPoolNFTBalanceBefore = await stakingNFT.balanceOf(manager.address);

--- a/test/integration/Cover/totalActiveCover.js
+++ b/test/integration/Cover/totalActiveCover.js
@@ -35,7 +35,7 @@ const buyCoverFixture = {
 
 describe('totalActiveCover', function () {
   beforeEach(async function () {
-    const { tk, stakingProducts, stakingPool0 } = this.contracts;
+    const { tk, stakingProducts, stakingPool1 } = this.contracts;
     const { stakingPoolManagers } = this.accounts;
 
     const members = this.accounts.members.slice(0, 5);
@@ -46,7 +46,7 @@ describe('totalActiveCover', function () {
 
     await stakingProducts
       .connect(stakingPoolManagers[0])
-      .setProducts(await stakingPool0.getPoolId(), [stakedProductParamTemplate]);
+      .setProducts(await stakingPool1.getPoolId(), [stakedProductParamTemplate]);
   });
 
   function calculateFirstTrancheId(lastBlock, period, gracePeriod) {
@@ -96,7 +96,7 @@ describe('totalActiveCover', function () {
         commissionDestination: AddressZero,
         ipfsData: '',
       },
-      [{ poolId: 0, coverAmountInAsset: amount.toString() }],
+      [{ poolId: 1, coverAmountInAsset: amount.toString() }],
       {
         value: expectedPremium,
       },
@@ -116,7 +116,7 @@ describe('totalActiveCover', function () {
 
   it('expire a cover that had a claim paid out fully', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { cover, stakingPool0, as, yc, gv, ybETH } = this.contracts;
+    const { cover, stakingPool1, as, yc, gv, ybETH } = this.contracts;
     const [coverBuyer1, staker1] = this.accounts.members;
     const [nonMember1] = this.accounts.nonMembers;
     const { BUCKET_SIZE } = this.config;
@@ -124,10 +124,10 @@ describe('totalActiveCover', function () {
     const { productId, coverAsset, period, gracePeriod, amount, coverId, segmentId, incidentId, assessmentId } =
       buyCoverFixture;
 
-    expect(await cover.stakingPool(0)).to.be.equal(stakingPool0.address);
+    expect(await cover.stakingPool(1)).to.be.equal(stakingPool1.address);
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, period, gracePeriod });
+    await stake({ stakingPool: stakingPool1, staker: staker1, period, gracePeriod });
 
     // cover buyer gets yield token
     await transferYieldToken({ tokenOwner: this.accounts.defaultSender, coverBuyer1, yc, ybETH });
@@ -188,7 +188,7 @@ describe('totalActiveCover', function () {
   it('expire a cover that had a partial claim paid out', async function () {
     const { DEFAULT_PRODUCTS } = this;
     const { BUCKET_SIZE } = this.config;
-    const { cover, stakingPool0, as, yc, gv, ybETH } = this.contracts;
+    const { cover, stakingPool1, as, yc, gv, ybETH } = this.contracts;
     const [coverBuyer1, staker1] = this.accounts.members;
     const [nonMember1] = this.accounts.nonMembers;
 
@@ -196,7 +196,7 @@ describe('totalActiveCover', function () {
       buyCoverFixture;
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, period, gracePeriod });
+    await stake({ stakingPool: stakingPool1, staker: staker1, period, gracePeriod });
 
     // cover buyer gets yield token
     await transferYieldToken({ tokenOwner: this.accounts.defaultSender, coverBuyer1, yc, ybETH });
@@ -264,7 +264,7 @@ describe('totalActiveCover', function () {
   it('expire a cover that had rejected claim', async function () {
     const { DEFAULT_PRODUCTS } = this;
     const { BUCKET_SIZE } = this.config;
-    const { cover, stakingPool0, as, yc, gv, ybETH } = this.contracts;
+    const { cover, stakingPool1, as, yc, gv, ybETH } = this.contracts;
     const [coverBuyer1, staker1, staker2] = this.accounts.members;
     const [nonMember1] = this.accounts.nonMembers;
 
@@ -272,7 +272,7 @@ describe('totalActiveCover', function () {
       buyCoverFixture;
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, period, gracePeriod });
+    await stake({ stakingPool: stakingPool1, staker: staker1, period, gracePeriod });
 
     // cover buyer gets yield token
     await transferYieldToken({ tokenOwner: this.accounts.defaultSender, coverBuyer1, yc, ybETH });

--- a/test/integration/IndividualClaims/submitClaim.js
+++ b/test/integration/IndividualClaims/submitClaim.js
@@ -38,7 +38,7 @@ describe('submitClaim', function () {
 
   it('submits ETH claim and approves claim', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { ic, cover, stakingPool0, as } = this.contracts;
+    const { ic, cover, stakingPool1, as } = this.contracts;
     const [coverBuyer1, staker1, staker2] = this.accounts.members;
 
     // Cover inputs
@@ -49,7 +49,7 @@ describe('submitClaim', function () {
     const amount = parseEther('1');
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, gracePeriod, period, productId });
+    await stake({ stakingPool: stakingPool1, staker: staker1, gracePeriod, period, productId });
 
     // Buy Cover
     await buyCover({
@@ -89,7 +89,7 @@ describe('submitClaim', function () {
 
   it('submits partial ETH claim and approves claim', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { ic, cover, stakingPool0, as } = this.contracts;
+    const { ic, cover, stakingPool1, as } = this.contracts;
     const [coverBuyer1, staker1, staker2] = this.accounts.members;
 
     // Cover inputs
@@ -100,7 +100,7 @@ describe('submitClaim', function () {
     const amount = parseEther('1');
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, gracePeriod, period, productId });
+    await stake({ stakingPool: stakingPool1, staker: staker1, gracePeriod, period, productId });
 
     // Buy Cover
     await buyCover({
@@ -141,7 +141,7 @@ describe('submitClaim', function () {
 
   it('submits ETH claim and rejects claim', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { ic, cover, stakingPool0, as } = this.contracts;
+    const { ic, cover, stakingPool1, as } = this.contracts;
     const [coverBuyer1, staker1, staker2, staker3] = this.accounts.members;
 
     // Cover inputs
@@ -152,7 +152,7 @@ describe('submitClaim', function () {
     const amount = parseEther('1');
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, gracePeriod, period, productId });
+    await stake({ stakingPool: stakingPool1, staker: staker1, gracePeriod, period, productId });
 
     // Buy Cover
     await buyCover({
@@ -190,7 +190,7 @@ describe('submitClaim', function () {
 
   it('submits partial ETH claim and rejects claim', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { ic, cover, stakingPool0, as } = this.contracts;
+    const { ic, cover, stakingPool1, as } = this.contracts;
     const [coverBuyer1, staker1, staker2, staker3] = this.accounts.members;
 
     // Cover inputs
@@ -201,7 +201,7 @@ describe('submitClaim', function () {
     const amount = parseEther('1');
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, gracePeriod, period, productId });
+    await stake({ stakingPool: stakingPool1, staker: staker1, gracePeriod, period, productId });
 
     // Buy Cover
     await buyCover({
@@ -239,7 +239,7 @@ describe('submitClaim', function () {
 
   it('submits DAI claim and approves claim', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { ic, cover, stakingPool0, as, dai } = this.contracts;
+    const { ic, cover, stakingPool1, as, dai } = this.contracts;
     const [coverBuyer1, staker1, staker2] = this.accounts.members;
 
     // Cover inputs
@@ -250,7 +250,7 @@ describe('submitClaim', function () {
     const amount = parseEther('1');
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, gracePeriod, period, productId });
+    await stake({ stakingPool: stakingPool1, staker: staker1, gracePeriod, period, productId });
 
     // cover buyer gets cover asset
     await transferCoverAsset({ tokenOwner: this.accounts.defaultSender, coverBuyer: coverBuyer1, asset: dai, cover });
@@ -292,7 +292,7 @@ describe('submitClaim', function () {
 
   it('submits partial DAI claim and approves claim', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { ic, cover, stakingPool0, as, dai } = this.contracts;
+    const { ic, cover, stakingPool1, as, dai } = this.contracts;
     const [coverBuyer1, staker1, staker2] = this.accounts.members;
 
     // Cover inputs
@@ -303,7 +303,7 @@ describe('submitClaim', function () {
     const amount = parseEther('1');
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, gracePeriod, period, productId });
+    await stake({ stakingPool: stakingPool1, staker: staker1, gracePeriod, period, productId });
 
     // cover buyer gets cover asset
     await transferCoverAsset({ tokenOwner: this.accounts.defaultSender, coverBuyer: coverBuyer1, asset: dai, cover });
@@ -345,7 +345,7 @@ describe('submitClaim', function () {
 
   it('submits DAI claim and rejects claim', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { ic, cover, stakingPool0, as, dai } = this.contracts;
+    const { ic, cover, stakingPool1, as, dai } = this.contracts;
     const [coverBuyer1, staker1, staker2, staker3] = this.accounts.members;
 
     // Cover inputs
@@ -356,7 +356,7 @@ describe('submitClaim', function () {
     const amount = parseEther('1');
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, gracePeriod, period, productId });
+    await stake({ stakingPool: stakingPool1, staker: staker1, gracePeriod, period, productId });
 
     // cover buyer gets cover asset
     await transferCoverAsset({ tokenOwner: this.accounts.defaultSender, coverBuyer: coverBuyer1, asset: dai, cover });
@@ -397,7 +397,7 @@ describe('submitClaim', function () {
 
   it('submits partial DAI claim and rejects claim', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { ic, cover, stakingPool0, as, dai } = this.contracts;
+    const { ic, cover, stakingPool1, as, dai } = this.contracts;
     const [coverBuyer1, staker1, staker2, staker3] = this.accounts.members;
 
     // Cover inputs
@@ -408,7 +408,7 @@ describe('submitClaim', function () {
     const amount = parseEther('1');
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, gracePeriod, period, productId });
+    await stake({ stakingPool: stakingPool1, staker: staker1, gracePeriod, period, productId });
 
     // cover buyer gets cover asset
     await transferCoverAsset({ tokenOwner: this.accounts.defaultSender, coverBuyer: coverBuyer1, asset: dai, cover });
@@ -449,7 +449,7 @@ describe('submitClaim', function () {
 
   it('submits USDC claim and approves claim (token with 6 decimals)', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { ic, cover, stakingPool0, as, usdc } = this.contracts;
+    const { ic, cover, stakingPool1, as, usdc } = this.contracts;
     const [coverBuyer1, staker1, staker2] = this.accounts.members;
 
     const usdcDecimals = 6;
@@ -462,7 +462,7 @@ describe('submitClaim', function () {
     const amount = parseUnits('10', usdcDecimals);
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, gracePeriod, period, productId });
+    await stake({ stakingPool: stakingPool1, staker: staker1, gracePeriod, period, productId });
 
     // cover buyer gets cover asset
     await transferCoverAsset({ tokenOwner: this.accounts.defaultSender, coverBuyer: coverBuyer1, asset: usdc, cover });
@@ -504,7 +504,7 @@ describe('submitClaim', function () {
 
   it('submits partial USDC claim and approves claim', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { ic, cover, stakingPool0, as, usdc } = this.contracts;
+    const { ic, cover, stakingPool1, as, usdc } = this.contracts;
     const [coverBuyer1, staker1, staker2] = this.accounts.members;
 
     const usdcDecimals = 6;
@@ -517,7 +517,7 @@ describe('submitClaim', function () {
     const amount = parseUnits('10', usdcDecimals);
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, gracePeriod, period, productId });
+    await stake({ stakingPool: stakingPool1, staker: staker1, gracePeriod, period, productId });
 
     // cover buyer gets cover asset
     await transferCoverAsset({ tokenOwner: this.accounts.defaultSender, coverBuyer: coverBuyer1, asset: usdc, cover });
@@ -559,7 +559,7 @@ describe('submitClaim', function () {
 
   it('submits partial USDC claim and rejects claim', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { ic, cover, stakingPool0, as, usdc } = this.contracts;
+    const { ic, cover, stakingPool1, as, usdc } = this.contracts;
     const [coverBuyer1, staker1, staker2, staker3] = this.accounts.members;
 
     const usdcDecimals = 6;
@@ -572,7 +572,7 @@ describe('submitClaim', function () {
     const amount = parseUnits('10', usdcDecimals);
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, gracePeriod, period, productId });
+    await stake({ stakingPool: stakingPool1, staker: staker1, gracePeriod, period, productId });
 
     // cover buyer gets cover asset
     await transferCoverAsset({ tokenOwner: this.accounts.defaultSender, coverBuyer: coverBuyer1, asset: usdc, cover });
@@ -613,7 +613,7 @@ describe('submitClaim', function () {
 
   it('multiple partial ETH claims approved on the same cover', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { ic, cover, stakingPool0, as } = this.contracts;
+    const { ic, cover, stakingPool1, as } = this.contracts;
     const [coverBuyer1, staker1, staker2] = this.accounts.members;
 
     // Cover inputs
@@ -624,7 +624,7 @@ describe('submitClaim', function () {
     const amount = parseEther('1');
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, gracePeriod, period, productId });
+    await stake({ stakingPool: stakingPool1, staker: staker1, gracePeriod, period, productId });
 
     // Buy Cover
     await buyCover({
@@ -733,7 +733,7 @@ describe('submitClaim', function () {
 
   it('multiple partial DAI claims approved on the same cover', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { ic, cover, stakingPool0, as, dai } = this.contracts;
+    const { ic, cover, stakingPool1, as, dai } = this.contracts;
     const [coverBuyer1, staker1, staker2] = this.accounts.members;
 
     // Cover inputs
@@ -744,7 +744,7 @@ describe('submitClaim', function () {
     const amount = parseEther('1');
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, gracePeriod, period, productId });
+    await stake({ stakingPool: stakingPool1, staker: staker1, gracePeriod, period, productId });
 
     // cover buyer gets cover asset
     await transferCoverAsset({ tokenOwner: this.accounts.defaultSender, coverBuyer: coverBuyer1, asset: dai, cover });
@@ -852,7 +852,7 @@ describe('submitClaim', function () {
 
   it('multiple partial USDC claims approved on the same cover', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { ic, cover, stakingPool0, as, usdc } = this.contracts;
+    const { ic, cover, stakingPool1, as, usdc } = this.contracts;
     const [coverBuyer1, staker1, staker2] = this.accounts.members;
 
     const usdcDecimals = 6;
@@ -865,7 +865,7 @@ describe('submitClaim', function () {
     const amount = parseUnits('10', usdcDecimals);
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, gracePeriod, period, productId });
+    await stake({ stakingPool: stakingPool1, staker: staker1, gracePeriod, period, productId });
 
     // cover buyer gets cover asset
     await transferCoverAsset({ tokenOwner: this.accounts.defaultSender, coverBuyer: coverBuyer1, asset: usdc, cover });
@@ -973,7 +973,7 @@ describe('submitClaim', function () {
 
   it('multiple partial claims on the same cover with combinations of approved / denied', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { ic, cover, stakingPool0, as } = this.contracts;
+    const { ic, cover, stakingPool1, as } = this.contracts;
     const [coverBuyer1, staker1, staker2, staker3] = this.accounts.members;
 
     // Cover inputs
@@ -984,7 +984,7 @@ describe('submitClaim', function () {
     const amount = parseEther('1');
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, gracePeriod, period, productId });
+    await stake({ stakingPool: stakingPool1, staker: staker1, gracePeriod, period, productId });
 
     // Buy Cover
     await buyCover({
@@ -1092,7 +1092,7 @@ describe('submitClaim', function () {
 
   it('correctly calculates premium in cover edit after a claim', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { p1, ic, cover, stakingPool0, as } = this.contracts;
+    const { p1, ic, cover, stakingPool1, as } = this.contracts;
     const [coverBuyer1, staker1, staker2] = this.accounts.members;
 
     // Cover inputs
@@ -1103,8 +1103,8 @@ describe('submitClaim', function () {
     const amount = parseEther('1');
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, gracePeriod, period, productId });
-    await stakeOnly({ stakingPool: stakingPool0, staker: staker1, gracePeriod, period, trancheIdOffset: 1 });
+    await stake({ stakingPool: stakingPool1, staker: staker1, gracePeriod, period, productId });
+    await stakeOnly({ stakingPool: stakingPool1, staker: staker1, gracePeriod, period, trancheIdOffset: 1 });
 
     // Buy Cover
     await buyCover({
@@ -1191,7 +1191,7 @@ describe('submitClaim', function () {
         commissionDestination: AddressZero,
         ipfsData: '',
       },
-      [{ poolId: '0', coverAmountInAsset: amount.toString() }],
+      [{ poolId: 1, coverAmountInAsset: amount }],
       { value: totalEditPremium, gasPrice: 0 },
     );
 
@@ -1204,10 +1204,10 @@ describe('submitClaim', function () {
 
   it('correctly updates pool allocation after claim and cover edit', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { ic, cover, stakingPool0, as } = this.contracts;
+    const { ic, cover, stakingPool1, as } = this.contracts;
     const [coverBuyer1, staker1, staker2] = this.accounts.members;
 
-    const NXM_PER_ALLOCATION_UNIT = await stakingPool0.NXM_PER_ALLOCATION_UNIT();
+    const NXM_PER_ALLOCATION_UNIT = await stakingPool1.NXM_PER_ALLOCATION_UNIT();
 
     // Move to the beginning of the next tranche
     const currentTrancheId = await moveTimeToNextTranche(1);
@@ -1220,23 +1220,23 @@ describe('submitClaim', function () {
     const amount = parseEther('1');
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, gracePeriod, period, productId });
-    await stakeOnly({ stakingPool: stakingPool0, staker: staker1, gracePeriod, period, trancheIdOffset: 1 });
+    await stake({ stakingPool: stakingPool1, staker: staker1, gracePeriod, period, productId });
+    await stakeOnly({ stakingPool: stakingPool1, staker: staker1, gracePeriod, period, trancheIdOffset: 1 });
 
-    const allocationId = await stakingPool0.getNextAllocationId();
+    const allocationId = await stakingPool1.getNextAllocationId();
     const lastBlock = await ethers.provider.getBlock('latest');
     const targetBucketId = Math.ceil((lastBlock.timestamp + period) / BUCKET_DURATION);
     const groupId = Math.floor(currentTrancheId / BUCKET_TRANCHE_GROUP_SIZE);
     const currentTrancheIndexInGroup = currentTrancheId % BUCKET_TRANCHE_GROUP_SIZE;
 
     {
-      const activeAllocations = await stakingPool0.getActiveAllocations(productId);
+      const activeAllocations = await stakingPool1.getActiveAllocations(productId);
       expect(activeAllocations[0]).to.equal(0);
 
-      const coverTrancheAllocations = await stakingPool0.coverTrancheAllocations(allocationId);
+      const coverTrancheAllocations = await stakingPool1.coverTrancheAllocations(allocationId);
       expect(coverTrancheAllocations).to.equal(0);
 
-      const expiringCoverBuckets = await stakingPool0.expiringCoverBuckets(productId, targetBucketId, groupId);
+      const expiringCoverBuckets = await stakingPool1.expiringCoverBuckets(productId, targetBucketId, groupId);
       expect(expiringCoverBuckets).to.equal(0);
     }
 
@@ -1257,15 +1257,15 @@ describe('submitClaim', function () {
     const preBurnCoverAllocation = await cover.coverSegmentAllocations(coverId, firstSegment, 0);
 
     {
-      const activeAllocations = await stakingPool0.getActiveAllocations(productId);
+      const activeAllocations = await stakingPool1.getActiveAllocations(productId);
       expect(activeAllocations[0]).to.equal(preBurnCoverAllocation.coverAmountInNXM.div(NXM_PER_ALLOCATION_UNIT));
 
-      const coverTrancheAllocations = await stakingPool0.coverTrancheAllocations(allocationId);
+      const coverTrancheAllocations = await stakingPool1.coverTrancheAllocations(allocationId);
       expect(coverTrancheAllocations.and(MaxUint32)).to.equal(
         preBurnCoverAllocation.coverAmountInNXM.div(NXM_PER_ALLOCATION_UNIT),
       );
 
-      const expiringCoverBuckets = await stakingPool0.expiringCoverBuckets(productId, targetBucketId, groupId);
+      const expiringCoverBuckets = await stakingPool1.expiringCoverBuckets(productId, targetBucketId, groupId);
       expect(expiringCoverBuckets.shr(currentTrancheIndexInGroup * EXPIRING_ALLOCATION_DATA_GROUP_SIZE)).to.equal(
         preBurnCoverAllocation.coverAmountInNXM.div(NXM_PER_ALLOCATION_UNIT),
       );
@@ -1296,18 +1296,18 @@ describe('submitClaim', function () {
       expect(payoutRedeemed).to.be.equal(true);
 
       const coverAllocation = await cover.coverSegmentAllocations(coverId, firstSegment, 0);
-      const activeAllocations = await stakingPool0.getActiveAllocations(productId);
+      const activeAllocations = await stakingPool1.getActiveAllocations(productId);
       expect(activeAllocations[0]).to.equal(
         preBurnCoverAllocation.coverAmountInNXM.div(2).div(NXM_PER_ALLOCATION_UNIT).add(1),
       );
       expect(activeAllocations[0]).to.equal(coverAllocation.coverAmountInNXM.div(NXM_PER_ALLOCATION_UNIT).add(1));
 
-      const coverTrancheAllocations = await stakingPool0.coverTrancheAllocations(allocationId);
+      const coverTrancheAllocations = await stakingPool1.coverTrancheAllocations(allocationId);
       expect(coverTrancheAllocations.and(MaxUint32)).to.equal(
         coverAllocation.coverAmountInNXM.div(NXM_PER_ALLOCATION_UNIT).add(1),
       );
 
-      const expiringCoverBuckets = await stakingPool0.expiringCoverBuckets(productId, targetBucketId, groupId);
+      const expiringCoverBuckets = await stakingPool1.expiringCoverBuckets(productId, targetBucketId, groupId);
       expect(expiringCoverBuckets.shr(currentTrancheIndexInGroup * EXPIRING_ALLOCATION_DATA_GROUP_SIZE)).to.equal(
         coverAllocation.coverAmountInNXM.div(NXM_PER_ALLOCATION_UNIT).add(1),
       );
@@ -1349,7 +1349,7 @@ describe('submitClaim', function () {
         commissionDestination: AddressZero,
         ipfsData: '',
       },
-      [{ poolId: '0', coverAmountInAsset: amount.toString() }],
+      [{ poolId: 1, coverAmountInAsset: amount }],
       { value: totalEditPremium },
     );
 
@@ -1358,15 +1358,15 @@ describe('submitClaim', function () {
       const coverAllocation = await cover.coverSegmentAllocations(coverId, secondSegment, 0);
       expect(coverAllocation.coverAmountInNXM).to.equal(preBurnCoverAllocation.coverAmountInNXM);
 
-      const activeAllocations = await stakingPool0.getActiveAllocations(productId);
+      const activeAllocations = await stakingPool1.getActiveAllocations(productId);
       expect(activeAllocations[0]).to.equal(coverAllocation.coverAmountInNXM.div(NXM_PER_ALLOCATION_UNIT));
 
-      const coverTrancheAllocations = await stakingPool0.coverTrancheAllocations(allocationId);
+      const coverTrancheAllocations = await stakingPool1.coverTrancheAllocations(allocationId);
       expect(coverTrancheAllocations.and(MaxUint32)).to.equal(
         coverAllocation.coverAmountInNXM.div(NXM_PER_ALLOCATION_UNIT),
       );
 
-      const expiringCoverBuckets = await stakingPool0.expiringCoverBuckets(productId, targetBucketId, groupId);
+      const expiringCoverBuckets = await stakingPool1.expiringCoverBuckets(productId, targetBucketId, groupId);
       expect(expiringCoverBuckets.shr(currentTrancheIndexInGroup * EXPIRING_ALLOCATION_DATA_GROUP_SIZE)).to.equal(
         coverAllocation.coverAmountInNXM.div(NXM_PER_ALLOCATION_UNIT),
       );

--- a/test/integration/MCR/updateMCR.js
+++ b/test/integration/MCR/updateMCR.js
@@ -162,7 +162,7 @@ describe('updateMCR', function () {
 
   // [todo] deal with test once active cover amount measurement is settled
   it.skip('increases desiredMCR if totalSumAssured is high enough', async function () {
-    const { mcr, stakingPool0, cover } = this.contracts;
+    const { mcr, stakingPool1, cover } = this.contracts;
 
     const [coverHolder, staker1] = this.accounts.members;
 
@@ -181,7 +181,7 @@ describe('updateMCR', function () {
     const amount = coverAmount;
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, gracePeriod, period, productId });
+    await stake({ stakingPool: stakingPool1, staker: staker1, gracePeriod, period, productId });
 
     const expectedPremium = parseEther('1');
     await cover.connect(coverHolder).buyCover(
@@ -198,7 +198,7 @@ describe('updateMCR', function () {
         commissionDestination: ethers.constants.AddressZero,
         ipfsData: '',
       },
-      [{ poolId: '0', coverAmountInAsset: amount }],
+      [{ poolId: 1, coverAmountInAsset: amount }],
       { value: expectedPremium },
     );
 

--- a/test/integration/Master/emergency-pause.js
+++ b/test/integration/Master/emergency-pause.js
@@ -140,7 +140,7 @@ describe('emergency pause', function () {
           commissionDestination: AddressZero,
           ipfsData: '',
         },
-        [{ poolId: '0', coverAmountInAsset: amount.toString() }],
+        [{ poolId: 1, coverAmountInAsset: amount.toString() }],
         {
           value: expectedPremium,
         },
@@ -150,7 +150,7 @@ describe('emergency pause', function () {
 
   it('stops claim payouts on redeemPayout', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { ic, cover, stakingPool0, as, master } = this.contracts;
+    const { ic, cover, stakingPool1, as, master } = this.contracts;
     const [coverBuyer1, staker1, staker2] = this.accounts.members;
     const emergencyAdmin = this.accounts.emergencyAdmin;
 
@@ -162,7 +162,7 @@ describe('emergency pause', function () {
     const amount = parseEther('1');
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, gracePeriod, period, productId });
+    await stake({ stakingPool: stakingPool1, staker: staker1, gracePeriod, period, productId });
 
     // Buy Cover
     const expectedPremium = amount
@@ -183,7 +183,7 @@ describe('emergency pause', function () {
         commissionDestination: AddressZero,
         ipfsData: '',
       },
-      [{ poolId: '0', coverAmountInAsset: amount.toString() }],
+      [{ poolId: 1, coverAmountInAsset: amount.toString() }],
       {
         value: expectedPremium,
       },
@@ -209,7 +209,7 @@ describe('emergency pause', function () {
 
   it('stops claim voting', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { ic, cover, stakingPool0, as, master } = this.contracts;
+    const { ic, cover, stakingPool1, as, master } = this.contracts;
     const [coverBuyer1, staker1] = this.accounts.members;
     const emergencyAdmin = this.accounts.emergencyAdmin;
 
@@ -221,7 +221,7 @@ describe('emergency pause', function () {
     const amount = parseEther('1');
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, gracePeriod, period, productId });
+    await stake({ stakingPool: stakingPool1, staker: staker1, gracePeriod, period, productId });
 
     // Buy Cover
     const expectedPremium = amount
@@ -242,7 +242,7 @@ describe('emergency pause', function () {
         commissionDestination: AddressZero,
         ipfsData: '',
       },
-      [{ poolId: '0', coverAmountInAsset: amount.toString() }],
+      [{ poolId: 1, coverAmountInAsset: amount.toString() }],
       {
         value: expectedPremium,
       },

--- a/test/integration/MemberRoles/switchMembershipAndAssets.js
+++ b/test/integration/MemberRoles/switchMembershipAndAssets.js
@@ -74,7 +74,7 @@ describe('switchMembershipAndAssets', function () {
   });
 
   it('transfers the provided covers to the new address', async function () {
-    const { mr: memberRoles, tk: token, cover, coverNFT, stakingPool0 } = this.contracts;
+    const { mr: memberRoles, tk: token, cover, coverNFT, stakingPool1 } = this.contracts;
     const [member, staker] = this.accounts.members;
     const [nonMember] = this.accounts.nonMembers;
 
@@ -86,7 +86,7 @@ describe('switchMembershipAndAssets', function () {
     const amount = parseEther('1');
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker, gracePeriod, period, productId });
+    await stake({ stakingPool: stakingPool1, staker, gracePeriod, period, productId });
 
     for (let i = 0; i < 3; i++) {
       const expectedPremium = parseEther('1');
@@ -104,7 +104,7 @@ describe('switchMembershipAndAssets', function () {
           commissionDestination: ethers.constants.AddressZero,
           ipfsData: '',
         },
-        [{ poolId: '0', coverAmountInAsset: amount }],
+        [{ poolId: 1, coverAmountInAsset: amount }],
         { value: expectedPremium },
       );
     }
@@ -128,16 +128,16 @@ describe('switchMembershipAndAssets', function () {
   });
 
   it.skip('transfers all staking LP shares of the provided staking pools', async function () {
-    const { mr: memberRoles, tk: token, stakingPool0, stakingPool1, stakingPool2 } = this.contracts;
+    const { mr: memberRoles, tk: token, stakingPool1, stakingPool2, stakingPool3 } = this.contracts;
     const {
       members: [member1],
       nonMembers: [nonMember1],
     } = this.accounts;
 
     const stakingPoolsAndAmounts = [
-      [stakingPool0, parseEther('1000')],
-      [stakingPool1, parseEther('10')],
+      [stakingPool1, parseEther('1000')],
       [stakingPool2, parseEther('10')],
+      [stakingPool3, parseEther('10')],
     ];
 
     const lastBlock = await ethers.provider.getBlock('latest');
@@ -161,28 +161,28 @@ describe('switchMembershipAndAssets', function () {
     await memberRoles.connect(member1).switchMembershipAndAssets(newMemberAddress, [], [0, 2], [[1], [1]]);
 
     {
-      const balance = await stakingPool0.balanceOf(member1.address);
+      const balance = await stakingPool1.balanceOf(member1.address);
       expect(balance).to.be.equal(0);
     }
     {
-      const balance = await stakingPool1.balanceOf(member1.address);
+      const balance = await stakingPool2.balanceOf(member1.address);
       expect(balance).to.be.equal(1);
     }
     {
-      const balance = await stakingPool2.balanceOf(member1.address);
+      const balance = await stakingPool3.balanceOf(member1.address);
       expect(balance).to.be.equal(0);
     }
 
     {
-      const balance = await stakingPool0.balanceOf(newMemberAddress);
+      const balance = await stakingPool1.balanceOf(newMemberAddress);
       expect(balance).to.be.equal(1);
     }
     {
-      const balance = await stakingPool1.balanceOf(newMemberAddress);
+      const balance = await stakingPool2.balanceOf(newMemberAddress);
       expect(balance).to.be.equal(0);
     }
     {
-      const balance = await stakingPool2.balanceOf(newMemberAddress);
+      const balance = await stakingPool3.balanceOf(newMemberAddress);
       expect(balance).to.be.equal(1);
     }
   });

--- a/test/integration/YieldTokenIncidents/submitClaim.js
+++ b/test/integration/YieldTokenIncidents/submitClaim.js
@@ -50,7 +50,7 @@ describe('submitClaim', function () {
 
   it('submits ETH claim and approves claim', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { cover, stakingPool0, as, yc, ybETH, gv } = this.contracts;
+    const { cover, stakingPool1, as, yc, ybETH, gv } = this.contracts;
     const [coverBuyer1, staker1] = this.accounts.members;
     const [nonMember1] = this.accounts.nonMembers;
 
@@ -60,7 +60,7 @@ describe('submitClaim', function () {
     const coverAsset = 0; // ETH
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, productId, period, gracePeriod });
+    await stake({ stakingPool: stakingPool1, staker: staker1, productId, period, gracePeriod });
 
     // cover buyer gets yield token
     await transferYieldToken({ tokenOwner: this.accounts.defaultSender, coverBuyer: coverBuyer1, yToken: ybETH, yc });
@@ -116,7 +116,7 @@ describe('submitClaim', function () {
 
   it('submits DAI claim and approves claim', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { cover, stakingPool0, as, dai, yc, ybDAI, gv } = this.contracts;
+    const { cover, stakingPool1, as, dai, yc, ybDAI, gv } = this.contracts;
     const [coverBuyer1, staker1] = this.accounts.members;
     const [nonMember1] = this.accounts.nonMembers;
 
@@ -126,7 +126,7 @@ describe('submitClaim', function () {
     const coverAsset = 1; // DAI
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, productId, period, gracePeriod });
+    await stake({ stakingPool: stakingPool1, staker: staker1, productId, period, gracePeriod });
 
     // cover buyer gets cover asset
     await transferCoverAsset({ tokenOwner: this.accounts.defaultSender, coverBuyer: coverBuyer1, asset: dai, cover });
@@ -185,7 +185,7 @@ describe('submitClaim', function () {
 
   it('submits ETH claim and rejects claim', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { cover, stakingPool0, as, yc, ybETH, gv } = this.contracts;
+    const { cover, stakingPool1, as, yc, ybETH, gv } = this.contracts;
     const [coverBuyer1, staker1, staker2] = this.accounts.members;
     const [nonMember1] = this.accounts.nonMembers;
 
@@ -195,7 +195,7 @@ describe('submitClaim', function () {
     const coverAsset = 0; // ETH
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, productId, period, gracePeriod });
+    await stake({ stakingPool: stakingPool1, staker: staker1, productId, period, gracePeriod });
 
     // cover buyer gets yield token
     await transferYieldToken({ tokenOwner: this.accounts.defaultSender, coverBuyer: coverBuyer1, yToken: ybETH, yc });
@@ -234,7 +234,7 @@ describe('submitClaim', function () {
 
   it('submits DAI claim and rejects claim', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { cover, stakingPool0, as, dai, yc, ybDAI, gv } = this.contracts;
+    const { cover, stakingPool1, as, dai, yc, ybDAI, gv } = this.contracts;
     const [coverBuyer1, staker1, staker2] = this.accounts.members;
     const [nonMember1] = this.accounts.nonMembers;
 
@@ -244,7 +244,7 @@ describe('submitClaim', function () {
     const coverAsset = 1; // DAI
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, productId, period, gracePeriod });
+    await stake({ stakingPool: stakingPool1, staker: staker1, productId, period, gracePeriod });
 
     // cover buyer gets cover asset
     await transferCoverAsset({ tokenOwner: this.accounts.defaultSender, coverBuyer: coverBuyer1, asset: dai, cover });
@@ -285,7 +285,7 @@ describe('submitClaim', function () {
 
   it('submits and redeems full amount of ETH claim', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { cover, stakingPool0, as, yc, ybETH, gv } = this.contracts;
+    const { cover, stakingPool1, as, yc, ybETH, gv } = this.contracts;
     const [coverBuyer1, staker1] = this.accounts.members;
     const [nonMember1] = this.accounts.nonMembers;
 
@@ -295,7 +295,7 @@ describe('submitClaim', function () {
     const coverAsset = 0; // ETH
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, productId, period, gracePeriod });
+    await stake({ stakingPool: stakingPool1, staker: staker1, productId, period, gracePeriod });
 
     // cover buyer gets yield token
     await transferYieldToken({ tokenOwner: this.accounts.defaultSender, coverBuyer: coverBuyer1, yToken: ybETH, yc });
@@ -337,7 +337,7 @@ describe('submitClaim', function () {
 
   it('submits and redeems full amount of DAI claim', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { cover, stakingPool0, as, dai, yc, ybDAI, gv } = this.contracts;
+    const { cover, stakingPool1, as, dai, yc, ybDAI, gv } = this.contracts;
     const [coverBuyer1, staker1] = this.accounts.members;
     const [nonMember1] = this.accounts.nonMembers;
 
@@ -347,7 +347,7 @@ describe('submitClaim', function () {
     const coverAsset = 1; // DAI
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, productId, period, gracePeriod });
+    await stake({ stakingPool: stakingPool1, staker: staker1, productId, period, gracePeriod });
 
     // cover buyer gets cover asset
     await transferCoverAsset({ tokenOwner: this.accounts.defaultSender, coverBuyer: coverBuyer1, asset: dai, cover });
@@ -389,7 +389,7 @@ describe('submitClaim', function () {
 
   it('submits and redeems claims from multiple users', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { cover, stakingPool0, as, yc, ybETH, gv } = this.contracts;
+    const { cover, stakingPool1, as, yc, ybETH, gv } = this.contracts;
     const [coverBuyer1, coverBuyer2, coverBuyer3, staker1] = this.accounts.members;
     const [nonMember1, nonMember2, nonMember3] = this.accounts.nonMembers;
 
@@ -399,7 +399,7 @@ describe('submitClaim', function () {
     const coverAsset = 0; // ETH
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, productId, period, gracePeriod });
+    await stake({ stakingPool: stakingPool1, staker: staker1, productId, period, gracePeriod });
 
     // coverBuyer1 gets yield token
     await transferYieldToken({ tokenOwner: this.accounts.defaultSender, coverBuyer: coverBuyer1, yToken: ybETH, yc });
@@ -497,7 +497,7 @@ describe('submitClaim', function () {
 
   it('submits and redeems claims from multiple products', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { cover, stakingPool0, as, yc, ybETH, gv, dai, ybDAI } = this.contracts;
+    const { cover, stakingPool1, as, yc, ybETH, gv, dai, ybDAI } = this.contracts;
     const [coverBuyer1, coverBuyer2, staker1] = this.accounts.members;
     const [nonMember1, nonMember2] = this.accounts.nonMembers;
 
@@ -509,7 +509,7 @@ describe('submitClaim', function () {
       const coverAsset = 0; // ETH
 
       // Stake to open up capacity
-      await stake({ stakingPool: stakingPool0, staker: staker1, productId, period, gracePeriod });
+      await stake({ stakingPool: stakingPool1, staker: staker1, productId, period, gracePeriod });
 
       // cover buyer gets yield token
       await transferYieldToken({ tokenOwner: this.accounts.defaultSender, coverBuyer: coverBuyer1, yToken: ybETH, yc });
@@ -539,7 +539,7 @@ describe('submitClaim', function () {
       const coverAsset = 1; // DAI
 
       // Stake to open up capacity
-      await stake({ stakingPool: stakingPool0, staker: staker1, productId, period, gracePeriod });
+      await stake({ stakingPool: stakingPool1, staker: staker1, productId, period, gracePeriod });
 
       // cover buyer gets cover asset
       await transferCoverAsset({ tokenOwner: this.accounts.defaultSender, coverBuyer: coverBuyer2, asset: dai, cover });
@@ -595,7 +595,7 @@ describe('submitClaim', function () {
 
   it('submits USDC claim and approves claim', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { cover, stakingPool0, as, usdc, yc, ybUSDC, gv } = this.contracts;
+    const { cover, stakingPool1, as, usdc, yc, ybUSDC, gv } = this.contracts;
     const [coverBuyer, staker] = this.accounts.members;
     const [nonMember] = this.accounts.nonMembers;
 
@@ -606,7 +606,7 @@ describe('submitClaim', function () {
     const coverAsset = 4; // usdc
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker, productId, period, gracePeriod });
+    await stake({ stakingPool: stakingPool1, staker, productId, period, gracePeriod });
 
     // cover buyer gets cover asset
     await transferCoverAsset({ tokenOwner: this.accounts.defaultSender, coverBuyer, asset: usdc, cover });
@@ -647,7 +647,7 @@ describe('submitClaim', function () {
 
   it('submits and redeems full amount of USDC claim', async function () {
     const { DEFAULT_PRODUCTS } = this;
-    const { cover, stakingPool0, as, usdc, yc, ybUSDC, gv } = this.contracts;
+    const { cover, stakingPool1, as, usdc, yc, ybUSDC, gv } = this.contracts;
     const [coverBuyer1, staker1] = this.accounts.members;
     const [nonMember1] = this.accounts.nonMembers;
 
@@ -659,7 +659,7 @@ describe('submitClaim', function () {
     const coverAsset = 4; // usdc
 
     // Stake to open up capacity
-    await stake({ stakingPool: stakingPool0, staker: staker1, productId, period, gracePeriod });
+    await stake({ stakingPool: stakingPool1, staker: staker1, productId, period, gracePeriod });
 
     // cover buyer gets cover asset
     await transferCoverAsset({ tokenOwner: this.accounts.defaultSender, coverBuyer: coverBuyer1, asset: usdc, cover });

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -523,10 +523,11 @@ async function setup() {
       '', // ipfs hash
     );
 
-    const stakingPoolAddress = await cover.stakingPool(i);
+    const poolId = i + 1;
+    const stakingPoolAddress = await cover.stakingPool(poolId);
     const stakingPoolInstance = await ethers.getContractAt('StakingPool', stakingPoolAddress);
 
-    this.contracts['stakingPool' + i] = stakingPoolInstance;
+    this.contracts['stakingPool' + poolId] = stakingPoolInstance;
   }
   const config = {
     BUCKET_SIZE: await cover.BUCKET_SIZE(),

--- a/test/integration/utils/cover.js
+++ b/test/integration/utils/cover.js
@@ -27,7 +27,7 @@ async function buyCover({ amount, productId, coverAsset, period, cover, coverBuy
       commissionDestination: AddressZero,
       ipfsData: '',
     },
-    [{ poolId: '0', coverAmountInAsset: amount.toString() }],
+    [{ poolId: 1, coverAmountInAsset: amount }],
     { value: coverAsset === ETH_ASSET_ID ? expectedPremium : 0 },
   );
 }

--- a/test/unit/Cover/burnStake.js
+++ b/test/unit/Cover/burnStake.js
@@ -230,7 +230,7 @@ describe('burnStake', function () {
 
     await cover.connect(internal).burnStake(expectedCoverId, segmentId, burnAmount);
 
-    const stakingPool = await ethers.getContractAt('CoverMockStakingPool', await cover.stakingPool(0));
+    const stakingPool = await ethers.getContractAt('CoverMockStakingPool', await cover.stakingPool(1));
 
     const burnStakeCalledWithAmount = await stakingPool.burnStakeCalledWithAmount();
     expect(burnStakeCalledWithAmount).to.be.equal(expectedBurnAmount);

--- a/test/unit/Cover/burnStake.js
+++ b/test/unit/Cover/burnStake.js
@@ -48,7 +48,7 @@ describe('burnStake', function () {
       amountPaidOut: payoutAmountInAsset,
     });
 
-    const stakingPool = await ethers.getContractAt('CoverMockStakingPool', await cover.stakingPool(0));
+    const stakingPool = await ethers.getContractAt('CoverMockStakingPool', await cover.stakingPool(1));
     const burnStakeCalledWithAmount = await stakingPool.burnStakeCalledWithAmount();
     expect(burnStakeCalledWithAmount).to.be.equal(expectedBurnAmount);
   });
@@ -96,7 +96,7 @@ describe('burnStake', function () {
     const amountPerPool = amount.div(amountOfPools);
 
     const allocationRequest = [];
-    for (let i = 0; i < amountOfPools; i++) {
+    for (let i = 1; i <= amountOfPools; i++) {
       await createStakingPool(
         cover,
         productId,
@@ -144,7 +144,7 @@ describe('burnStake', function () {
     });
 
     for (let i = 0; i < amountOfPools; i++) {
-      const stakingPool = await ethers.getContractAt('CoverMockStakingPool', await cover.stakingPool(i));
+      const stakingPool = await ethers.getContractAt('CoverMockStakingPool', await cover.stakingPool(i + 1));
 
       const burnStakeCalledWithAmount = await stakingPool.burnStakeCalledWithAmount();
       expect(burnStakeCalledWithAmount).to.be.equal(expectedBurnAmount[i]);
@@ -188,7 +188,7 @@ describe('burnStake', function () {
       amountPaidOut: payoutAmountInAsset,
     });
 
-    const stakingPool = await ethers.getContractAt('CoverMockStakingPool', await cover.stakingPool(0));
+    const stakingPool = await ethers.getContractAt('CoverMockStakingPool', await cover.stakingPool(1));
     const burnStakeCalledWithAmount = await stakingPool.burnStakeCalledWithAmount();
     expect(burnStakeCalledWithAmount).to.be.equal(expectedBurnAmount);
   });

--- a/test/unit/Cover/createStakingPool.js
+++ b/test/unit/Cover/createStakingPool.js
@@ -64,7 +64,7 @@ describe('createStakingPool', function () {
       );
     }
 
-    const poolId = 0;
+    const poolId = 1;
     const salt = Buffer.from(poolId.toString(16).padStart(64, '0'), 'hex');
     const initCodeHash = Buffer.from(requiredHash, 'hex');
     const expectedAddress = ethers.utils.getCreate2Address(stakingPoolFactory.address, salt, initCodeHash);
@@ -103,7 +103,7 @@ describe('createStakingPool', function () {
     const { cover } = this;
     const [stakingPoolCreator, stakingPoolManager] = this.accounts.generalPurpose;
     const { initialPoolFee, maxPoolFee, productInitializationParams } = newPoolFixture;
-    const poolId = 0;
+    const poolId = 1;
 
     const firstStakingPoolAddress = await cover.stakingPool(poolId);
 
@@ -135,7 +135,7 @@ describe('createStakingPool', function () {
       ipfsDescriptionHash,
     );
 
-    const poolId = 0;
+    const poolId = 1;
     const expectedSPAddress = await cover.stakingPool(poolId);
     await expect(tx).to.emit(stakingPoolFactory, 'StakingPoolCreated').withArgs(poolId, expectedSPAddress);
   });

--- a/test/unit/Cover/editCover.js
+++ b/test/unit/Cover/editCover.js
@@ -61,7 +61,7 @@ describe('editCover', function () {
         commissionDestination: AddressZero,
         ipfsData: '',
       },
-      [{ poolId: '0', coverAmountInAsset: increasedAmount.toString() }],
+      [{ poolId: 1, coverAmountInAsset: increasedAmount.toString() }],
       {
         value: extraPremium.add(1),
       },
@@ -105,7 +105,7 @@ describe('editCover', function () {
         commissionDestination: AddressZero,
         ipfsData: '',
       },
-      [{ poolId: '0', coverAmountInAsset: reducedAmount.toString() }],
+      [{ poolId: 1, coverAmountInAsset: reducedAmount.toString() }],
       {
         value: 0,
       },
@@ -159,8 +159,8 @@ describe('editCover', function () {
         ipfsData: '',
       },
       [
-        { poolId: 0, skip: true, coverAmountInAsset: 0 },
-        { poolId: 1, skip: false, coverAmountInAsset: amount },
+        { poolId: 1, skip: true, coverAmountInAsset: 0 },
+        { poolId: 2, skip: false, coverAmountInAsset: amount },
       ],
       {
         value: expectedPremium.add(1),
@@ -170,13 +170,13 @@ describe('editCover', function () {
     const buyerBalanceAfter = await ethers.provider.getBalance(coverBuyer.address);
     expect(buyerBalanceAfter).to.be.lt(buyerBalanceBefore.sub(expectedPremium));
 
-    const pool0Allocation = await cover.coverSegmentAllocations(expectedCoverId, 1, 0);
-    expect(pool0Allocation.poolId).to.be.equal(0);
-    const pool1Allocation = await cover.coverSegmentAllocations(expectedCoverId, 1, 1);
+    const pool1Allocation = await cover.coverSegmentAllocations(expectedCoverId, 1, 0);
     expect(pool1Allocation.poolId).to.be.equal(1);
+    const pool2Allocation = await cover.coverSegmentAllocations(expectedCoverId, 1, 1);
+    expect(pool2Allocation.poolId).to.be.equal(2);
 
-    expect(pool0Allocation.coverAmountInNXM).to.be.equal(amount);
     expect(pool1Allocation.coverAmountInNXM).to.be.equal(amount);
+    expect(pool2Allocation.coverAmountInNXM).to.be.equal(amount);
 
     await assertCoverFields(cover, expectedCoverId, {
       productId,
@@ -222,7 +222,7 @@ describe('editCover', function () {
         commissionDestination: AddressZero,
         ipfsData: '',
       },
-      [{ poolId: '0', skip: false, coverAmountInAsset: amount.toString() }],
+      [{ poolId: 1, skip: false, coverAmountInAsset: amount.toString() }],
       {
         value: extraPremium.add(10),
       },
@@ -264,7 +264,7 @@ describe('editCover', function () {
         commissionDestination: AddressZero,
         ipfsData: '',
       },
-      [{ poolId: '0', skip: false, coverAmountInAsset: amount.toString() }],
+      [{ poolId: 1, skip: false, coverAmountInAsset: amount.toString() }],
       {
         value: 0,
       },
@@ -317,7 +317,7 @@ describe('editCover', function () {
         commissionDestination: AddressZero,
         ipfsData: '',
       },
-      [{ poolId: '0', skip: false, coverAmountInAsset: increasedAmount.toString() }],
+      [{ poolId: 1, skip: false, coverAmountInAsset: increasedAmount.toString() }],
       {
         value: extraPremium.add(10),
       },
@@ -370,7 +370,7 @@ describe('editCover', function () {
         commissionDestination: AddressZero,
         ipfsData: '',
       },
-      [{ poolId: '0', skip: false, coverAmountInAsset: decreasedAmount.toString() }],
+      [{ poolId: 1, skip: false, coverAmountInAsset: decreasedAmount.toString() }],
       {
         value: extraPremium,
       },
@@ -439,7 +439,7 @@ describe('editCover', function () {
         commissionDestination: AddressZero,
         ipfsData: '',
       },
-      [{ poolId: '0', skip: false, coverAmountInAsset: increasedAmount.toString() }],
+      [{ poolId: 1, skip: false, coverAmountInAsset: increasedAmount.toString() }],
       {
         value: extraPremium,
       },
@@ -487,7 +487,7 @@ describe('editCover', function () {
         commissionDestination: AddressZero,
         ipfsData: '',
       },
-      [{ poolId: '0', skip: false, coverAmountInAsset: reducedAmount.toString() }],
+      [{ poolId: 1, skip: false, coverAmountInAsset: reducedAmount.toString() }],
       {
         value: 0,
       },
@@ -534,7 +534,7 @@ describe('editCover', function () {
           commissionDestination: AddressZero,
           ipfsData: '',
         },
-        [{ poolId: '0', skip: true, coverAmountInAsset: increasedAmount }],
+        [{ poolId: 1, skip: true, coverAmountInAsset: increasedAmount }],
         { value: extraPremium.add(10) },
       ),
     ).to.be.revertedWithCustomError(cover, 'ExpiredCoversCannotBeEdited');
@@ -576,7 +576,7 @@ describe('editCover', function () {
           commissionDestination: AddressZero,
           ipfsData: '',
         },
-        [{ poolId: '0', skip: false, coverAmountInAsset: increasedAmount.toString() }],
+        [{ poolId: 1, skip: false, coverAmountInAsset: increasedAmount.toString() }],
         {
           value: extraPremium,
         },
@@ -621,7 +621,7 @@ describe('editCover', function () {
           commissionDestination: AddressZero,
           ipfsData: '',
         },
-        [{ poolId: '0', skip: false, coverAmountInAsset: increasedAmount.toString() }],
+        [{ poolId: 1, skip: false, coverAmountInAsset: increasedAmount.toString() }],
         {
           value: extraPremium,
         },
@@ -665,7 +665,7 @@ describe('editCover', function () {
         commissionDestination: AddressZero,
         ipfsData: '',
       },
-      [{ poolId: '0', coverAmountInAsset: amount }],
+      [{ poolId: 1, coverAmountInAsset: amount }],
       { value: expectedPremium.add(10) },
     );
 
@@ -702,7 +702,7 @@ describe('editCover', function () {
           commissionDestination: AddressZero,
           ipfsData: '',
         },
-        [{ poolId: '0', skip: false, coverAmountInAsset: increasedAmount }],
+        [{ poolId: 1, skip: false, coverAmountInAsset: increasedAmount }],
         { value: extraPremium.add(10) },
       ),
     ).to.be.revertedWithCustomError(cover, 'OnlyOwnerOrApproved');
@@ -737,7 +737,7 @@ describe('editCover', function () {
           commissionDestination: AddressZero,
           ipfsData: '',
         },
-        [{ poolId: '0', skip: false, coverAmountInAsset: increasedAmount }],
+        [{ poolId: 1, skip: false, coverAmountInAsset: increasedAmount }],
         { value: extraPremium.add(10) },
       ),
     ).to.be.revertedWith('NOT_MINTED');
@@ -779,7 +779,7 @@ describe('editCover', function () {
           commissionDestination: AddressZero,
           ipfsData: '',
         },
-        [{ poolId: '0', skip: false, coverAmountInAsset: increasedAmount.toString() }],
+        [{ poolId: 1, skip: false, coverAmountInAsset: increasedAmount.toString() }],
         {
           value: extraPremium,
         },
@@ -824,7 +824,7 @@ describe('editCover', function () {
           commissionDestination: AddressZero,
           ipfsData: '',
         },
-        [{ poolId: '0', skip: false, coverAmountInAsset: increasedAmount.toString() }],
+        [{ poolId: 1, skip: false, coverAmountInAsset: increasedAmount.toString() }],
         {
           value: extraPremium,
         },
@@ -869,7 +869,7 @@ describe('editCover', function () {
           commissionDestination: AddressZero,
           ipfsData: '',
         },
-        [{ poolId: '0', skip: false, coverAmountInAsset: increasedAmount }],
+        [{ poolId: 1, skip: false, coverAmountInAsset: increasedAmount }],
         { value: extraPremium.add(1) },
       ),
     ).to.not.be.reverted;
@@ -909,7 +909,7 @@ describe('editCover', function () {
           commissionDestination: AddressZero,
           ipfsData: '',
         },
-        [{ poolId: '0', skip: false, coverAmountInAsset: increasedAmount }],
+        [{ poolId: 1, skip: false, coverAmountInAsset: increasedAmount }],
         { value: extraPremium.add(1) },
       ),
     ).to.not.be.reverted;
@@ -951,7 +951,7 @@ describe('editCover', function () {
           commissionDestination: AddressZero,
           ipfsData: '',
         },
-        [{ poolId: '0', skip: false, coverAmountInAsset: increasedAmount }],
+        [{ poolId: 1, skip: false, coverAmountInAsset: increasedAmount }],
         { value: extraPremium.add(1) },
       ),
     ).to.be.revertedWithCustomError(cover, 'UnexpectedCoverAsset');
@@ -993,7 +993,7 @@ describe('editCover', function () {
           commissionDestination: AddressZero,
           ipfsData: '',
         },
-        [{ poolId: '0', skip: false, coverAmountInAsset: increasedAmount }],
+        [{ poolId: 1, skip: false, coverAmountInAsset: increasedAmount }],
         { value: extraPremium.add(1) },
       ),
     ).to.be.revertedWithCustomError(cover, 'UnexpectedProductId');
@@ -1084,7 +1084,7 @@ describe('editCover', function () {
           commissionDestination: AddressZero,
           ipfsData,
         },
-        [{ poolId: '0', skip: false, coverAmountInAsset: increasedAmount }],
+        [{ poolId: 1, skip: false, coverAmountInAsset: increasedAmount }],
         { value: extraPremium.add(1) },
       ),
     )
@@ -1129,7 +1129,7 @@ describe('editCover', function () {
         commissionDestination: AddressZero,
         ipfsData: '',
       },
-      [{ poolId: '0', coverAmountInAsset: increasedAmount.toString() }],
+      [{ poolId: 1, coverAmountInAsset: increasedAmount.toString() }],
       {
         value: extraPremium,
       },
@@ -1190,7 +1190,7 @@ describe('editCover', function () {
         commissionDestination: AddressZero,
         ipfsData: '',
       },
-      [{ poolId: '0', coverAmountInAsset: increasedAmount.toString() }],
+      [{ poolId: 1, coverAmountInAsset: increasedAmount.toString() }],
       {
         value: 0,
       },
@@ -1250,8 +1250,8 @@ describe('editCover', function () {
         ipfsData: '',
       },
       [
-        { poolId: 0, skip: true, coverAmountInAsset: 0 },
-        { poolId: 1, skip: false, coverAmountInAsset: amount },
+        { poolId: 1, skip: true, coverAmountInAsset: 0 },
+        { poolId: 2, skip: false, coverAmountInAsset: amount },
       ],
       {
         value: expectedPremium.add(1),
@@ -1265,13 +1265,13 @@ describe('editCover', function () {
     const segment = await cover.coverSegments(expectedCoverId, firstEditSegment);
 
     {
-      const pool0Allocation = await cover.coverSegmentAllocations(expectedCoverId, firstEditSegment, 0);
-      expect(pool0Allocation.poolId).to.be.equal(0);
-      expect(pool0Allocation.coverAmountInNXM).to.be.equal(amount);
-
-      const pool1Allocation = await cover.coverSegmentAllocations(expectedCoverId, firstEditSegment, 1);
+      const pool1Allocation = await cover.coverSegmentAllocations(expectedCoverId, firstEditSegment, 0);
       expect(pool1Allocation.poolId).to.be.equal(1);
       expect(pool1Allocation.coverAmountInNXM).to.be.equal(amount);
+
+      const pool2Allocation = await cover.coverSegmentAllocations(expectedCoverId, firstEditSegment, 1);
+      expect(pool2Allocation.poolId).to.be.equal(2);
+      expect(pool2Allocation.coverAmountInNXM).to.be.equal(amount);
 
       await assertCoverFields(cover, expectedCoverId, {
         productId,
@@ -1310,8 +1310,8 @@ describe('editCover', function () {
         ipfsData: '',
       },
       [
-        { poolId: 0, skip: false, coverAmountInAsset: increasedPoolAmount },
         { poolId: 1, skip: false, coverAmountInAsset: increasedPoolAmount },
+        { poolId: 2, skip: false, coverAmountInAsset: increasedPoolAmount },
       ],
       {
         value: extraPremium.add(10),
@@ -1321,13 +1321,13 @@ describe('editCover', function () {
     const secondEditSegment = 2;
 
     {
-      const pool0Allocation = await cover.coverSegmentAllocations(expectedCoverId, secondEditSegment, 0);
-      expect(pool0Allocation.poolId).to.be.equal(0);
-      expect(pool0Allocation.coverAmountInNXM).to.be.equal(increasedPoolAmount);
-
-      const pool1Allocation = await cover.coverSegmentAllocations(expectedCoverId, secondEditSegment, 1);
+      const pool1Allocation = await cover.coverSegmentAllocations(expectedCoverId, secondEditSegment, 0);
       expect(pool1Allocation.poolId).to.be.equal(1);
       expect(pool1Allocation.coverAmountInNXM).to.be.equal(increasedPoolAmount);
+
+      const pool2Allocation = await cover.coverSegmentAllocations(expectedCoverId, secondEditSegment, 1);
+      expect(pool2Allocation.poolId).to.be.equal(2);
+      expect(pool2Allocation.coverAmountInNXM).to.be.equal(increasedPoolAmount);
 
       await assertCoverFields(cover, expectedCoverId, {
         productId,
@@ -1375,7 +1375,7 @@ describe('editCover', function () {
         commissionDestination: AddressZero,
         ipfsData: '',
       },
-      [{ poolId: 0, skip: true, coverAmountInAsset: amount.mul(2) }],
+      [{ poolId: 1, skip: true, coverAmountInAsset: amount.mul(2) }],
       {
         value: expectedPremium.mul(2),
       },
@@ -1383,9 +1383,9 @@ describe('editCover', function () {
 
     const firstEditSegment = 1;
     {
-      const pool0Allocation = await cover.coverSegmentAllocations(expectedCoverId, firstEditSegment, 0);
-      expect(pool0Allocation.poolId).to.be.equal(0);
-      expect(pool0Allocation.coverAmountInNXM).to.be.equal(amount);
+      const pool1Allocation = await cover.coverSegmentAllocations(expectedCoverId, firstEditSegment, 0);
+      expect(pool1Allocation.poolId).to.be.equal(1);
+      expect(pool1Allocation.coverAmountInNXM).to.be.equal(amount);
 
       await assertCoverFields(cover, expectedCoverId, {
         productId,
@@ -1434,7 +1434,7 @@ describe('editCover', function () {
           commissionDestination: AddressZero,
           ipfsData: '',
         },
-        [{ poolId: 1, skip: false, coverAmountInAsset: amount }],
+        [{ poolId: 2, skip: false, coverAmountInAsset: amount }],
         {
           value: expectedPremium,
         },
@@ -1488,7 +1488,7 @@ describe('editCover', function () {
         commissionDestination: AddressZero,
         ipfsData: '',
       },
-      [{ poolId: '0', coverAmountInAsset: increasedAmount.toString() }],
+      [{ poolId: 1, coverAmountInAsset: increasedAmount.toString() }],
       {
         value: extraPremium.add(1),
       },

--- a/test/unit/Cover/helpers.js
+++ b/test/unit/Cover/helpers.js
@@ -17,7 +17,6 @@ async function createStakingPool(cover, productId, capacity, targetPrice, active
 
   const factoryAddress = await cover.stakingPoolFactory();
   const stakingPoolFactory = await ethers.getContractAt('StakingPoolFactory', factoryAddress);
-  const stakingPoolIndex = await stakingPoolFactory.stakingPoolCount();
 
   await cover.connect(creator).createStakingPool(
     manager.address,
@@ -28,7 +27,8 @@ async function createStakingPool(cover, productId, capacity, targetPrice, active
     '', // ipfsDescriptionHash
   );
 
-  const stakingPoolAddress = await cover.stakingPool(stakingPoolIndex);
+  const stakingPoolId = await stakingPoolFactory.stakingPoolCount();
+  const stakingPoolAddress = await cover.stakingPool(stakingPoolId);
   const stakingPool = await ethers.getContractAt('CoverMockStakingPool', stakingPoolAddress);
 
   await stakingPool.setStake(productId, capacity);
@@ -70,7 +70,7 @@ async function buyCoverOnOnePool(params) {
     targetPriceRatio,
   );
 
-  const allocationRequest = [{ poolId: 0, coverAmountInAsset: amount }];
+  const allocationRequest = [{ poolId: 1, coverAmountInAsset: amount }];
 
   return buyCoverOnMultiplePools.call(this, { ...params, allocationRequest });
 }

--- a/test/unit/Cover/setProducts.js
+++ b/test/unit/Cover/setProducts.js
@@ -19,7 +19,7 @@ describe('setProducts', function () {
 
   // Cover.PoolAllocationRequest
   const poolAllocationRequestTemplate = {
-    poolId: '0',
+    poolId: 1,
     coverAmountInAsset: amount,
   };
 

--- a/test/unit/Cover/totalActiveCoverInAsset.js
+++ b/test/unit/Cover/totalActiveCoverInAsset.js
@@ -117,7 +117,7 @@ describe('totalActiveCoverInAsset', function () {
         commissionDestination: AddressZero,
         ipfsData: '',
       },
-      [{ poolId: 0, coverAmountInAsset: amount }],
+      [{ poolId: 1, coverAmountInAsset: amount }],
     );
 
     const { timestamp } = await ethers.provider.getBlock('latest');
@@ -146,7 +146,7 @@ describe('totalActiveCoverInAsset', function () {
           commissionDestination: AddressZero,
           ipfsData: '',
         },
-        [{ poolId: 0, coverAmountInAsset: amount }],
+        [{ poolId: 1, coverAmountInAsset: amount }],
       );
     }
 
@@ -221,7 +221,7 @@ describe('totalActiveCoverInAsset', function () {
           commissionDestination: AddressZero,
           ipfsData: '',
         },
-        [{ poolId: 0, coverAmountInAsset: amount }],
+        [{ poolId: 1, coverAmountInAsset: amount }],
       );
       // Burn first segment of coverId == i
       await cover.connect(internalContract).burnStake(i + 1, 0, amount.div(2));

--- a/test/unit/StakingPool/depositTo.js
+++ b/test/unit/StakingPool/depositTo.js
@@ -25,7 +25,7 @@ const productParams = {
 };
 
 const poolInitParams = {
-  poolId: 0,
+  poolId: 1,
   initialPoolFee: 5, // 5%
   maxPoolFee: 5, // 5%
   products: [productParams],

--- a/test/unit/StakingPool/extendDeposit.js
+++ b/test/unit/StakingPool/extendDeposit.js
@@ -21,7 +21,7 @@ const productParams = {
 };
 
 const poolInitParams = {
-  poolId: 0,
+  poolId: 1,
   initialPoolFee: 5, // 5%
   maxPoolFee: 5, // 5%
   products: [productParams],

--- a/test/unit/StakingPool/initialize.js
+++ b/test/unit/StakingPool/initialize.js
@@ -10,7 +10,7 @@ const product0 = {
 };
 
 const initializeParams = {
-  poolId: 0,
+  poolId: 1,
   isPrivatePool: false,
   initialPoolFee: 5, // 5%
   maxPoolFee: 5, // 5%

--- a/test/unit/StakingPool/processExpirations.js
+++ b/test/unit/StakingPool/processExpirations.js
@@ -32,7 +32,7 @@ const productParams = {
 };
 
 const poolInitParams = {
-  poolId: 0,
+  poolId: 1,
   initialPoolFee: 5, // 5%
   maxPoolFee: 5, // 5%
   products: [productParams],

--- a/test/unit/StakingPool/requestAllocation.js
+++ b/test/unit/StakingPool/requestAllocation.js
@@ -115,6 +115,7 @@ describe('requestAllocation', function () {
     await cover.setProductType({ claimMethod: 1, gracePeriod: daysToSeconds(7) }, productId);
 
     // Initialize staking pool
+    const poolId = 1;
     const isPrivatePool = false;
     const ipfsDescriptionHash = 'Staking pool 1';
     const maxPoolFee = 10; // 10%

--- a/test/unit/StakingPool/requestAllocation.js
+++ b/test/unit/StakingPool/requestAllocation.js
@@ -99,7 +99,7 @@ const product3 = {
   targetPrice: 200, // 2%}
 };
 
-const poolId = 0;
+const poolId = 1;
 const trancheOffset = 5;
 
 describe('requestAllocation', function () {

--- a/test/unit/StakingPool/setPoolFee.js
+++ b/test/unit/StakingPool/setPoolFee.js
@@ -30,7 +30,7 @@ const product = {
 };
 
 const initializeParams = {
-  poolId: 0,
+  poolId: 1,
   isPrivatePool: false,
   initialPoolFee: 5, // 5%
   maxPoolFee: 5, // 5%

--- a/test/unit/StakingPool/setPoolPrivacy.js
+++ b/test/unit/StakingPool/setPoolPrivacy.js
@@ -10,7 +10,7 @@ describe('setPoolPrivacy', function () {
   };
 
   const initializeParams = {
-    poolId: 0,
+    poolId: 1,
     isPrivatePool: false,
     initialPoolFee: 5, // 5%
     maxPoolFee: 5, // 5%

--- a/test/unit/StakingPool/withdraw.js
+++ b/test/unit/StakingPool/withdraw.js
@@ -21,7 +21,7 @@ const product0 = {
 };
 
 const initializeParams = {
-  poolId: 0,
+  poolId: 1,
   isPrivatePool: false,
   initialPoolFee: 5, // 5%
   maxPoolFee: 5, // 5%

--- a/test/unit/StakingPoolFactory/stakingPoolFactory.js
+++ b/test/unit/StakingPoolFactory/stakingPoolFactory.js
@@ -51,7 +51,7 @@ describe('StakingPoolFactory', function () {
     const proxyHash = bytesToHex(keccak256(hexToBytes(proxyBytecode.replace(/^0x/i, ''))));
     const initCodeHash = Buffer.from(proxyHash, 'hex');
 
-    for (let i = 0; i < 10; i++) {
+    for (let i = 1; i <= 10; i++) {
       const poolId = i;
       const salt = Buffer.from(poolId.toString(16).padStart(64, '0'), 'hex');
       const expectedAddress = ethers.utils.getCreate2Address(stakingPoolFactory.address, salt, initCodeHash);
@@ -59,7 +59,7 @@ describe('StakingPoolFactory', function () {
       await expect(stakingPoolFactory.connect(operator).create(beacon.address))
         .to.emit(stakingPoolFactory, 'StakingPoolCreated')
         .withArgs(poolId, expectedAddress);
-      expect(await stakingPoolFactory.stakingPoolCount()).to.be.equal(poolId + 1);
+      expect(await stakingPoolFactory.stakingPoolCount()).to.be.equal(poolId);
     }
   });
 });


### PR DESCRIPTION
## Context

Makes the staking pool ids start at 1.

## Changes proposed in this pull request

- Staking pools start at 1
- Fix an ugly bug in Cover where burns were done on the wrong staking pools

## Test plan

All tests are passing. The bug was discovered due to the intended change and existing tests started to fail.

## Checklist

- [ ] Rebased the base branch
- [ ] Attached corresponding Github issue
- [ ] Prefixed the name with the type of change (i.e. feat, chore, test)
- [ ] Performed a self-review of my own code
- [ ] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [ ] Didn't generate new warnings
- [ ] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
