### PR TITLE
Fix: start covers at block timestamp

### DIFF
--- a/contracts/modules/assessment/IndividualClaims.sol
+++ b/contracts/modules/assessment/IndividualClaims.sol
@@ -291,7 +291,7 @@ contract IndividualClaims is IIndividualClaims, MasterAwareV2 {
         "Invalid claim method for this product type"
       );
       require(requestedAmount <= segment.amount, "Covered amount exceeded");
-      require(segment.start <= block.timestamp, "Cover starts in the future");
+      require(block.timestamp > segment.start, "Cannot buy cover and submit claim in the same block");
       require(
         uint(segment.start) + uint(segment.period) + uint(segment.gracePeriod) > block.timestamp,
         "Cover is outside the grace period"

--- a/contracts/modules/assessment/YieldTokenIncidents.sol
+++ b/contracts/modules/assessment/YieldTokenIncidents.sol
@@ -255,6 +255,8 @@ contract YieldTokenIncidents is IYieldTokenIncidents, MasterAwareV2 {
 
       require(coverData.productId == incident.productId, "Product id mismatch");
 
+      require(block.timestamp > coverSegment.start, "Cannot buy cover and submit claim in the same block");
+
       // Calculate the payout amount
       {
         uint deductiblePriceBefore =

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -237,7 +237,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard {
     _coverSegments[coverId].push(
       CoverSegment(
         coverAmountInCoverAsset.toUint96(), // cover amount in cover asset
-        (block.timestamp + 1).toUint32(), // start
+        block.timestamp.toUint32(), // start
         params.period, // period
         allocationRequest.gracePeriod.toUint32(),
         globalRewardsRatio,

--- a/test/integration/IndividualClaims/submitClaim.js
+++ b/test/integration/IndividualClaims/submitClaim.js
@@ -1199,7 +1199,7 @@ describe('submitClaim', function () {
 
     // should pay for premium to reset amount
     expect(ethBalanceAfter).to.not.be.equal(ethBalanceBefore);
-    expect(ethBalanceAfter).to.be.equal(ethBalanceBefore.sub(totalEditPremium).add(1));
+    expect(ethBalanceAfter).to.be.equal(ethBalanceBefore.sub(totalEditPremium));
   });
 
   it('correctly updates pool allocation after claim and cover edit', async function () {

--- a/test/unit/Cover/buyCover.js
+++ b/test/unit/Cover/buyCover.js
@@ -1000,7 +1000,7 @@ describe('buyCover', function () {
     expect(segment.gracePeriod).to.be.equal(gracePeriod);
     expect(segment.period).to.be.equal(period);
     expect(segment.amount).to.be.equal(amount);
-    expect(segment.start).to.be.equal(timestamp + 1);
+    expect(segment.start).to.be.equal(timestamp);
     expect(segment.globalRewardsRatio).to.be.equal(globalRewardsRatio);
 
     const segmentPoolAllocationIndex = 0;
@@ -1374,7 +1374,7 @@ describe('buyCover', function () {
     expect(segment.gracePeriod).to.be.equal(gracePeriod);
     expect(segment.period).to.be.equal(period);
     expect(segment.amount).to.be.equal(amount);
-    expect(segment.start).to.be.equal(timestamp + 1);
+    expect(segment.start).to.be.equal(timestamp);
     expect(segment.globalRewardsRatio).to.be.equal(globalRewardsRatio);
 
     const segmentPoolAllocationIndex = 0;

--- a/test/unit/Cover/editCover.js
+++ b/test/unit/Cover/editCover.js
@@ -1478,7 +1478,7 @@ describe('editCover', function () {
       .mul(period)
       .div(priceDenominator)
       .div(3600 * 24 * 365)
-      .mul(2); // for the 2 pools
+      .mul(2); // for 2 pools
 
     const extraPremium = expectedEditPremium.sub(expectedRefund);
 

--- a/test/unit/Cover/editCover.js
+++ b/test/unit/Cover/editCover.js
@@ -35,11 +35,16 @@ describe('editCover', function () {
 
     const { expectedPremium, segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
+    const passedPeriod = BigNumber.from(10);
+    const { start: startTimestamp } = await cover.coverSegments(expectedCoverId, 0);
+    const editTimestamp = BigNumber.from(startTimestamp).add(passedPeriod);
+    await setNextBlockTime(editTimestamp.toNumber());
+
     const increasedAmount = amount.mul(2);
 
     const expectedRefund = segment.amount
       .mul(targetPriceRatio)
-      .mul(segment.period - 1)
+      .mul(BigNumber.from(segment.period).sub(passedPeriod))
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
 
@@ -54,7 +59,7 @@ describe('editCover', function () {
         coverAsset,
         amount: increasedAmount,
         period,
-        maxPremiumInAsset: expectedEditPremium.add(1),
+        maxPremiumInAsset: extraPremium.add(1),
         paymentAsset: coverAsset,
         payWitNXM: false,
         commissionRatio: parseEther('0'),
@@ -197,9 +202,14 @@ describe('editCover', function () {
 
     const { expectedPremium, segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
+    const passedPeriod = BigNumber.from(10);
+    const { start: startTimestamp } = await cover.coverSegments(expectedCoverId, 0);
+    const editTimestamp = BigNumber.from(startTimestamp).add(passedPeriod);
+    await setNextBlockTime(editTimestamp.toNumber());
+
     const expectedRefund = segment.amount
       .mul(targetPriceRatio)
-      .mul(segment.period - 1)
+      .mul(BigNumber.from(segment.period).sub(passedPeriod))
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
 
@@ -215,7 +225,7 @@ describe('editCover', function () {
         coverAsset,
         amount,
         period: increasedPeriod,
-        maxPremiumInAsset: expectedEditPremium.add(10),
+        maxPremiumInAsset: extraPremium.add(1),
         paymentAsset: coverAsset,
         payWitNXM: false,
         commissionRatio: parseEther('0'),
@@ -224,7 +234,7 @@ describe('editCover', function () {
       },
       [{ poolId: 1, skip: false, coverAmountInAsset: amount.toString() }],
       {
-        value: extraPremium.add(10),
+        value: extraPremium.add(1),
       },
     );
 
@@ -291,9 +301,14 @@ describe('editCover', function () {
 
     const { expectedPremium, segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
+    const passedPeriod = BigNumber.from(10);
+    const { start: startTimestamp } = await cover.coverSegments(expectedCoverId, 0);
+    const editTimestamp = BigNumber.from(startTimestamp).add(passedPeriod);
+    await setNextBlockTime(editTimestamp.toNumber());
+
     const expectedRefund = segment.amount
       .mul(targetPriceRatio)
-      .mul(segment.period - 1)
+      .mul(BigNumber.from(segment.period).sub(passedPeriod))
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
 
@@ -310,7 +325,7 @@ describe('editCover', function () {
         coverAsset,
         amount: increasedAmount,
         period: increasedPeriod,
-        maxPremiumInAsset: expectedEditPremium.add(10),
+        maxPremiumInAsset: extraPremium.add(2),
         paymentAsset: coverAsset,
         payWitNXM: false,
         commissionRatio: parseEther('0'),
@@ -319,7 +334,7 @@ describe('editCover', function () {
       },
       [{ poolId: 1, skip: false, coverAmountInAsset: increasedAmount.toString() }],
       {
-        value: extraPremium.add(10),
+        value: extraPremium.add(2),
       },
     );
 
@@ -344,9 +359,14 @@ describe('editCover', function () {
 
     const { expectedPremium, segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
+    const passedPeriod = BigNumber.from(10);
+    const { start: startTimestamp } = await cover.coverSegments(expectedCoverId, 0);
+    const editTimestamp = BigNumber.from(startTimestamp).add(passedPeriod);
+    await setNextBlockTime(editTimestamp.toNumber());
+
     const expectedRefund = segment.amount
       .mul(targetPriceRatio)
-      .mul(segment.period - 1)
+      .mul(BigNumber.from(segment.period).sub(passedPeriod))
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
 
@@ -363,7 +383,7 @@ describe('editCover', function () {
         coverAsset,
         amount: decreasedAmount,
         period: increasedPeriod,
-        maxPremiumInAsset: expectedEditPremium,
+        maxPremiumInAsset: extraPremium,
         paymentAsset: coverAsset,
         payWitNXM: false,
         commissionRatio: parseEther('0'),
@@ -840,10 +860,15 @@ describe('editCover', function () {
     const { productId, coverAsset, period, amount, targetPriceRatio, priceDenominator } = coverBuyFixture;
     const { expectedPremium, segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
+    const passedPeriod = BigNumber.from(10);
+    const { start: startTimestamp } = await cover.coverSegments(expectedCoverId, 0);
+    const editTimestamp = BigNumber.from(startTimestamp).add(passedPeriod);
+    await setNextBlockTime(editTimestamp.toNumber());
+
     const increasedAmount = amount.mul(2);
     const expectedRefund = segment.amount
       .mul(targetPriceRatio)
-      .mul(segment.period - 1)
+      .mul(BigNumber.from(segment.period).sub(passedPeriod))
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
 
@@ -862,7 +887,7 @@ describe('editCover', function () {
           coverAsset,
           amount: increasedAmount,
           period,
-          maxPremiumInAsset: expectedEditPremium.add(1),
+          maxPremiumInAsset: extraPremium.add(1),
           paymentAsset: coverAsset,
           payWitNXM: false,
           commissionRatio: parseEther('0'),
@@ -1052,10 +1077,15 @@ describe('editCover', function () {
       segmentId,
     } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
+    const passedPeriod = BigNumber.from(10);
+    const { start: startTimestamp } = await cover.coverSegments(expectedCoverId, 0);
+    const editTimestamp = BigNumber.from(startTimestamp).add(passedPeriod);
+    await setNextBlockTime(editTimestamp.toNumber());
+
     const increasedAmount = amount.mul(2);
     const expectedRefund = segment.amount
       .mul(targetPriceRatio)
-      .mul(segment.period - 1)
+      .mul(BigNumber.from(segment.period).sub(passedPeriod))
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
 
@@ -1077,7 +1107,7 @@ describe('editCover', function () {
           coverAsset,
           amount: increasedAmount,
           period,
-          maxPremiumInAsset: expectedEditPremium.add(1),
+          maxPremiumInAsset: extraPremium.add(1),
           paymentAsset: coverAsset,
           payWitNXM: false,
           commissionRatio: parseEther('0'),
@@ -1101,11 +1131,16 @@ describe('editCover', function () {
 
     const { expectedPremium, segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
+    const passedPeriod = BigNumber.from(10);
+    const { start: startTimestamp } = await cover.coverSegments(expectedCoverId, 0);
+    const editTimestamp = BigNumber.from(startTimestamp).add(passedPeriod);
+    await setNextBlockTime(editTimestamp.toNumber());
+
     const increasedAmount = amount.mul(2);
 
     const expectedRefund = segment.amount
       .mul(targetPriceRatio)
-      .mul(segment.period - 1)
+      .mul(BigNumber.from(segment.period).sub(passedPeriod))
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
 
@@ -1162,11 +1197,16 @@ describe('editCover', function () {
 
     const { expectedPremium, segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
+    const passedPeriod = BigNumber.from(10);
+    const { start: startTimestamp } = await cover.coverSegments(expectedCoverId, 0);
+    const editTimestamp = BigNumber.from(startTimestamp).add(passedPeriod);
+    await setNextBlockTime(editTimestamp.toNumber());
+
     const increasedAmount = amount.mul(2);
 
     const expectedRefund = segment.amount
       .mul(targetPriceRatio)
-      .mul(segment.period - 1)
+      .mul(BigNumber.from(segment.period).sub(passedPeriod))
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
 
@@ -1283,11 +1323,16 @@ describe('editCover', function () {
       });
     }
 
+    const passedPeriod = BigNumber.from(10);
+    const { start: startTimestamp } = await cover.coverSegments(expectedCoverId, 0);
+    const editTimestamp = BigNumber.from(startTimestamp).add(passedPeriod);
+    await setNextBlockTime(editTimestamp.toNumber());
+
     const increasedPoolAmount = amount.mul(2);
 
     const expectedRefund = segment.amount
       .mul(targetPriceRatio)
-      .mul(segment.period - 1)
+      .mul(BigNumber.from(segment.period).sub(passedPeriod))
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
 
@@ -1302,7 +1347,7 @@ describe('editCover', function () {
         coverAsset,
         amount: increasedPoolAmount.mul(2),
         period,
-        maxPremiumInAsset: extraPremium.add(10),
+        maxPremiumInAsset: extraPremium.add(1),
         paymentAsset: coverAsset,
         payWitNXM: false,
         commissionRatio: parseEther('0'),
@@ -1314,7 +1359,7 @@ describe('editCover', function () {
         { poolId: 2, skip: false, coverAmountInAsset: increasedPoolAmount },
       ],
       {
-        value: extraPremium.add(10),
+        value: extraPremium.add(1),
       },
     );
 

--- a/test/unit/Cover/editCover.js
+++ b/test/unit/Cover/editCover.js
@@ -204,7 +204,7 @@ describe('editCover', function () {
 
     const { productId, coverAsset, period, amount, targetPriceRatio, priceDenominator } = coverBuyFixture;
 
-    const { expectedPremium, segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
+    const { segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
     const passedPeriod = BigNumber.from(10);
     const { start: startTimestamp } = await cover.coverSegments(expectedCoverId, 0);
@@ -217,9 +217,16 @@ describe('editCover', function () {
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
 
-    const expectedEditPremium = expectedPremium.mul(2);
-    const extraPremium = expectedEditPremium.sub(expectedRefund);
     const increasedPeriod = period * 2;
+
+    // premium for the new amount, without refunds
+    const expectedEditPremium = amount
+      .mul(targetPriceRatio)
+      .mul(increasedPeriod)
+      .div(priceDenominator)
+      .div(3600 * 24 * 365);
+
+    const extraPremium = expectedEditPremium.sub(expectedRefund);
 
     await cover.connect(coverBuyer).buyCover(
       {
@@ -229,7 +236,7 @@ describe('editCover', function () {
         coverAsset,
         amount,
         period: increasedPeriod,
-        maxPremiumInAsset: extraPremium.add(1),
+        maxPremiumInAsset: extraPremium,
         paymentAsset: coverAsset,
         payWitNXM: false,
         commissionRatio: parseEther('0'),
@@ -238,7 +245,7 @@ describe('editCover', function () {
       },
       [{ poolId: 1, skip: false, coverAmountInAsset: amount.toString() }],
       {
-        value: extraPremium.add(1),
+        value: extraPremium,
       },
     );
 
@@ -303,7 +310,7 @@ describe('editCover', function () {
 
     await buyCoverOnOnePool.call(this, coverBuyFixture);
 
-    const { expectedPremium, segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
+    const { segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
     const passedPeriod = BigNumber.from(10);
     const { start: startTimestamp } = await cover.coverSegments(expectedCoverId, 0);
@@ -316,10 +323,17 @@ describe('editCover', function () {
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
 
-    const expectedEditPremium = expectedPremium.mul(4);
-    const extraPremium = expectedEditPremium.sub(expectedRefund);
     const increasedAmount = amount.mul(2);
     const increasedPeriod = period * 2;
+
+    // premium for the new amount, without refunds
+    const expectedEditPremium = increasedAmount
+      .mul(targetPriceRatio)
+      .mul(increasedPeriod)
+      .div(priceDenominator)
+      .div(3600 * 24 * 365);
+
+    const extraPremium = expectedEditPremium.sub(expectedRefund);
 
     await cover.connect(coverBuyer).buyCover(
       {
@@ -329,7 +343,7 @@ describe('editCover', function () {
         coverAsset,
         amount: increasedAmount,
         period: increasedPeriod,
-        maxPremiumInAsset: extraPremium.add(2),
+        maxPremiumInAsset: extraPremium,
         paymentAsset: coverAsset,
         payWitNXM: false,
         commissionRatio: parseEther('0'),
@@ -338,7 +352,7 @@ describe('editCover', function () {
       },
       [{ poolId: 1, skip: false, coverAmountInAsset: increasedAmount.toString() }],
       {
-        value: extraPremium.add(2),
+        value: extraPremium,
       },
     );
 
@@ -361,7 +375,7 @@ describe('editCover', function () {
 
     await buyCoverOnOnePool.call(this, coverBuyFixture);
 
-    const { expectedPremium, segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
+    const { segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
     const passedPeriod = BigNumber.from(10);
     const { start: startTimestamp } = await cover.coverSegments(expectedCoverId, 0);
@@ -374,10 +388,17 @@ describe('editCover', function () {
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
 
-    const expectedEditPremium = expectedPremium;
-    const extraPremium = expectedEditPremium.sub(expectedRefund);
     const decreasedAmount = amount.div(2);
     const increasedPeriod = period * 2;
+
+    // premium for the new amount, without refunds
+    const expectedEditPremium = decreasedAmount
+      .mul(targetPriceRatio)
+      .mul(increasedPeriod)
+      .div(priceDenominator)
+      .div(3600 * 24 * 365);
+
+    const extraPremium = expectedEditPremium.sub(expectedRefund);
 
     await cover.connect(coverBuyer).buyCover(
       {
@@ -427,11 +448,7 @@ describe('editCover', function () {
 
     await buyCoverOnOnePool.call(this, coverBuyFixture);
 
-    const {
-      expectedPremium,
-      segment,
-      coverId: expectedCoverId,
-    } = await buyCoverOnOnePool.call(this, { ...coverBuyFixture, period });
+    const { segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, { ...coverBuyFixture, period });
 
     const { start: startTimestamp } = await cover.coverSegments(expectedCoverId, 0);
     const passedPeriod = BigNumber.from(10);
@@ -444,8 +461,16 @@ describe('editCover', function () {
       .div(priceDenominator);
 
     const increasedAmount = amount.mul(2);
-    const expectedPremiumWithoutRefund = expectedPremium; // reduced period by half and increased amount to double
-    const extraPremium = expectedPremiumWithoutRefund.sub(expectedRefund);
+    const decreasedPeriod = period.div(2);
+
+    // premium for the new amount, without refunds
+    const expectedEditPremium = increasedAmount
+      .mul(targetPriceRatio)
+      .mul(decreasedPeriod)
+      .div(priceDenominator)
+      .div(3600 * 24 * 365);
+
+    const extraPremium = expectedEditPremium.sub(expectedRefund);
 
     await setNextBlockTime(editTimestamp.toNumber());
     await cover.connect(coverBuyer).buyCover(
@@ -532,12 +557,25 @@ describe('editCover', function () {
 
     const [coverBuyer] = this.accounts.members;
 
-    const { productId, coverAsset, period, amount } = coverBuyFixture;
-    const { expectedPremium, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
+    const { productId, targetPriceRatio, priceDenominator, coverAsset, period, amount } = coverBuyFixture;
+    const { segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
+
+    const expectedRefund = segment.amount
+      .mul(targetPriceRatio)
+      .mul(segment.period)
+      .div(MAX_COVER_PERIOD)
+      .div(priceDenominator);
 
     const increasedAmount = amount.mul(2);
-    const expectedEditPremium = expectedPremium.mul(2);
-    const extraPremium = expectedEditPremium;
+
+    // premium for the new amount, without refunds
+    const expectedEditPremium = increasedAmount
+      .mul(targetPriceRatio)
+      .mul(period)
+      .div(priceDenominator)
+      .div(3600 * 24 * 365);
+
+    const extraPremium = expectedEditPremium.sub(expectedRefund);
 
     const now = await ethers.provider.getBlock('latest').then(block => block.timestamp);
     await setNextBlockTime(now + period + 3600);
@@ -551,7 +589,7 @@ describe('editCover', function () {
           coverAsset,
           amount: increasedAmount,
           period,
-          maxPremiumInAsset: expectedEditPremium.add(10),
+          maxPremiumInAsset: extraPremium,
           paymentAsset: coverAsset,
           payWitNXM: false,
           commissionRatio: parseEther('0'),
@@ -559,7 +597,7 @@ describe('editCover', function () {
           ipfsData: '',
         },
         [{ poolId: 1, skip: true, coverAmountInAsset: increasedAmount }],
-        { value: extraPremium.add(10) },
+        { value: extraPremium },
       ),
     ).to.be.revertedWithCustomError(cover, 'ExpiredCoversCannotBeEdited');
   });
@@ -571,7 +609,7 @@ describe('editCover', function () {
 
     const { productId, coverAsset, amount, priceDenominator, targetPriceRatio } = coverBuyFixture;
 
-    const { expectedPremium, segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
+    const { segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
     const expectedRefund = segment.amount
       .mul(targetPriceRatio)
@@ -579,7 +617,13 @@ describe('editCover', function () {
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
     const increasedAmount = amount.mul(2);
-    const expectedEditPremium = expectedPremium.mul(2);
+
+    // premium for the new amount, without refunds
+    const expectedEditPremium = increasedAmount
+      .mul(targetPriceRatio)
+      .mul(segment.period)
+      .div(priceDenominator)
+      .div(3600 * 24 * 365);
     const extraPremium = expectedEditPremium.sub(expectedRefund);
 
     const periodTooLong = daysToSeconds(366);
@@ -593,7 +637,7 @@ describe('editCover', function () {
           coverAsset,
           amount: increasedAmount,
           period: periodTooLong,
-          maxPremiumInAsset: expectedEditPremium,
+          maxPremiumInAsset: extraPremium,
           paymentAsset: coverAsset,
           payWitNXM: false,
           commissionRatio: parseEther('0'),
@@ -618,7 +662,7 @@ describe('editCover', function () {
 
     await buyCoverOnOnePool.call(this, coverBuyFixture);
 
-    const { expectedPremium, segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
+    const { segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
     const expectedRefund = segment.amount
       .mul(targetPriceRatio)
@@ -626,7 +670,14 @@ describe('editCover', function () {
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
     const increasedAmount = amount.mul(2);
-    const expectedEditPremium = expectedPremium.mul(2);
+
+    // premium for the new amount, without refunds
+    const expectedEditPremium = increasedAmount
+      .mul(targetPriceRatio)
+      .mul(period)
+      .div(priceDenominator)
+      .div(3600 * 24 * 365);
+
     const extraPremium = expectedEditPremium.sub(expectedRefund);
 
     await expect(
@@ -658,10 +709,10 @@ describe('editCover', function () {
     const [boardMember] = this.accounts.advisoryBoardMembers;
     const [coverBuyer] = this.accounts.members;
 
-    const { productId, coverAsset, amount, period } = coverBuyFixture;
+    const { productId, targetPriceRatio, priceDenominator, coverAsset, amount, period } = coverBuyFixture;
 
     // Buy cover
-    const { expectedPremium, segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
+    const { segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
     // Edit product gracePeriod
     const productTypeBefore = await cover.productTypes(productId);
@@ -671,8 +722,27 @@ describe('editCover', function () {
     const productType = await cover.productTypes(productId);
     expect(newGracePeriod).to.be.equal(productType.gracePeriod);
 
-    const now = await ethers.provider.getBlock('latest').then(block => block.timestamp);
-    await setNextBlockTime(now + daysToSeconds(1));
+    const passedPeriod = BigNumber.from(10);
+
+    const expectedRefund = segment.amount
+      .mul(targetPriceRatio)
+      .mul(BigNumber.from(segment.period).sub(passedPeriod))
+      .div(MAX_COVER_PERIOD)
+      .div(priceDenominator);
+    // const increasedAmount = amount.mul(2);
+
+    // premium for the new amount, without refunds
+    const expectedEditPremium = amount
+      .mul(targetPriceRatio)
+      .mul(period)
+      .div(priceDenominator)
+      .div(3600 * 24 * 365);
+
+    const extraPremium = expectedEditPremium.sub(expectedRefund);
+
+    const { start: startTimestamp } = await cover.coverSegments(expectedCoverId, 0);
+    const editTimestamp = BigNumber.from(startTimestamp).add(passedPeriod);
+    await setNextBlockTime(editTimestamp.toNumber());
 
     await cover.connect(coverBuyer).buyCover(
       {
@@ -682,7 +752,7 @@ describe('editCover', function () {
         coverAsset,
         amount,
         period,
-        maxPremiumInAsset: expectedPremium.add(10),
+        maxPremiumInAsset: extraPremium,
         paymentAsset: coverAsset,
         payWitNXM: false,
         commissionRatio: parseEther('0'),
@@ -690,7 +760,7 @@ describe('editCover', function () {
         ipfsData: '',
       },
       [{ poolId: 1, coverAmountInAsset: amount }],
-      { value: expectedPremium.add(10) },
+      { value: extraPremium },
     );
 
     const secondSegment = await cover.coverSegments(expectedCoverId, 1);
@@ -703,11 +773,17 @@ describe('editCover', function () {
 
     const [coverBuyer, otherUser] = this.accounts.members;
 
-    const { productId, coverAsset, period, amount } = coverBuyFixture;
-    const { expectedPremium, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
+    const { productId, targetPriceRatio, priceDenominator, coverAsset, period, amount } = coverBuyFixture;
+    const { coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
     const increasedAmount = amount.mul(2);
-    const expectedEditPremium = expectedPremium.mul(2);
+
+    // premium for the new amount, without refunds
+    const expectedEditPremium = increasedAmount
+      .mul(targetPriceRatio)
+      .mul(period)
+      .div(priceDenominator)
+      .div(3600 * 24 * 365);
     const extraPremium = expectedEditPremium;
 
     await expect(
@@ -737,11 +813,17 @@ describe('editCover', function () {
 
     const [coverBuyer] = this.accounts.members;
 
-    const { productId, coverAsset, period, amount } = coverBuyFixture;
-    const { expectedPremium, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
+    const { productId, targetPriceRatio, priceDenominator, coverAsset, period, amount } = coverBuyFixture;
+    const { coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
     const increasedAmount = amount.mul(2);
-    const expectedEditPremium = expectedPremium.mul(2);
+
+    // premium for the new amount, without refunds
+    const expectedEditPremium = increasedAmount
+      .mul(targetPriceRatio)
+      .mul(period)
+      .div(priceDenominator)
+      .div(3600 * 24 * 365);
     const extraPremium = expectedEditPremium;
 
     const invalidCoverId = expectedCoverId.add(100);
@@ -754,7 +836,7 @@ describe('editCover', function () {
           coverAsset,
           amount: increasedAmount,
           period,
-          maxPremiumInAsset: expectedEditPremium.add(10),
+          maxPremiumInAsset: expectedEditPremium,
           paymentAsset: coverAsset,
           payWitNXM: false,
           commissionRatio: parseEther('0'),
@@ -762,7 +844,7 @@ describe('editCover', function () {
           ipfsData: '',
         },
         [{ poolId: 1, skip: false, coverAmountInAsset: increasedAmount }],
-        { value: extraPremium.add(10) },
+        { value: extraPremium },
       ),
     ).to.be.revertedWith('NOT_MINTED');
   });
@@ -774,7 +856,7 @@ describe('editCover', function () {
 
     const { productId, coverAsset, amount, priceDenominator, targetPriceRatio } = coverBuyFixture;
 
-    const { expectedPremium, segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
+    const { segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
     const expectedRefund = segment.amount
       .mul(targetPriceRatio)
@@ -782,7 +864,13 @@ describe('editCover', function () {
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
     const increasedAmount = amount.mul(2);
-    const expectedEditPremium = expectedPremium.mul(2);
+
+    // premium for the new amount, without refunds
+    const expectedEditPremium = increasedAmount
+      .mul(targetPriceRatio)
+      .mul(segment.period)
+      .div(priceDenominator)
+      .div(3600 * 24 * 365);
     const extraPremium = expectedEditPremium.sub(expectedRefund);
 
     const periodTooShort = daysToSeconds(10);
@@ -818,7 +906,7 @@ describe('editCover', function () {
 
     const { productId, coverAsset, amount, period, priceDenominator, targetPriceRatio } = coverBuyFixture;
 
-    const { expectedPremium, segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
+    const { segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
     const expectedRefund = segment.amount
       .mul(targetPriceRatio)
@@ -827,7 +915,13 @@ describe('editCover', function () {
       .div(priceDenominator);
 
     const increasedAmount = amount.mul(2);
-    const expectedEditPremium = expectedPremium.mul(2);
+
+    // premium for the new amount, without refunds
+    const expectedEditPremium = increasedAmount
+      .mul(targetPriceRatio)
+      .mul(period)
+      .div(priceDenominator)
+      .div(3600 * 24 * 365);
     const extraPremium = expectedEditPremium.sub(expectedRefund);
 
     const smallExpectedEditPremium = expectedEditPremium.div(10);
@@ -862,7 +956,7 @@ describe('editCover', function () {
     const [coverBuyer] = this.accounts.members;
 
     const { productId, coverAsset, period, amount, targetPriceRatio, priceDenominator } = coverBuyFixture;
-    const { expectedPremium, segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
+    const { segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
     const passedPeriod = BigNumber.from(10);
     const { start: startTimestamp } = await cover.coverSegments(expectedCoverId, 0);
@@ -876,7 +970,13 @@ describe('editCover', function () {
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
 
-    const expectedEditPremium = expectedPremium.mul(2);
+    // premium for the new amount, without refunds
+    const expectedEditPremium = increasedAmount
+      .mul(targetPriceRatio)
+      .mul(period)
+      .div(priceDenominator)
+      .div(3600 * 24 * 365);
+
     const extraPremium = expectedEditPremium.sub(expectedRefund);
 
     const coverOwner = await coverNFT.ownerOf(expectedCoverId);
@@ -891,7 +991,7 @@ describe('editCover', function () {
           coverAsset,
           amount: increasedAmount,
           period,
-          maxPremiumInAsset: extraPremium.add(1),
+          maxPremiumInAsset: extraPremium,
           paymentAsset: coverAsset,
           payWitNXM: false,
           commissionRatio: parseEther('0'),
@@ -899,7 +999,7 @@ describe('editCover', function () {
           ipfsData: '',
         },
         [{ poolId: 1, skip: false, coverAmountInAsset: increasedAmount }],
-        { value: extraPremium.add(1) },
+        { value: extraPremium },
       ),
     ).to.not.be.reverted;
   });
@@ -909,12 +1009,17 @@ describe('editCover', function () {
 
     const [coverBuyer, otherUser] = this.accounts.members;
 
-    const { productId, coverAsset, period, amount } = coverBuyFixture;
-    const { expectedPremium, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
+    const { productId, targetPriceRatio, priceDenominator, coverAsset, period, amount } = coverBuyFixture;
+    const { coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
     const increasedAmount = amount.mul(2);
 
-    const expectedEditPremium = expectedPremium.mul(2);
+    // premium for the new amount, without refunds
+    const expectedEditPremium = increasedAmount
+      .mul(targetPriceRatio)
+      .mul(period)
+      .div(priceDenominator)
+      .div(3600 * 24 * 365);
     const extraPremium = expectedEditPremium;
 
     const coverOwner = await coverNFT.ownerOf(expectedCoverId);
@@ -931,7 +1036,7 @@ describe('editCover', function () {
           coverAsset,
           amount: increasedAmount,
           period,
-          maxPremiumInAsset: expectedEditPremium.add(1),
+          maxPremiumInAsset: expectedEditPremium,
           paymentAsset: coverAsset,
           payWitNXM: false,
           commissionRatio: parseEther('0'),
@@ -939,7 +1044,7 @@ describe('editCover', function () {
           ipfsData: '',
         },
         [{ poolId: 1, skip: false, coverAmountInAsset: increasedAmount }],
-        { value: extraPremium.add(1) },
+        { value: extraPremium },
       ),
     ).to.not.be.reverted;
   });
@@ -950,7 +1055,7 @@ describe('editCover', function () {
     const [coverBuyer] = this.accounts.members;
 
     const { productId, coverAsset, period, amount, targetPriceRatio, priceDenominator } = coverBuyFixture;
-    const { expectedPremium, segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
+    const { segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
     const increasedAmount = amount.mul(2);
     const expectedRefund = segment.amount
@@ -959,7 +1064,12 @@ describe('editCover', function () {
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
 
-    const expectedEditPremium = expectedPremium.mul(2);
+    // premium for the new amount, without refunds
+    const expectedEditPremium = increasedAmount
+      .mul(targetPriceRatio)
+      .mul(period)
+      .div(priceDenominator)
+      .div(3600 * 24 * 365);
     const extraPremium = expectedEditPremium.sub(expectedRefund);
 
     const incorrectCoverAsset = 1;
@@ -973,7 +1083,7 @@ describe('editCover', function () {
           coverAsset: incorrectCoverAsset,
           amount: increasedAmount,
           period,
-          maxPremiumInAsset: expectedEditPremium.add(1),
+          maxPremiumInAsset: expectedEditPremium,
           paymentAsset: coverAsset,
           payWitNXM: false,
           commissionRatio: parseEther('0'),
@@ -981,7 +1091,7 @@ describe('editCover', function () {
           ipfsData: '',
         },
         [{ poolId: 1, skip: false, coverAmountInAsset: increasedAmount }],
-        { value: extraPremium.add(1) },
+        { value: extraPremium },
       ),
     ).to.be.revertedWithCustomError(cover, 'UnexpectedCoverAsset');
   });
@@ -992,7 +1102,7 @@ describe('editCover', function () {
     const [coverBuyer] = this.accounts.members;
 
     const { coverAsset, period, amount, targetPriceRatio, priceDenominator } = coverBuyFixture;
-    const { expectedPremium, segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
+    const { segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
     const increasedAmount = amount.mul(2);
     const expectedRefund = segment.amount
@@ -1001,7 +1111,13 @@ describe('editCover', function () {
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
 
-    const expectedEditPremium = expectedPremium.mul(2);
+    // premium for the new amount, without refunds
+    const expectedEditPremium = increasedAmount
+      .mul(targetPriceRatio)
+      .mul(period)
+      .div(priceDenominator)
+      .div(3600 * 24 * 365);
+
     const extraPremium = expectedEditPremium.sub(expectedRefund);
 
     const incorrectProductId = 1;
@@ -1015,7 +1131,7 @@ describe('editCover', function () {
           coverAsset,
           amount: increasedAmount,
           period,
-          maxPremiumInAsset: expectedEditPremium.add(1),
+          maxPremiumInAsset: expectedEditPremium,
           paymentAsset: coverAsset,
           payWitNXM: false,
           commissionRatio: parseEther('0'),
@@ -1023,7 +1139,7 @@ describe('editCover', function () {
           ipfsData: '',
         },
         [{ poolId: 1, skip: false, coverAmountInAsset: increasedAmount }],
-        { value: extraPremium.add(1) },
+        { value: extraPremium },
       ),
     ).to.be.revertedWithCustomError(cover, 'UnexpectedProductId');
   });

--- a/test/unit/Cover/editCover.js
+++ b/test/unit/Cover/editCover.js
@@ -39,7 +39,7 @@ describe('editCover', function () {
 
     const expectedRefund = segment.amount
       .mul(targetPriceRatio)
-      .mul(segment.period)
+      .mul(segment.period - 1)
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
 
@@ -199,7 +199,7 @@ describe('editCover', function () {
 
     const expectedRefund = segment.amount
       .mul(targetPriceRatio)
-      .mul(segment.period)
+      .mul(segment.period - 1)
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
 
@@ -293,7 +293,7 @@ describe('editCover', function () {
 
     const expectedRefund = segment.amount
       .mul(targetPriceRatio)
-      .mul(segment.period)
+      .mul(segment.period - 1)
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
 
@@ -346,7 +346,7 @@ describe('editCover', function () {
 
     const expectedRefund = segment.amount
       .mul(targetPriceRatio)
-      .mul(segment.period)
+      .mul(segment.period - 1)
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
 
@@ -843,7 +843,7 @@ describe('editCover', function () {
     const increasedAmount = amount.mul(2);
     const expectedRefund = segment.amount
       .mul(targetPriceRatio)
-      .mul(segment.period)
+      .mul(segment.period - 1)
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
 
@@ -1055,7 +1055,7 @@ describe('editCover', function () {
     const increasedAmount = amount.mul(2);
     const expectedRefund = segment.amount
       .mul(targetPriceRatio)
-      .mul(segment.period)
+      .mul(segment.period - 1)
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
 
@@ -1105,7 +1105,7 @@ describe('editCover', function () {
 
     const expectedRefund = segment.amount
       .mul(targetPriceRatio)
-      .mul(segment.period)
+      .mul(segment.period - 1)
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
 
@@ -1166,7 +1166,7 @@ describe('editCover', function () {
 
     const expectedRefund = segment.amount
       .mul(targetPriceRatio)
-      .mul(segment.period)
+      .mul(segment.period - 1)
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
 
@@ -1287,7 +1287,7 @@ describe('editCover', function () {
 
     const expectedRefund = segment.amount
       .mul(targetPriceRatio)
-      .mul(segment.period)
+      .mul(segment.period - 1)
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
 

--- a/test/unit/Cover/editCover.js
+++ b/test/unit/Cover/editCover.js
@@ -1215,7 +1215,12 @@ describe('editCover', function () {
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
 
-    const expectedEditPremium = expectedPremium.mul(2);
+    // premium for the new amount, without refunds
+    const expectedEditPremium = increasedAmount
+      .mul(targetPriceRatio)
+      .mul(period)
+      .div(priceDenominator)
+      .div(3600 * 24 * 365);
     const extraPremium = expectedEditPremium.sub(expectedRefund);
 
     const coverOwner = await coverNFT.ownerOf(expectedCoverId);
@@ -1233,7 +1238,7 @@ describe('editCover', function () {
           coverAsset,
           amount: increasedAmount,
           period,
-          maxPremiumInAsset: extraPremium.add(1),
+          maxPremiumInAsset: extraPremium,
           paymentAsset: coverAsset,
           payWitNXM: false,
           commissionRatio: parseEther('0'),
@@ -1241,7 +1246,7 @@ describe('editCover', function () {
           ipfsData,
         },
         [{ poolId: 1, skip: false, coverAmountInAsset: increasedAmount }],
-        { value: extraPremium.add(1) },
+        { value: extraPremium },
       ),
     )
       .to.emit(cover, 'CoverEdited')
@@ -1255,7 +1260,7 @@ describe('editCover', function () {
 
     const { productId, coverAsset, period, amount, priceDenominator, targetPriceRatio } = coverBuyFixture;
 
-    const { expectedPremium, segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
+    const { segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
     const passedPeriod = BigNumber.from(10);
     const { start: startTimestamp } = await cover.coverSegments(expectedCoverId, 0);
@@ -1270,8 +1275,13 @@ describe('editCover', function () {
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
 
-    const expectedEditPremium = expectedPremium.mul(2);
-    const extraPremium = expectedEditPremium.sub(expectedRefund).add(1);
+    // premium for the new amount, without refunds
+    const expectedEditPremium = increasedAmount
+      .mul(targetPriceRatio)
+      .mul(period)
+      .div(priceDenominator)
+      .div(3600 * 24 * 365);
+    const extraPremium = expectedEditPremium.sub(expectedRefund);
 
     const poolEthBalanceBefore = await ethers.provider.getBalance(pool.address);
 
@@ -1321,7 +1331,7 @@ describe('editCover', function () {
     await nxm.mint(coverBuyer.address, parseEther('1000'));
     await nxm.connect(coverBuyer).approve(tokenController.address, parseEther('1000'));
 
-    const { expectedPremium, segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
+    const { segment, coverId: expectedCoverId } = await buyCoverOnOnePool.call(this, coverBuyFixture);
 
     const passedPeriod = BigNumber.from(10);
     const { start: startTimestamp } = await cover.coverSegments(expectedCoverId, 0);
@@ -1336,8 +1346,13 @@ describe('editCover', function () {
       .div(MAX_COVER_PERIOD)
       .div(priceDenominator);
 
-    const expectedEditPremium = expectedPremium.mul(2);
-    const extraPremium = expectedEditPremium.sub(expectedRefund).add(1);
+    // premium for the new amount, without refunds
+    const expectedEditPremium = increasedAmount
+      .mul(targetPriceRatio)
+      .mul(period)
+      .div(priceDenominator)
+      .div(3600 * 24 * 365);
+    const extraPremium = expectedEditPremium.sub(expectedRefund);
 
     const userBalanceBefore = await nxm.balanceOf(coverBuyer.address);
 

--- a/test/unit/IndividualClaims/submitClaim.js
+++ b/test/unit/IndividualClaims/submitClaim.js
@@ -272,12 +272,12 @@ describe('submitClaim', function () {
       individualClaims.connect(coverOwner).submitClaim(coverId, 1, segment0.amount, '', {
         value: deposit,
       }),
-    ).to.be.revertedWith('Cover starts in the future');
+    ).to.be.revertedWith('Cannot buy cover and submit claim in the same block');
     await expect(
       individualClaims.connect(coverOwner).submitClaim(coverId, 0, segment0.amount, '', {
         value: deposit,
       }),
-    ).not.to.be.revertedWith('Cover starts in the future');
+    ).not.to.be.revertedWith('Cannot buy cover and submit claim in the same block');
   });
 
   it('reverts if the cover segment is outside the grace period', async function () {


### PR DESCRIPTION
## Context

Cover edits where underflowing because of a mismatch between cover start in Cover contract (`block.timestamp + 1`) and cover start / rewards streaming start in StakingPool (`block.timestamp`).

## Changes proposed in this pull request

This PR makes the cover start at `block.timestamp` and instead explicitly prevents claim submission in the same block.

## Test plan

Please describe the tests cases that you ran to verify your changes. Add further instructions on 
how to run them if needed (i.e. migration / deployment scripts, env vars, etc).


## Checklist

- [ ] Rebased the base branch
- [ ] Attached corresponding Github issue
- [ ] Prefixed the name with the type of change (i.e. feat, chore, test)
- [ ] Performed a self-review of my own code
- [ ] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [ ] Didn't generate new warnings
- [ ] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
