### PR TITLE
Fix: SwapOperator denominator bug + enzyme full withdrawal

### DIFF
--- a/contracts/modules/capital/SwapOperator.sol
+++ b/contracts/modules/capital/SwapOperator.sol
@@ -509,12 +509,23 @@ contract SwapOperator {
     // Validate there's no current cow swap order going on
     require(!orderInProgress(), "SwapOp: an order is already in place");
 
+    IPool pool = _pool();
+
+    if (assetAddress == ETH) {
+      uint ethBalance = address(this).balance;
+      require(ethBalance > 0, "SwapOp: Balance = 0");
+
+      // We assume ETH is always supported so we directly transfer it back to the Pool
+      (bool sent, ) = payable(address(pool)).call{value: ethBalance}("");
+      require(sent, "SwapOp: Failed to send Ether to pool");
+
+      return;
+    }
+
     IERC20 asset = IERC20(assetAddress);
 
     uint balance = asset.balanceOf(address(this));
     require(balance > 0, "SwapOp: Balance = 0");
-
-    IPool pool = _pool();
 
     SwapDetails memory swapDetails = pool.getAssetSwapDetails(assetAddress);
 

--- a/contracts/modules/capital/SwapOperator.sol
+++ b/contracts/modules/capital/SwapOperator.sol
@@ -513,7 +513,7 @@ contract SwapOperator {
 
     if (assetAddress == ETH) {
       uint ethBalance = address(this).balance;
-      require(ethBalance > 0, "SwapOp: Balance = 0");
+      require(ethBalance > 0, "SwapOp: ETH balance to recover is 0");
 
       // We assume ETH is always supported so we directly transfer it back to the Pool
       (bool sent, ) = payable(address(pool)).call{value: ethBalance}("");

--- a/contracts/modules/capital/SwapOperator.sol
+++ b/contracts/modules/capital/SwapOperator.sol
@@ -392,7 +392,7 @@ contract SwapOperator {
       (, uint netShareValue) = enzymeFundValueCalculatorRouter.calcNetShareValue(enzymeV4VaultProxyAddress);
 
       uint avgAmountOut = amountIn * 1e18 / netShareValue;
-      uint maxSlippageAmount = avgAmountOut * swapDetails.maxSlippageRatio / 1e18;
+      uint maxSlippageAmount = avgAmountOut * swapDetails.maxSlippageRatio / MAX_SLIPPAGE_DENOMINATOR;
       uint minOutOnMaxSlippage = avgAmountOut - maxSlippageAmount;
 
       require(amountOutMin >= minOutOnMaxSlippage, "SwapOp: amountOutMin < minOutOnMaxSlippage");
@@ -458,7 +458,7 @@ contract SwapOperator {
 
       // avgAmountOut in ETH
       uint avgAmountOut = amountIn * netShareValue / (10 ** fromToken.decimals());
-      uint maxSlippageAmount = avgAmountOut * swapDetails.maxSlippageRatio / 1e18;
+      uint maxSlippageAmount = avgAmountOut * swapDetails.maxSlippageRatio / MAX_SLIPPAGE_DENOMINATOR;
       uint minOutOnMaxSlippage = avgAmountOut - maxSlippageAmount;
 
       // slippage check

--- a/test/fork/index.js
+++ b/test/fork/index.js
@@ -6,4 +6,5 @@ describe('fork tests', function () {
   require('./withdraw-switch-membership-restrictions');
   require('./run-basic-functionality-tests');
   require('./cowswap-swaps');
+  require('./withdraw-enzyme-shares');
 });

--- a/test/fork/migrated-claims.js
+++ b/test/fork/migrated-claims.js
@@ -111,7 +111,6 @@ describe('Migrated claims', function () {
   before(async function () {
     // Initialize evm helper
     await evm.connect(ethers.provider);
-    await getSigner('0x1eE3ECa7aEF17D1e74eD7C447CcBA61aC76aDbA9');
 
     // Get or revert snapshot if network is tenderly
     if (network.name === 'tenderly') {

--- a/test/fork/migration-v2.js
+++ b/test/fork/migration-v2.js
@@ -158,7 +158,6 @@ describe('V2 upgrade', function () {
   before(async function () {
     // Initialize evm helper
     await evm.connect(ethers.provider);
-    await getSigner('0x1eE3ECa7aEF17D1e74eD7C447CcBA61aC76aDbA9');
 
     // Get or revert snapshot if network is tenderly
     if (network.name === 'tenderly') {

--- a/test/fork/product-type-update.js
+++ b/test/fork/product-type-update.js
@@ -62,7 +62,6 @@ describe('Update product types', function () {
   before(async function () {
     // Initialize evm helper
     await evm.connect(ethers.provider);
-    await getSigner('0x1eE3ECa7aEF17D1e74eD7C447CcBA61aC76aDbA9');
 
     // Get or revert snapshot if network is tenderly
     if (network.name === 'tenderly') {

--- a/test/fork/utils.js
+++ b/test/fork/utils.js
@@ -173,7 +173,6 @@ async function enableAsEnzymeReceiver(receiverAddress) {
   const comptroller = await ethers.getContractAt('IEnzymeV4Comptroller', EnzymeAdress.ENZYME_COMPTROLLER_PROXY_ADDRESS);
   const vault = await ethers.getContractAt('IEnzymeV4Vault', EnzymeAdress.ENZYMEV4_VAULT_PROXY_ADDRESS);
   const ownerAddress = await vault.getOwner();
-  console.log('Enzyme vault owner address:', ownerAddress);
 
   // Unlock and funding vault owner
   const owner = await getSigner(ownerAddress);

--- a/test/fork/withdraw-enzyme-shares.js
+++ b/test/fork/withdraw-enzyme-shares.js
@@ -93,7 +93,7 @@ describe('Enzyme ETH withdrawal', function () {
       ENZYMEV4_VAULT_PROXY_ADDRESS,
       '0',
       '1',
-      '10000', // max slippage ratio
+      '50', // max slippage ratio
     );
 
     await enableAsEnzymeReceiver(this.swapOperator.address);
@@ -105,7 +105,7 @@ describe('Enzyme ETH withdrawal', function () {
     const latestAnswer = await this.enzymeSharesOracle.latestAnswer();
 
     // Enzyme returns a few ethers under the oracle price currently
-    const errorMargin = parseEther('25');
+    const errorMargin = parseEther('40');
 
     const minOut = shareAmount.mul(latestAnswer).div(parseEther('1')).sub(errorMargin);
 

--- a/test/fork/withdraw-enzyme-shares.js
+++ b/test/fork/withdraw-enzyme-shares.js
@@ -23,11 +23,10 @@ const getSigner = async address => {
   return provider.getSigner(address);
 };
 
-describe('prevent switch or withdraw membership when tokens are locked', function () {
+describe('Enzyme ETH withdrawal', function () {
   before(async function () {
     // Initialize evm helper
     await evm.connect(ethers.provider);
-    await getSigner('0x1eE3ECa7aEF17D1e74eD7C447CcBA61aC76aDbA9');
 
     // Get or revert snapshot if network is tenderly
     if (network.name === 'tenderly') {

--- a/test/fork/withdraw-enzyme-shares.js
+++ b/test/fork/withdraw-enzyme-shares.js
@@ -1,0 +1,116 @@
+const { ethers, network } = require('hardhat');
+const { expect } = require('chai');
+const { parseEther, toUtf8Bytes } = ethers.utils;
+const evm = require('./evm')();
+const { enableAsEnzymeReceiver } = require('./utils');
+const { toBytes8 } = require('../../lib/helpers');
+
+const WETH_ADDRESS = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
+const ENZYMEV4_VAULT_PROXY_ADDRESS = '0x27F23c710dD3d878FE9393d93465FeD1302f2EbD';
+const ENZYME_FUND_VALUE_CALCULATOR_ROUTER = '0x7c728cd0CfA92401E01A4849a01b57EE53F5b2b9';
+const COWSWAP_SETTLEMENT = '0x9008D19f58AAbD9eD0D60971565AA8510560ab41';
+
+const V2Addresses = {
+  SwapOperator: '0xcafea536d7f79F31Fa49bC40349f6a5F7E19D842',
+};
+
+const getSigner = async address => {
+  const provider =
+    network.name !== 'hardhat' // ethers errors out when using non-local accounts
+      ? new ethers.providers.JsonRpcProvider(network.config.url)
+      : ethers.provider;
+  return provider.getSigner(address);
+};
+
+describe('prevent switch or withdraw membership when tokens are locked', function () {
+  before(async function () {
+    // Initialize evm helper
+    await evm.connect(ethers.provider);
+    await getSigner('0x1eE3ECa7aEF17D1e74eD7C447CcBA61aC76aDbA9');
+
+    // Get or revert snapshot if network is tenderly
+    if (network.name === 'tenderly') {
+      const { TENDERLY_SNAPSHOT_ID } = process.env;
+      if (TENDERLY_SNAPSHOT_ID) {
+        await evm.revert(TENDERLY_SNAPSHOT_ID);
+        console.log(`Reverted to snapshot ${TENDERLY_SNAPSHOT_ID}`);
+      } else {
+        console.log('Snapshot ID: ', await evm.snapshot());
+      }
+    }
+  });
+
+  it('load contracts', async function () {
+    this.master = await ethers.getContractAt('NXMaster', '0x01BFd82675DBCc7762C84019cA518e701C0cD07e');
+    this.swapOperator = await ethers.getContractAt('SwapOperator', V2Addresses.SwapOperator);
+
+    this.pool = await ethers.getContractAt('Pool', await this.master.getLatestAddress(toUtf8Bytes('P1')));
+
+    this.enzymeVaultShares = await ethers.getContractAt('ERC20Mock', ENZYMEV4_VAULT_PROXY_ADDRESS);
+
+    const governanceAddress = await this.master.getLatestAddress(toUtf8Bytes('GV'));
+
+    await evm.impersonate(governanceAddress);
+    await evm.setBalance(governanceAddress, parseEther('1000'));
+    this.governanceImpersonated = await getSigner(governanceAddress);
+  });
+
+  it('Upgrade SwapOperator', async function () {
+    const swapControllerAddress = await this.swapOperator.swapController();
+
+    const newSwapOperator = await ethers.deployContract('SwapOperator', [
+      COWSWAP_SETTLEMENT,
+      swapControllerAddress,
+      this.master.address,
+      WETH_ADDRESS,
+      ENZYMEV4_VAULT_PROXY_ADDRESS,
+      ENZYME_FUND_VALUE_CALCULATOR_ROUTER,
+      '0',
+    ]);
+
+    await this.pool
+      .connect(this.governanceImpersonated)
+      .updateAddressParameters(toBytes8('SWP_OP'), newSwapOperator.address);
+
+    this.swapOperator = await ethers.getContractAt('SwapOperator', newSwapOperator.address);
+  });
+
+  it('withdraw enzyme', async function () {
+    const swapControllerAddress = await this.swapOperator.swapController();
+    await evm.impersonate(swapControllerAddress);
+    await evm.setBalance(swapControllerAddress, parseEther('1000'));
+    const swapController = await getSigner(swapControllerAddress);
+
+    const shareAmount = await this.enzymeVaultShares.balanceOf(this.pool.address);
+
+    console.log({
+      shareAmount: shareAmount.toString(),
+    });
+
+    await this.pool.connect(this.governanceImpersonated).setSwapDetails(
+      ENZYMEV4_VAULT_PROXY_ADDRESS,
+      '0',
+      '1',
+      '10000', // max slippage ratio
+    );
+
+    await enableAsEnzymeReceiver(this.swapOperator.address);
+
+    const poolBalanceBefore = await ethers.provider.getBalance(this.pool.address);
+
+    const swapAmount = shareAmount;
+
+    const minExpectedETHPercentage = 8581;
+    const minOut = shareAmount.mul(minExpectedETHPercentage).div(10000);
+    await this.swapOperator.connect(swapController).swapEnzymeVaultShareForETH(swapAmount, minOut);
+
+    const poolBalanceAfter = await ethers.provider.getBalance(this.pool.address);
+
+    const poolBalanceIncrease = poolBalanceAfter.sub(poolBalanceBefore);
+
+    console.log({
+      poolBalanceIncrease: poolBalanceIncrease.toString(),
+    });
+    expect(poolBalanceIncrease).to.be.greaterThanOrEqual(minOut);
+  });
+});

--- a/test/fork/withdraw-switch-membership-restrictions.js
+++ b/test/fork/withdraw-switch-membership-restrictions.js
@@ -88,7 +88,6 @@ describe('prevent switch or withdraw membership when tokens are locked', functio
   before(async function () {
     // Initialize evm helper
     await evm.connect(ethers.provider);
-    await getSigner('0x1eE3ECa7aEF17D1e74eD7C447CcBA61aC76aDbA9');
 
     // Get or revert snapshot if network is tenderly
     if (network.name === 'tenderly') {

--- a/test/unit/SwapOperator/recoverAsset.js
+++ b/test/unit/SwapOperator/recoverAsset.js
@@ -48,4 +48,25 @@ describe('recoverAsset', function () {
 
     expect(balanceAfter).to.be.equal(amountInSwapOperator);
   });
+
+  it('recovers ETH', async function () {
+    const { swapOperator, pool } = this.contracts;
+
+    const [receiver] = this.accounts.nonMembers;
+
+    const ETH = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
+
+    const amountInPool = parseEther('2000');
+    await this.accounts.defaultSender.sendTransaction({ to: swapOperator.address, value: amountInPool });
+
+    const amountInSwapOperator = parseEther('10');
+
+    await this.accounts.defaultSender.sendTransaction({ to: swapOperator.address, value: amountInSwapOperator });
+
+    await swapOperator.recoverAsset(ETH, receiver.address);
+
+    const balanceAfter = await ethers.provider.getBalance(pool.address);
+
+    expect(balanceAfter.sub(amountInPool)).to.be.equal(amountInSwapOperator);
+  });
 });


### PR DESCRIPTION
## Context

Issues

https://github.com/NexusMutual/smart-contracts/issues/861

https://github.com/NexusMutual/smart-contracts/issues/451

Test how withdrawal of Enzyme would work and fix any bugs related to that.

Also add recovery of ETH from swap operator.

## Changes proposed in this pull request

Fix the bug in SwapOperator where the denominator for the slippage calculation is 1e18 instead of 10000 (the correct value) for the 2 Enzyme calls.


Notes:

A withdrawal in any amount requires:

* changing Enzyme vault shares asset details min  to 0  and max to a value that's lower than the current shares amount (eg. 1) respectively.
* Upgrade SwapOperator to fix the denominator bug.
* Get Enzyme to enable the new SwapOperator as a Shares Receiver.
* call swapEnzymeVaultShareForETH with the current amount of shares (15348001519741036985819).

Expecting to receive this amount of ETH back : ```13171239851868541139524``` in wei or roughly ```13171.23985186854``` ETH.

## Test plan

Write a fork test that extracts all ETH from enzyme and clears out all the shares.


## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
