### PR TITLE
Feature: Validate staking nft owner at deposit 

### DIFF
--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -402,6 +402,11 @@ contract StakingPool is IStakingPool, Multicall {
       if (stakingNFT.stakingPoolOf(requestTokenId) != poolId) {
         revert InvalidStakingPoolForToken();
       }
+      // validate only the token owner or an approved address can deposit
+      if (!stakingNFT.isApprovedOrOwner(msg.sender, requestTokenId)) {
+        revert NotTokenOwnerOrApproved();
+      }
+
       tokenId = requestTokenId;
     }
 


### PR DESCRIPTION
## Context
Closes issue https://github.com/NexusMutual/smart-contracts/issues/652

## Changes proposed in this pull request

Check `msg.sender` is the staking NFT owner or approved when making a deposit to it.


## Test plan
Unit test


## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
