### PR TITLE
Fix effective weight calculation

### DIFF
--- a/contracts/modules/staking/StakingProducts.sol
+++ b/contracts/modules/staking/StakingProducts.sol
@@ -33,6 +33,10 @@ contract StakingProducts is IStakingProducts, MasterAwareV2, Multicall {
   uint public constant MAX_ACTIVE_TRANCHES = 8; // 7 whole quarters + 1 partial quarter
   uint public constant WEIGHT_DENOMINATOR = 100;
 
+  uint public constant ONE_NXM = 1 ether;
+  uint public constant ALLOCATION_UNITS_PER_NXM = 100;
+  uint public constant NXM_PER_ALLOCATION_UNIT = ONE_NXM / ALLOCATION_UNITS_PER_NXM;
+
   // pool id => product id => Product
   mapping(uint => mapping(uint => StakedProduct)) private _products;
   // pool id => { totalEffectiveWeight, totalTargetWeight }
@@ -334,7 +338,7 @@ contract StakingProducts is IStakingProducts, MasterAwareV2, Multicall {
     uint activeStake = stakingPool.getActiveStake();
     uint multiplier = globalCapacityRatio * (CAPACITY_REDUCTION_DENOMINATOR - capacityReductionRatio);
     uint denominator = GLOBAL_CAPACITY_DENOMINATOR * CAPACITY_REDUCTION_DENOMINATOR;
-    uint totalCapacity = activeStake * multiplier / denominator;
+    uint totalCapacity = activeStake * multiplier / denominator / NXM_PER_ALLOCATION_UNIT;
 
     if (totalCapacity == 0) {
       return targetWeight.toUint16();


### PR DESCRIPTION
## Context

Effective weight should be calculated by using pool capacity (not weighted), not product capacity (weighted).

## Changes proposed in this pull request

`StakingProducts._getEffectiveWeight` was calling `StakingPool.getTrancheCapacities` but then it summed up the results. This means that we don't actually need to go through every tranche, get its amount of shares, calculate the capacity per tranche and we can directly calculate the capacity using the active stake. This is much cheaper and solves the problem we had in the first place.

## Test plan

Not yet implemented.

## Checklist

- [ ] Rebased the base branch
- [ ] Attached corresponding Github issue
- [ ] Prefixed the name with the type of change (i.e. feat, chore, test)
- [ ] Performed a self-review of my own code
- [ ] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [ ] Didn't generate new warnings
- [ ] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
