### PR TITLE
Replace ALLOCATION_UNITS_PER_NXM function with mock in buyV2Covers.js

### DIFF
--- a/scripts/mocks/buyV2Covers.js
+++ b/scripts/mocks/buyV2Covers.js
@@ -70,7 +70,7 @@ async function buyCover(productId, poolId, cover, buyer, amount, period, payment
 
   // Calculate premium for productId 0
   const NXM_PER_ALLOCATION_UNIT = await cover.NXM_PER_ALLOCATION_UNIT();
-  const ALLOCATION_UNITS_PER_NXM = await cover.ALLOCATION_UNITS_PER_NXM();
+  const ALLOCATION_UNITS_PER_NXM = 100;
   const TARGET_PRICE_DENOMINATOR = await stakingProducts.TARGET_PRICE_DENOMINATOR();
   const [expectedPremium] = await stakingProducts.calculatePremium(
     stakedProduct, // staked product


### PR DESCRIPTION
Really small fix for the `buyV2Covers.js` script. Since the `ALLOCATION_UNITS_PER_NXM` function of the `Cover` contract is private now, it is mocked.