### PR TITLE
Fix: Expiration bucket check on cover expiration

### DIFF
--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -618,7 +618,7 @@ contract StakingPool is IStakingPool, Multicall {
 
     // prevent allocation requests (edits and forced expirations) for expired covers
     if (request.allocationId != 0) {
-      uint expirationBucketId = request.previousExpiration / BUCKET_DURATION;
+      uint expirationBucketId = Math.divCeil(request.previousExpiration, BUCKET_DURATION);
       if (coverTrancheAllocations[request.allocationId] == 0 || firstActiveBucketId >= expirationBucketId) {
         revert AlreadyDeallocated(request.allocationId);
       }

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -16,6 +16,8 @@ import "../../libraries/UncheckedMath.sol";
 import "../../libraries/SafeUintCast.sol";
 import "./StakingTypesLib.sol";
 
+import "hardhat/console.sol";
+
 // total stake = active stake + expired stake
 // total capacity = active stake * global capacity factor
 // total product capacity = total capacity * capacity reduction factor * product weight
@@ -614,6 +616,14 @@ contract StakingPool is IStakingPool, Multicall {
     // passing true because we change the reward per second
     processExpirations(true);
 
+    // prevent allocation requests (edits and forced expirations) for expired covers
+    if (request.allocationId != 0) {
+      uint expirationBucketId = request.previousExpiration / BUCKET_DURATION;
+      if (coverTrancheAllocations[request.allocationId] == 0 || firstActiveBucketId >= expirationBucketId) {
+        revert AlreadyDeallocated(request.allocationId);
+      }
+    }
+
     uint[] memory trancheAllocations = request.allocationId == 0
       ? getActiveAllocations(request.productId)
       : getActiveAllocationsWithoutCover(
@@ -626,13 +636,6 @@ contract StakingPool is IStakingPool, Multicall {
     // we are only deallocating
     // rewards streaming is left as is
     if (amount == 0) {
-      uint expirationBucketId = request.previousExpiration / BUCKET_DURATION;
-
-      // revert with cover already deallocated
-      if (coverTrancheAllocations[request.allocationId] == 0 || firstActiveBucketId > expirationBucketId) {
-        revert AlreadyDeallocated(request.allocationId);
-      }
-
       // store deallocated amount
       updateStoredAllocations(
         request.productId,

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -16,8 +16,6 @@ import "../../libraries/UncheckedMath.sol";
 import "../../libraries/SafeUintCast.sol";
 import "./StakingTypesLib.sol";
 
-import "hardhat/console.sol";
-
 // total stake = active stake + expired stake
 // total capacity = active stake * global capacity factor
 // total product capacity = total capacity * capacity reduction factor * product weight

--- a/test/unit/StakingPool/helpers.js
+++ b/test/unit/StakingPool/helpers.js
@@ -209,12 +209,16 @@ async function calculateStakeAndRewardsWithdrawAmounts(stakingPool, deposit, tra
   };
 }
 
-async function moveTimeToNextTranche(amountOfTranches) {
-  const { firstActiveTrancheId: currentTrancheId } = await getTranches();
-  const nextTrancheId = currentTrancheId + amountOfTranches;
+async function moveTimeToNextTranche(trancheCount) {
+  const nextTrancheId = (await getCurrentTrancheId()) + trancheCount;
   await setTime(nextTrancheId * TRANCHE_DURATION);
-
   return nextTrancheId;
+}
+
+async function moveTimeToNextBucket(bucketCount) {
+  const nextBucketId = (await getCurrentBucket()) + bucketCount;
+  await setTime(nextBucketId * BUCKET_DURATION);
+  return nextBucketId;
 }
 
 module.exports = {
@@ -234,6 +238,7 @@ module.exports = {
   estimateStakeShares,
   generateRewards,
   calculateStakeAndRewardsWithdrawAmounts,
+  moveTimeToNextBucket,
   moveTimeToNextTranche,
   TRANCHE_DURATION,
   BUCKET_DURATION,

--- a/test/unit/StakingPool/requestAllocation.js
+++ b/test/unit/StakingPool/requestAllocation.js
@@ -1667,11 +1667,9 @@ describe('requestAllocation', function () {
     const allocationReceipt = await allocationTx.wait();
     const { blockNumber: allocationBlockNumber } = allocationReceipt;
     const { timestamp: allocationTimestamp } = await ethers.provider.getBlock(allocationBlockNumber);
-    console.log({ allocationTimestamp });
 
     {
       const allocations = await stakingPool.getActiveAllocations(productId);
-      console.log(allocations);
       const allocatedAmount = allocations.reduce((acc, allocation) => acc.add(allocation), Zero);
       expect(allocatedAmount).to.be.equal(amount.div(NXM_PER_ALLOCATION_UNIT));
     }
@@ -1681,7 +1679,6 @@ describe('requestAllocation', function () {
 
     {
       const allocations = await stakingPool.getActiveAllocations(productId);
-      console.log(allocations);
       const allocatedAmount = allocations.reduce((acc, allocation) => acc.add(allocation), Zero);
       expect(allocatedAmount).to.be.equal(Zero);
     }
@@ -1690,7 +1687,7 @@ describe('requestAllocation', function () {
       ...allocationRequest,
       allocationId,
       previousStart: allocationTimestamp,
-      previousEnd: allocationTimestamp + allocationRequest.period,
+      previousExpiration: allocationTimestamp + allocationRequest.period,
     };
 
     await expect(stakingPool.requestAllocation(0, 0, expireAllocationRequest))

--- a/test/unit/StakingProducts/initializeProducts.js
+++ b/test/unit/StakingProducts/initializeProducts.js
@@ -117,7 +117,7 @@ describe('initializeProducts', function () {
     await cover.allocateCapacity(
       { ...buyCoverParamsTemplate, owner: coverBuyer.address, amount: parseEther('10') },
       0,
-      800,
+      0,
       stakingPool.address,
     );
   });


### PR DESCRIPTION
## Context

Due to a lax check on the expiration bucket id the expire cover could revert with an underflow since the allocations could have been already freed up.

## Changes proposed in this pull request

This PR moves corrects the check and moves it earlier in the code to fail with a custom error instead.

## Test plan

Added a new test that:
1. Allocates a short cover in the current bucket
2. Moves to the next bucket
3. Tries to expire

Before the fix it will fail with an underflow, with the fix it fails with a custom error.

## Checklist

- [ ] Rebased the base branch
- [ ] Attached corresponding Github issue
- [ ] Prefixed the name with the type of change (i.e. feat, chore, test)
- [ ] Performed a self-review of my own code
- [ ] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [ ] Didn't generate new warnings
- [ ] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
