### PR TITLE
Fix processExpirations by advancing to next bucket and depositing to next tranche

### DIFF
--- a/test/unit/StakingPool/processExpirations.js
+++ b/test/unit/StakingPool/processExpirations.js
@@ -1,7 +1,7 @@
 const { ethers } = require('hardhat');
 const { expect } = require('chai');
 
-const { setEtherBalance, increaseTime } = require('../utils').evm;
+const { setEtherBalance, increaseTime, setNextBlockTime, mineNextBlock } = require('../utils').evm;
 const { daysToSeconds } = require('../utils').helpers;
 const {
   getTranches,
@@ -338,9 +338,14 @@ describe('processExpirations', function () {
 
     const { amount, tokenId, destination } = depositToFixture;
 
+    // advance to the start of the next bucket
+    const currentBucketId = BigNumber.from(await getCurrentBucket());
+    await setNextBlockTime(currentBucketId.add(1).mul(BUCKET_DURATION).toNumber());
+    await mineNextBlock();
+
     const { firstActiveTrancheId } = await getTranches();
 
-    await stakingPool.connect(user).depositTo(amount, firstActiveTrancheId, tokenId, destination);
+    await stakingPool.connect(user).depositTo(amount, firstActiveTrancheId + 1, tokenId, destination);
 
     await generateRewards(stakingPool, this.coverSigner, daysToSeconds(10), 0);
 
@@ -436,9 +441,14 @@ describe('processExpirations', function () {
 
     const { amount, tokenId, destination } = depositToFixture;
 
+    // advance to the start of the next bucket
+    const currentBucketId = BigNumber.from(await getCurrentBucket());
+    await setNextBlockTime(currentBucketId.add(1).mul(BUCKET_DURATION).toNumber());
+    await mineNextBlock();
+
     const { firstActiveTrancheId } = await getTranches();
 
-    await stakingPool.connect(user).depositTo(amount, firstActiveTrancheId, tokenId, destination);
+    await stakingPool.connect(user).depositTo(amount, firstActiveTrancheId + 1, tokenId, destination);
 
     await generateRewards(stakingPool, this.coverSigner, daysToSeconds(10), 0);
 


### PR DESCRIPTION
## Context

Process expirations bucket related tests were failing due to bucket mismatch. The tests assumed the bucket where the rewards expire is the next one, however the cover period did not fit in the current bucket so it was expired in the `currentBucket + 2` instead.

## Changes proposed in this pull request

This PR advances the time to the beginning of the next bucket (unconditionally). This however may lead to a different problem where the tranche expires sooner than the bucket which would fail the cover buy (reward generation), hence it changes the deposit to happen on a further tranche.

## Test plan

No new tests required.

## Checklist

- [ ] Rebased the base branch
- [ ] Attached corresponding Github issue
- [ ] Prefixed the name with the type of change (i.e. feat, chore, test)
- [ ] Performed a self-review of my own code
- [ ] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [ ] Didn't generate new warnings
- [ ] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
