### PR TITLE
Fix: Changing the commission calculation

### DIFF
--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -408,15 +408,15 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard, Mu
     IPool _pool = pool();
     uint premiumInPaymentAsset = nxmPriceInCoverAsset * premiumInNxm / ONE_NXM;
     uint commission = (premiumInPaymentAsset * COMMISSION_DENOMINATOR / (COMMISSION_DENOMINATOR - commissionRatio)) - premiumInPaymentAsset;
+    uint premiumWithCommission = premiumInPaymentAsset + commission;
 
-    if (premiumInPaymentAsset + commission > maxPremiumInAsset) {
+    if (premiumWithCommission > maxPremiumInAsset) {
       revert PriceExceedsMaxPremiumInAsset();
     }
 
     // ETH payment
     if (paymentAsset == ETH_ASSET_ID) {
 
-      uint premiumWithCommission = premiumInPaymentAsset + commission;
       if (msg.value < premiumWithCommission) {
         revert InsufficientEthSent();
       }

--- a/test/unit/Cover/buyCover.js
+++ b/test/unit/Cover/buyCover.js
@@ -5,6 +5,7 @@ const { createStakingPool, assertCoverFields } = require('./helpers');
 const { setEtherBalance } = require('../utils').evm;
 const { daysToSeconds } = require('../utils').helpers;
 
+const { BigNumber } = ethers;
 const { parseEther } = ethers.utils;
 const { AddressZero } = ethers.constants;
 
@@ -19,7 +20,7 @@ const buyCoverFixture = {
   period: 3600 * 24 * 30, // 30 days
   amount: parseEther('1000'),
   targetPriceRatio: 260,
-  priceDenominator: 10000,
+  priceDenominator: BigNumber.from(10000),
   activeCover: parseEther('8000'),
   capacity: parseEther('10000'),
   expectedPremium: parseEther('1000').mul(260).div(10000), // amount * targetPriceRatio / priceDenominator
@@ -193,8 +194,8 @@ describe('buyCover', function () {
       .mul(period)
       .div(3600 * 24 * 365);
 
-    const expectedCommission = expectedBasePremium.mul(commissionRatio).div(priceDenominator);
-    const expectedPremium = expectedBasePremium.add(expectedCommission);
+    const expectedPremium = expectedBasePremium.mul(priceDenominator).div(priceDenominator.sub(commissionRatio));
+    const expectedCommission = expectedPremium.sub(expectedBasePremium);
 
     await nxm.mint(coverBuyer.address, parseEther('100000'));
     await nxm.connect(coverBuyer).approve(tokenController.address, parseEther('100000'));
@@ -267,8 +268,8 @@ describe('buyCover', function () {
       .mul(period)
       .div(3600 * 24 * 365);
 
-    const expectedCommission = expectedBasePremium.mul(commissionRatio).div(10000);
-    const expectedPremium = expectedBasePremium.add(expectedCommission);
+    const expectedPremium = expectedBasePremium.mul(priceDenominator).div(priceDenominator.sub(commissionRatio));
+    const expectedCommission = expectedPremium.sub(expectedBasePremium);
 
     await dai.mint(coverBuyer.address, parseEther('100000'));
     await dai.connect(coverBuyer).approve(cover.address, parseEther('100000'));
@@ -336,8 +337,8 @@ describe('buyCover', function () {
       .mul(period)
       .div(3600 * 24 * 365);
 
-    const expectedCommission = expectedBasePremium.mul(commissionRatio).div(10000);
-    const expectedPremium = expectedBasePremium.add(expectedCommission);
+    const expectedPremium = expectedBasePremium.mul(priceDenominator).div(priceDenominator.sub(commissionRatio));
+    const expectedCommission = expectedPremium.sub(expectedBasePremium);
 
     await usdc.mint(coverBuyer.address, parseEther('100000'));
 
@@ -1066,8 +1067,7 @@ describe('buyCover', function () {
       .div(priceDenominator)
       .mul(period)
       .div(3600 * 24 * 365);
-    const expectedCommission = expectedBasePremium.mul(commissionRatio).div(priceDenominator);
-    const expectedPremium = expectedBasePremium.add(expectedCommission);
+    const expectedPremium = expectedBasePremium.mul(priceDenominator).div(priceDenominator.sub(commissionRatio));
 
     const txData = await cover.connect(coverBuyer).populateTransaction.buyCover(
       {


### PR DESCRIPTION
## Context

Issue: #779 


## Changes proposed in this pull request

Commission calculation changed from `x * (1 + commission)` to `x / (1 - commission)`


## Test plan

Tests for buy cover changed to check the change in commission calculation


## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [ ] Didn't generate new warnings
- [ ] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
