### PR TITLE
Fix `calculateFixedPricePremium` arguments

### DIFF
--- a/contracts/modules/staking/StakingProducts.sol
+++ b/contracts/modules/staking/StakingProducts.sol
@@ -415,7 +415,7 @@ contract StakingProducts is IStakingProducts, MasterAwareV2, Multicall {
     uint targetPrice = Math.max(product.targetPrice, globalMinPrice);
 
     if (useFixedPrice) {
-      return calculateFixedPricePremium(period, coverAmount, targetPrice, nxmPerAllocationUnit, TARGET_PRICE_DENOMINATOR);
+      return calculateFixedPricePremium(coverAmount, period, targetPrice, nxmPerAllocationUnit, TARGET_PRICE_DENOMINATOR);
     }
 
     (premium, product) = calculatePremium(


### PR DESCRIPTION
## Context

When calling `calculateFixedPricePremium` we pass coverAmount and period in wrong order

## Changes proposed in this pull request

Fix the arguments order in the `calculateFixedPricePremium` invoke

## Test plan


## Checklist

- [x] Rebased the base branch
- [ ] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [ ] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [ ] Didn't generate new warnings
- [ ] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
