### PR TITLE
Feat: Script for setProductType tx generation

### DIFF
--- a/scripts/products/generate-product-types-tx.js
+++ b/scripts/products/generate-product-types-tx.js
@@ -11,60 +11,47 @@ const OUTPUT_FILE = path.join(
   'setProductTypes-txs.json', // filename
 );
 
+const COVER_ADDRESS = '0xcafeac0fF5dA0A2777d915531bfA6B29d282Ee62';
+
 /**
  * How to use from CLI:
- *  node scripts/products/generate-product-types-tx.js [Cover.sol address] [Signing AB Member Address]
+ *  node scripts/products/generate-product-types-tx.js
  *  The script uses product-type-data.csv as an input. Currently, supports only updates to existing products.
  *  file output is written to scripts/products/setProductTypes-txs.json
  *  Use that transaction data in your MetaMask extension to sign.
- * @param provider
- * @param coverAddress
- * @param signerAddress
- * @returns {Promise<{setProductTypesTransaction: PopulatedTransaction}>}
  */
-const main = async (provider, coverAddress, signerAddress) => {
-  console.log(`Using cover address: ${coverAddress} and signer address ${signerAddress}`);
-
-  if (!signerAddress) {
-    throw new Error(`Undefined signer address ${signerAddress}`);
-  }
-
-  const signer = provider.getSigner(signerAddress);
+const main = async () => {
+  const cover = await ethers.getContractAt('Cover', COVER_ADDRESS);
 
   const V2OnChainProductTypeDataProductsPath = path.join(__dirname, '../v2-migration/input/product-type-data.csv');
+
   const productTypeData = csvParse(fs.readFileSync(V2OnChainProductTypeDataProductsPath, 'utf8'), {
     columns: true,
     skip_empty_lines: true,
   });
-
-  const productTypeIpfsHashes = require(path.join(__dirname, '../v2-migration/output/product-type-ipfs-hashes.json'));
-  const cover = await ethers.getContractAt('Cover', coverAddress, signer);
-
-  let expectedProductTypeId = 0;
-  const productTypeEntries = productTypeData.map(data => {
+  const productTypeEntries = productTypeData.map((data, i) => {
     return {
-      productTypeName: data.Name,
+      productTypeName: '',
       productTypeId: data.Id,
-      ipfsMetadata: productTypeIpfsHashes[data.Id],
+      ipfsMetadata: '',
       productType: {
         claimMethod: data['Claim Method'],
         gracePeriod: data['Grace Period (days)'] * 24 * 3600, // This MUST be in seconds
       },
-      expectedProductTypeId: expectedProductTypeId++,
+      expectedProductTypeId: i,
     };
   });
 
   const setProductTypesTransaction = await cover.populateTransaction.setProductTypes(productTypeEntries);
+  fs.writeFileSync(OUTPUT_FILE, JSON.stringify({ setProductTypesTransaction }, null, 2), 'utf8');
 
-  const txs = {
-    setProductTypesTransaction,
-  };
-  fs.writeFileSync(OUTPUT_FILE, JSON.stringify(txs, null, 2), 'utf8');
-  return txs;
+  console.log(`Wrote transaction data to ${OUTPUT_FILE}`);
+
+  return { setProductTypesTransaction };
 };
 
 if (require.main === module) {
-  main(ethers.provider, process.argv[2], process.argv[3]).catch(e => {
+  main().catch(e => {
     console.log('Unhandled error encountered: ', e.stack);
     process.exit(1);
   });

--- a/scripts/products/generate-product-types-tx.js
+++ b/scripts/products/generate-product-types-tx.js
@@ -1,0 +1,73 @@
+require('dotenv').config();
+const { ethers, config } = require('hardhat');
+const fs = require('fs');
+const path = require('path');
+
+const { parse: csvParse } = require('csv-parse/sync');
+
+const OUTPUT_FILE = path.join(
+  config.paths.root,
+  'scripts/products/', // dir
+  'setProductTypes-txs.json', // filename
+);
+
+/**
+ * How to use from CLI:
+ *  node scripts/products/generate-product-types-tx.js [Cover.sol address] [Signing AB Member Address]
+ *  The script uses product-type-data.csv as an input. Currently, supports only updates to existing products.
+ *  file output is written to scripts/products/setProductTypes-txs.json
+ *  Use that transaction data in your MetaMask extension to sign.
+ * @param provider
+ * @param coverAddress
+ * @param signerAddress
+ * @returns {Promise<{setProductTypesTransaction: PopulatedTransaction}>}
+ */
+const main = async (provider, coverAddress, signerAddress) => {
+  console.log(`Using cover address: ${coverAddress} and signer address ${signerAddress}`);
+
+  if (!signerAddress) {
+    throw new Error(`Undefined signer address ${signerAddress}`);
+  }
+
+  const signer = provider.getSigner(signerAddress);
+
+  const V2OnChainProductTypeDataProductsPath = path.join(__dirname, '../v2-migration/input/product-type-data.csv');
+  const productTypeData = csvParse(fs.readFileSync(V2OnChainProductTypeDataProductsPath, 'utf8'), {
+    columns: true,
+    skip_empty_lines: true,
+  });
+
+  const productTypeIpfsHashes = require(path.join(__dirname, '../v2-migration/output/product-type-ipfs-hashes.json'));
+  const cover = await ethers.getContractAt('Cover', coverAddress, signer);
+
+  let expectedProductTypeId = 0;
+  const productTypeEntries = productTypeData.map(data => {
+    return {
+      productTypeName: data.Name,
+      productTypeId: data.Id,
+      ipfsMetadata: productTypeIpfsHashes[data.Id],
+      productType: {
+        claimMethod: data['Claim Method'],
+        gracePeriod: data['Grace Period (days)'] * 24 * 3600, // This MUST be in seconds
+      },
+      expectedProductTypeId: expectedProductTypeId++,
+    };
+  });
+
+  const setProductTypesTransaction = await cover.populateTransaction.setProductTypes(productTypeEntries);
+
+  const txs = {
+    setProductTypesTransaction,
+  };
+  fs.writeFileSync(OUTPUT_FILE, JSON.stringify(txs, null, 2), 'utf8');
+  return txs;
+};
+
+if (require.main === module) {
+  main(ethers.provider, process.argv[2], process.argv[3]).catch(e => {
+    console.log('Unhandled error encountered: ', e.stack);
+    process.exit(1);
+  });
+}
+
+module.exports = main;

--- a/test/fork/index.js
+++ b/test/fork/index.js
@@ -1,3 +1,3 @@
 describe('fork tests', function () {
-  require('./migration-v2');
+  require('./product-type-update');
 });

--- a/test/fork/product-type-update.js
+++ b/test/fork/product-type-update.js
@@ -113,16 +113,13 @@ describe('Update product types', function () {
   });
 
   it('Fix grace period days -> seconds for product types', async function () {
-    const signerAddress = await this.abMembers[0].getAddress();
-
-    const { setProductTypesTransaction } = await generateProductTypesTx(
-      ethers.provider,
-      this.cover.address,
-      signerAddress,
-    );
+    const { setProductTypesTransaction } = await generateProductTypesTx();
 
     console.log('Calling setProductTypes.');
-    await this.abMembers[0].sendTransaction(setProductTypesTransaction);
+    await this.abMembers[0].sendTransaction({
+      to: setProductTypesTransaction.to,
+      data: setProductTypesTransaction.data,
+    });
 
     console.log('Assert on-chain product type data.');
     const V2OnChainProductTypeDataProductsPath = path.join(

--- a/test/fork/product-type-update.js
+++ b/test/fork/product-type-update.js
@@ -1,0 +1,154 @@
+const { ethers, network } = require('hardhat');
+const { expect } = require('chai');
+
+const evm = require('./evm')();
+
+const {
+  Address: { ETH },
+} = require('./utils');
+const { daysToSeconds } = require('../../lib/helpers');
+const path = require('path');
+const { parse: csvParse } = require('csv-parse/sync');
+const fs = require('fs');
+const generateProductTypesTx = require('../../scripts/products/generate-product-types-tx');
+
+const { parseEther, toUtf8Bytes } = ethers.utils;
+
+const DAI_ADDRESS = '0x6B175474E89094C44Da98b954EedeAC495271d0F';
+
+const ASSET_V1_TO_ASSET_V2 = {};
+ASSET_V1_TO_ASSET_V2[ETH.toLowerCase()] = 0;
+ASSET_V1_TO_ASSET_V2[DAI_ADDRESS.toLowerCase()] = 1;
+
+const V2Addresses = {
+  SwapOperator: '0xcafea536d7f79F31Fa49bC40349f6a5F7E19D842',
+  PriceFeedOracle: '0xcafeaf0a0672360941b7f0b6d015797292e842c6',
+  Pool: '0xcafea112Db32436c2390F5EC988f3aDB96870627',
+  NXMaster: '0xcafea0047591B979c714A63283B8f902554deB66',
+  ProductsV1: '0xcafeab02966FdC69Ce5aFDD532DD51466892E32B',
+  CoverNFTDescriptor: '0xcafead1E31Ac8e4924Fc867c2C54FAB037458cb9',
+  CoverNFT: '0xcafeaCa76be547F14D0220482667B42D8E7Bc3eb',
+  StakingPoolFactory: '0xcafeafb97BF8831D95C0FC659b8eB3946B101CB3',
+  StakingNFTDescriptor: '0xcafea534e156a41b3e77f29Bf93C653004f1455C',
+  StakingNFT: '0xcafea508a477D94c502c253A58239fb8F948e97f',
+  StakingPool: '0xcafeacf62FB96fa1243618c4727Edf7E04D1D4Ca',
+  CoverImpl: '0xcafeaCbabeEd884AE94046d87C8aAB120958B8a6',
+  StakingProductsImpl: '0xcafea524e89514e131eE9F8462536793d49d8738',
+  IndividualClaimsImpl: '0xcafeaC308bC9B49d6686897270735b4Dc11Fa1Cf',
+  YieldTokenIncidentsImpl: '0xcafea7F77b63E995aE864dA9F36c8012666F8Fa4',
+  AssessmentImpl: '0xcafea40dE114C67925BeB6e8f0F0e2ee4a25Dd88',
+  LegacyClaimsReward: '0xcafeaDcAcAA2CD81b3c54833D6896596d218BFaB',
+  TokenController: '0xcafea53357c11b3967A8C7167Fb4973C75063DbB',
+  MCR: '0xcafea444db21dc06f34570185cF0014701c7D62e',
+  MemberRoles: '0xcafea22Faff6aEc1d1bfc146b2e2EABC73Fa7Acc',
+  LegacyPooledStaking: '0xcafea16366682a6c0083c38b2a731BC223c53D27',
+  CoverMigrator: '0xcafeac41b010299A9bec5308CCe6aFC2c4DF8D39',
+  LegacyGateway: '0xcafeaD694A05815f03F19c357200c6D95968e205',
+  Governance: '0xcafeafA258Be9aCb7C0De989be21A8e9583FBA65',
+  CoverViewer: '0xcafea84e199C85E44F34CD75374188D33FB94B4b',
+  StakingViewer: '0xcafea2B7904eE0089206ab7084bCaFB8D476BD04',
+};
+
+const NXM_TOKEN_ADDRESS = '0xd7c49CEE7E9188cCa6AD8FF264C1DA2e69D4Cf3B';
+
+const getSigner = async address => {
+  const provider =
+    network.name !== 'hardhat' // ethers errors out when using non-local accounts
+      ? new ethers.providers.JsonRpcProvider(network.config.url)
+      : ethers.provider;
+  return provider.getSigner(address);
+};
+describe('Update product types', function () {
+  before(async function () {
+    // Initialize evm helper
+    await evm.connect(ethers.provider);
+    await getSigner('0x1eE3ECa7aEF17D1e74eD7C447CcBA61aC76aDbA9');
+
+    // Get or revert snapshot if network is tenderly
+    if (network.name === 'tenderly') {
+      const { TENDERLY_SNAPSHOT_ID } = process.env;
+      if (TENDERLY_SNAPSHOT_ID) {
+        await evm.revert(TENDERLY_SNAPSHOT_ID);
+        console.log(`Reverted to snapshot ${TENDERLY_SNAPSHOT_ID}`);
+      } else {
+        console.log('Snapshot ID: ', await evm.snapshot());
+      }
+    }
+  });
+
+  it('load contracts', async function () {
+    this.master = await ethers.getContractAt('NXMaster', '0x01BFd82675DBCc7762C84019cA518e701C0cD07e');
+    this.productsV1 = await ethers.getContractAt('ProductsV1', V2Addresses.ProductsV1);
+    this.gateway = await ethers.getContractAt('LegacyGateway', '0x089Ab1536D032F54DFbC194Ba47529a4351af1B5');
+    this.quotationData = await ethers.getContractAt(
+      'LegacyQuotationData',
+      '0x1776651F58a17a50098d31ba3C3cD259C1903f7A',
+    );
+    this.individualClaims = await ethers.getContractAt(
+      'IndividualClaims',
+      await this.master.getLatestAddress(toUtf8Bytes('CI')),
+    );
+    this.coverMigrator = await ethers.getContractAt(
+      'CoverMigrator',
+      await this.master.getLatestAddress(toUtf8Bytes('CL')),
+    );
+    this.coverViewer = await ethers.getContractAt('CoverViewer', V2Addresses.CoverViewer);
+    this.assessment = await ethers.getContractAt('Assessment', await this.master.getLatestAddress(toUtf8Bytes('AS')));
+    this.assessment = await ethers.getContractAt('Assessment', await this.master.getLatestAddress(toUtf8Bytes('AS')));
+    this.dai = await ethers.getContractAt('ERC20Mock', DAI_ADDRESS);
+    this.cover = await ethers.getContractAt('Cover', await this.master.getLatestAddress(toUtf8Bytes('CO')));
+    this.memberRoles = await ethers.getContractAt('MemberRoles', await this.master.getLatestAddress(toUtf8Bytes('MR')));
+    this.governance = await ethers.getContractAt('Governance', await this.master.getLatestAddress(toUtf8Bytes('GV')));
+    this.nxmToken = await ethers.getContractAt('NXMToken', NXM_TOKEN_ADDRESS);
+  });
+
+  it('Impersonate AB members', async function () {
+    const { memberArray: abMembers } = await this.memberRoles.members(1);
+    this.abMembers = [];
+    for (const address of abMembers) {
+      await evm.impersonate(address);
+      await evm.setBalance(address, parseEther('1000'));
+      this.abMembers.push(await getSigner(address));
+    }
+  });
+
+  it('Fix grace period days -> seconds for product types', async function () {
+    const signerAddress = await this.abMembers[0].getAddress();
+
+    const { setProductTypesTransaction } = await generateProductTypesTx(
+      ethers.provider,
+      this.cover.address,
+      signerAddress,
+    );
+
+    console.log('Calling setProductTypes.');
+    await this.abMembers[0].sendTransaction(setProductTypesTransaction);
+
+    console.log('Assert on-chain product type data.');
+    const V2OnChainProductTypeDataProductsPath = path.join(
+      __dirname,
+      '../../scripts/v2-migration/input/product-type-data.csv',
+    );
+    const productTypeData = csvParse(fs.readFileSync(V2OnChainProductTypeDataProductsPath, 'utf8'), {
+      columns: true,
+      skip_empty_lines: true,
+    });
+
+    const productTypesCount = await this.cover.productTypesCount();
+    assert.equal(productTypesCount.toNumber(), productTypeData.length);
+
+    for (let i = 0; i < productTypeData.length; i++) {
+      const productType = await this.cover.productTypes(i);
+      const productTypeName = await this.cover.productTypeNames(i);
+
+      const data = productTypeData[i];
+
+      expect(productTypeName).to.be.equal(data.Name);
+      expect(productType.claimMethod.toString()).to.be.equal(data['Claim Method']);
+      expect(productType.gracePeriod.toString()).to.be.equal(daysToSeconds(data['Grace Period (days)']).toString());
+      expect(productType);
+
+      console.log(`Product type ${productTypeName} gracePeriod=${productType.gracePeriod.toString()}`);
+    }
+  });
+});


### PR DESCRIPTION
## Context

On-chain the product type data is wrong. We stored grace period for product types in days not in seconds.

## Changes proposed in this pull request

Add script to generate an update data for all the current product types, to update the information for grace Period more particularly, which is wrong (days instead of seconds).

Note: this only supports updates now to solve for this immediate use case. We can add support for inserting new product types in the future.

To run it locally you can do this:

```node scripts/products/generate-product-types-tx.js 0xcafeac0fF5dA0A2777d915531bfA6B29d282Ee62 0x87B2a7559d85f4653f13E6546A14189cd5455d45```

Which is assuming 0x87 is the AB signer.

## Test plan

Tested with a fork test.

## Checklist

- [x] Rebased the base branch
- [ ] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
