### PR TITLE
Update deploy script + deployments build script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:jammy
+
+# add basic utils
+RUN apt-get update
+RUN apt-get install -y curl git inotify-tools ca-certificates gnupg
+
+# add nodejs
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN apt-get update
+RUN apt-get install -y nodejs
+
+RUN mkdir /out
+VOLUME /out
+
+RUN useradd -m ubuntu
+RUN chown ubuntu:ubuntu /out
+USER ubuntu
+
+WORKDIR /app
+COPY --chown=ubuntu:ubuntu ./ ./
+RUN npm install
+
+ENV ENABLE_OPTIMIZER=1
+RUN npx hardhat compile
+
+
+ENV ADDRESSES_FILE=/out/addresses.json
+ENV ABI_DIR=/out/abis/
+
+EXPOSE 8545
+CMD node scripts/deploy/start.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@nomicfoundation/hardhat-chai-matchers": "^1.0.3",
         "@nomiclabs/hardhat-ethers": "^2.2.1",
         "@nomiclabs/hardhat-etherscan": "^2.1.8",
-        "@tenderly/hardhat-tenderly": "^1.5.3",
+        "@tenderly/hardhat-tenderly": "^1.7.7",
         "@typechain/ethers-v5": "^10.1.0",
         "@typechain/hardhat": "^6.1.5",
         "chai": "^4.3.6",
@@ -2319,9 +2319,9 @@
       }
     },
     "node_modules/@tenderly/hardhat-tenderly": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@tenderly/hardhat-tenderly/-/hardhat-tenderly-1.6.1.tgz",
-      "integrity": "sha512-VhnOcRVB8J1mZk5QUifthsidyEb4p6Qj0nyy07qdnF8GL/kcVDBgqluyapGS1hUhp/SVQqpKHcFTWbVJ/B0l4w==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/@tenderly/hardhat-tenderly/-/hardhat-tenderly-1.7.7.tgz",
+      "integrity": "sha512-p/jLzRPpoD7J0LGvUFEQjgniDzmP5AzfTgy41qqzyjhOsW0voe7wZI8lXjadl5MEr7rAXN1iH3VncT13qG6+Zw==",
       "dev": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.7.0",
@@ -2329,15 +2329,13 @@
         "axios": "^0.27.2",
         "ethers": "^5.7.0",
         "fs-extra": "^10.1.0",
-        "hardhat": "^2.10.2",
         "hardhat-deploy": "^0.11.14",
         "js-yaml": "^4.1.0",
-        "tenderly": "^0.4.0",
+        "tenderly": "^0.5.3",
         "tslog": "^4.3.1"
       },
       "peerDependencies": {
-        "hardhat": "^2.10.2",
-        "tenderly": "^0.4.0"
+        "hardhat": "^2.10.2"
       }
     },
     "node_modules/@tenderly/hardhat-tenderly/node_modules/argparse": {
@@ -12481,9 +12479,9 @@
       "dev": true
     },
     "node_modules/tenderly": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/tenderly/-/tenderly-0.4.0.tgz",
-      "integrity": "sha512-wZgQ8Z1utc/QoAfVvMHO/ONLXJ3Vw3yjzJzpMmMUR4kvUu861mI7+mL9R1aeUuXI06cv81LZH96Vh+AOseIYoA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/tenderly/-/tenderly-0.5.3.tgz",
+      "integrity": "sha512-sR+sbZKZzt3b2+moXJsrkBvbava1/4mGulIfuZw8bwr2OpCH8N00dME1t89JC8RjVnQjy4VewVFHyWANdn5zYQ==",
       "dev": true,
       "dependencies": {
         "axios": "^0.27.2",
@@ -12761,9 +12759,9 @@
       }
     },
     "node_modules/tslog": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/tslog/-/tslog-4.8.1.tgz",
-      "integrity": "sha512-WT+irgsc2KZBGdErWCiJo+6bt/Xl7TioSt3s/0y8wk3FVV2ogG0NhCcsp36qmBbZm3kWbBr6BfNCd8fSf/oa8g==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/tslog/-/tslog-4.9.2.tgz",
+      "integrity": "sha512-wBM+LRJoNl34Bdu8mYEFxpvmOUedpNUwMNQB/NcuPIZKwdDde6xLHUev3bBjXQU7gdurX++X/YE7gLH8eXYsiQ==",
       "dev": true,
       "engines": {
         "node": ">=16"
@@ -15780,9 +15778,9 @@
       }
     },
     "@tenderly/hardhat-tenderly": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@tenderly/hardhat-tenderly/-/hardhat-tenderly-1.6.1.tgz",
-      "integrity": "sha512-VhnOcRVB8J1mZk5QUifthsidyEb4p6Qj0nyy07qdnF8GL/kcVDBgqluyapGS1hUhp/SVQqpKHcFTWbVJ/B0l4w==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/@tenderly/hardhat-tenderly/-/hardhat-tenderly-1.7.7.tgz",
+      "integrity": "sha512-p/jLzRPpoD7J0LGvUFEQjgniDzmP5AzfTgy41qqzyjhOsW0voe7wZI8lXjadl5MEr7rAXN1iH3VncT13qG6+Zw==",
       "dev": true,
       "requires": {
         "@ethersproject/bignumber": "^5.7.0",
@@ -15790,10 +15788,9 @@
         "axios": "^0.27.2",
         "ethers": "^5.7.0",
         "fs-extra": "^10.1.0",
-        "hardhat": "^2.10.2",
         "hardhat-deploy": "^0.11.14",
         "js-yaml": "^4.1.0",
-        "tenderly": "^0.4.0",
+        "tenderly": "^0.5.3",
         "tslog": "^4.3.1"
       },
       "dependencies": {
@@ -23735,9 +23732,9 @@
       }
     },
     "tenderly": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/tenderly/-/tenderly-0.4.0.tgz",
-      "integrity": "sha512-wZgQ8Z1utc/QoAfVvMHO/ONLXJ3Vw3yjzJzpMmMUR4kvUu861mI7+mL9R1aeUuXI06cv81LZH96Vh+AOseIYoA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/tenderly/-/tenderly-0.5.3.tgz",
+      "integrity": "sha512-sR+sbZKZzt3b2+moXJsrkBvbava1/4mGulIfuZw8bwr2OpCH8N00dME1t89JC8RjVnQjy4VewVFHyWANdn5zYQ==",
       "dev": true,
       "requires": {
         "axios": "^0.27.2",
@@ -23953,9 +23950,9 @@
       }
     },
     "tslog": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/tslog/-/tslog-4.8.1.tgz",
-      "integrity": "sha512-WT+irgsc2KZBGdErWCiJo+6bt/Xl7TioSt3s/0y8wk3FVV2ogG0NhCcsp36qmBbZm3kWbBr6BfNCd8fSf/oa8g==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/tslog/-/tslog-4.9.2.tgz",
+      "integrity": "sha512-wBM+LRJoNl34Bdu8mYEFxpvmOUedpNUwMNQB/NcuPIZKwdDde6xLHUev3bBjXQU7gdurX++X/YE7gLH8eXYsiQ==",
       "dev": true
     },
     "tsort": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@nomicfoundation/hardhat-chai-matchers": "^1.0.3",
     "@nomiclabs/hardhat-ethers": "^2.2.1",
     "@nomiclabs/hardhat-etherscan": "^2.1.8",
-    "@tenderly/hardhat-tenderly": "^1.5.3",
+    "@tenderly/hardhat-tenderly": "^1.7.7",
     "@typechain/ethers-v5": "^10.1.0",
     "@typechain/hardhat": "^6.1.5",
     "chai": "^4.3.6",

--- a/scripts/deploy/deploy.js
+++ b/scripts/deploy/deploy.js
@@ -9,7 +9,7 @@ const verifier = require('./verifier')();
 const { setEtherBalance } = require('../../test/utils').evm;
 
 const { AddressZero, MaxUint256 } = ethers.constants;
-const { parseEther } = ethers.utils;
+const { parseEther, parseUnits } = ethers.utils;
 const { ABI_DIR, ADDRESSES_FILE, INITIAL_MEMBERS = '' } = process.env;
 
 if (!ABI_DIR || !ADDRESSES_FILE) {
@@ -308,6 +308,7 @@ async function main() {
       abiFilename: 'EACAggregatorProxy',
     });
     await chainlinkDaiMock.setLatestAnswer(parseEther('0.000357884806717390'));
+    await chainlinkDaiMock.setDecimals(18);
     CHAINLINK_DAI_ETH[network.name] = chainlinkDaiMock.address;
   }
 
@@ -318,6 +319,7 @@ async function main() {
       abiFilename: 'EACAggregatorProxy',
     });
     await chainlinkStEthMock.setLatestAnswer(parseEther('1.003')); // almost 1:1
+    await chainlinkStEthMock.setDecimals(18);
     CHAINLINK_STETH_ETH[network.name] = chainlinkStEthMock.address;
   }
 
@@ -328,6 +330,7 @@ async function main() {
       abiFilename: 'EACAggregatorProxy',
     });
     await chainlinkEnzymeVaultMock.setLatestAnswer(parseEther('1.003')); // almost 1:1
+    await chainlinkEnzymeVaultMock.setDecimals(18);
     CHAINLINK_ENZYME_VAULT[network.name] = chainlinkEnzymeVaultMock.address;
   }
 
@@ -338,7 +341,8 @@ async function main() {
       alias: 'Chainlink-ETH-USD',
       abiFilename: 'EACAggregatorProxy',
     });
-    await chainlinkEthUsdMock.setLatestAnswer(parseEther('1234.56'));
+    await chainlinkEthUsdMock.setLatestAnswer(parseUnits('1234.56', 8));
+    await chainlinkEthUsdMock.setDecimals(8);
     CHAINLINK_ETH_USD[network.name] = chainlinkEthUsdMock.address;
   }
 

--- a/scripts/deploy/deploy.js
+++ b/scripts/deploy/deploy.js
@@ -6,27 +6,11 @@ const { hex } = require('../../lib/helpers');
 const proposalCategories = require('../../lib/proposal-categories');
 const products = require('../v2-migration/output/migratableProducts.json');
 const verifier = require('./verifier')();
+const { setEtherBalance } = require('../../test/utils').evm;
 
-const { BigNumber } = ethers;
 const { AddressZero, MaxUint256 } = ethers.constants;
-const { hexValue, parseEther } = ethers.utils;
-
+const { parseEther } = ethers.utils;
 const { ABI_DIR, ADDRESSES_FILE, INITIAL_MEMBERS = '' } = process.env;
-
-const setBalance = async (address, amount) => {
-  const tests = [
-    { name: 'hardhat', regex: /HardhatNetwork/ },
-    { name: 'tenderly', regex: /Tenderly/ },
-  ];
-
-  // find node type
-  const clientVersion = await ethers.provider.send('web3_clientVersion', []);
-  const { name: node = 'unknown' } = tests.find(test => test.regex.test(clientVersion));
-  const method = `${node}_setBalance`;
-  const value = hexValue(BigNumber.from(amount));
-
-  return ethers.provider.send(method, [address, value]);
-};
 
 if (!ABI_DIR || !ADDRESSES_FILE) {
   console.log('ABI_DIR and ADDRESSES_FILE env vars are required');
@@ -122,14 +106,16 @@ async function main() {
   // Remove verbose logs
   // await network.provider.send('hardhat_setLoggingEnabled', [false]);
 
+  // make sure the contracts are compiled and we're not deploying an outdated artifact
+  await run('compile');
+
   const [ownerSigner] = await ethers.getSigners();
   const { address: owner } = ownerSigner;
 
   console.log(`Using network: ${network.name}`);
   console.log(`Using deployer address: ${owner}`);
 
-  // make sure the contracts are compiled and we're not deploying an outdated artifact
-  await run('compile');
+  await setEtherBalance(owner, parseEther('100'));
 
   const OwnedUpgradeabilityProxy = await ethers.getContractFactory('OwnedUpgradeabilityProxy');
 
@@ -384,7 +370,7 @@ async function main() {
   const pool = await deployImmutable('Pool', poolParameters);
 
   console.log('Funding the Pool');
-  await setBalance(pool.address, parseEther('50000'));
+  await setEtherBalance(pool.address, parseEther('50000'));
   await dai.mint(pool.address, parseEther('6500000'));
 
   console.log('Initializing contracts');

--- a/scripts/deploy/deploy.js
+++ b/scripts/deploy/deploy.js
@@ -380,10 +380,7 @@ async function main() {
   console.log('Deploying Pool');
   const legacyPoolParameters = [master, priceFeedOracle, swapOperator, dai, stETH, enzymeVault, tk].map(x => x.address);
   const legacyPool = await deployImmutable('LegacyPool', legacyPoolParameters);
-  const swapValue = await legacyPool.swapValue();
-  const poolParameters = [master, priceFeedOracle, swapOperator, tk, legacyPool]
-    .map(c => c.address)
-    .concat([swapValue]);
+  const poolParameters = [master, priceFeedOracle, swapOperator, tk, legacyPool].map(c => c.address);
   const pool = await deployImmutable('Pool', poolParameters);
 
   console.log('Funding the Pool');

--- a/scripts/deploy/deploy.js
+++ b/scripts/deploy/deploy.js
@@ -387,7 +387,7 @@ async function main() {
   const pool = await deployImmutable('Pool', poolParameters);
 
   console.log('Funding the Pool');
-  await setBalance(pool.address, parseEther('5000'));
+  await setBalance(pool.address, parseEther('50000'));
   await dai.mint(pool.address, parseEther('6500000'));
 
   console.log('Initializing contracts');


### PR DESCRIPTION
The deployments `build.js` script now also outputs abi json files to `dist/data/abis/`. The `addresses.json` file is also moved to the `dist/data` folder (from the `dist` folder). Now the `@nexusmutual/sdk` package can copy them over and re-expose them. This is convenient for loading the abis with libs who require json files instead of javascript objects.

But the actual real reason this was changed is because this enables the `frontend-next` to load freshly generated abis via some `npm link` magic. Check [Notion](https://www.notion.so/nxmcommunity/Local-development-95f84f09cbfb4b90bcdcba52e1d2fa90?pvs=4) out for more info.

Note: this includes the Ramm contract.