### PR TITLE
Feature: `getProductPools` function

### DIFF
--- a/contracts/modules/staking/StakingViewer.sol
+++ b/contracts/modules/staking/StakingViewer.sol
@@ -142,30 +142,30 @@ contract StakingViewer is Multicall {
   }
 
   function getProductPools(uint productId) public view returns (Pool[] memory pools) {
-    uint stakedPoolsCount = 0;
+    uint queueSize = 0;
     uint poolCount = stakingPoolFactory.stakingPoolCount();
     Pool[] memory stakedPoolsQueue = new Pool[](poolCount);
 
     for (uint i = 1; i <= poolCount; i++) {
       (
-      uint lastEffectiveWeight,
-      uint targetWeight,
-      uint targetPrice,
-      uint bumpedPrice,
-      uint bumpedPriceUpdateTime
-      ) = stakingPool(i).getProduct(productId);
+        uint lastEffectiveWeight,
+        uint targetWeight,
+        /* uint targetPrice */,
+        /* uint bumpedPrice */,
+        uint bumpedPriceUpdateTime
+      ) = stakingProducts.getProduct(i, productId);
 
       if (targetWeight == 0 && lastEffectiveWeight == 0 && bumpedPriceUpdateTime == 0) {
         continue;
       }
 
       Pool memory pool = getPool(i);
-      stakedPoolsQueue[stakedPoolsCount] = pool;
-      stakedPoolsCount++;
+      stakedPoolsQueue[queueSize] = pool;
+      queueSize++;
     }
-    pools = new Pool[](stakedPoolsCount);
+    pools = new Pool[](queueSize);
 
-    for (uint i = 0; i < stakedPoolsCount; i++) {
+    for (uint i = 0; i < queueSize; i++) {
       pools[i] = stakedPoolsQueue[i];
     }
 

--- a/contracts/modules/staking/StakingViewer.sol
+++ b/contracts/modules/staking/StakingViewer.sol
@@ -134,8 +134,39 @@ contract StakingViewer is Multicall {
     uint poolCount = stakingPoolFactory.stakingPoolCount();
     pools = new Pool[](poolCount);
 
-    for (uint i = 0; i < poolCount; i++) {
+    for (uint i = 1; i <= poolCount; i++) {
       pools[i] = getPool(i);
+    }
+
+    return pools;
+  }
+
+  function getProductPools(uint productId) public view returns (Pool[] memory pools) {
+    uint stakedPoolsCount = 0;
+    uint poolCount = stakingPoolFactory.stakingPoolCount();
+    Pool[] memory stakedPoolsQueue = new Pool[](poolCount);
+
+    for (uint i = 1; i <= poolCount; i++) {
+      (
+      uint lastEffectiveWeight,
+      uint targetWeight,
+      uint targetPrice,
+      uint bumpedPrice,
+      uint bumpedPriceUpdateTime
+      ) = stakingPool(i).getProduct(productId);
+
+      if (targetWeight == 0 && lastEffectiveWeight == 0 && bumpedPriceUpdateTime == 0) {
+        continue;
+      }
+
+      Pool memory pool = getPool(i);
+      stakedPoolsQueue[stakedPoolsCount] = pool;
+      stakedPoolsCount++;
+    }
+    pools = new Pool[](stakedPoolsCount);
+
+    for (uint i = 0; i < stakedPoolsCount; i++) {
+      pools[i] = stakedPoolsQueue[i];
     }
 
     return pools;


### PR DESCRIPTION
## Context

StakingViewer needs a function that returns all the pools for the product


## Changes proposed in this pull request

StakingViewer expanded with `getProductPools` function.


## Test plan

N/A


## Checklist

- [x] Rebased the base branch
- [ ] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
