### PR TITLE
Fix withdraw() removing reward shares bug

### DIFF
--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -581,9 +581,8 @@ contract StakingPool is IStakingPool, Multicall {
           withdrawnRewards += trancheRewardsToWithdraw;
 
           // save checkpoint
-          deposit.lastAccNxmPerRewardShare = _accNxmPerRewardsShare.toUint96();
+          deposit.lastAccNxmPerRewardShare = accNxmPerRewardShareToUse.toUint96();
           deposit.pendingRewards = 0;
-          deposit.rewardsShares = 0;
         }
 
         emit Withdraw(msg.sender, tokenId, trancheId, trancheStakeToWithdraw, trancheRewardsToWithdraw);


### PR DESCRIPTION
## Context

Reward shares were set to zero when withdrawing rewards blocking subsequent withdrawals.

## Changes proposed in this pull request

- Does not zero out the deposit reward shares when withdrawing rewards
- Correctly stores the `lastAccNxmPerRewardShare` for expired deposits (for consistency)

## Test plan

Added a test with two deposits, one being withdrawn a single time and the other two times, making sure the amounts are the same.

## Checklist

- [ ] Rebased the base branch
- [ ] Attached corresponding Github issue
- [ ] Prefixed the name with the type of change (i.e. feat, chore, test)
- [ ] Performed a self-review of my own code
- [ ] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [ ] Didn't generate new warnings
- [ ] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
