### PR TITLE
Check membership when minting

### DIFF
--- a/contracts/interfaces/INXMToken.sol
+++ b/contracts/interfaces/INXMToken.sol
@@ -14,6 +14,8 @@ interface INXMToken {
 
   function isLockedForMV(address member) external view returns (uint);
 
+  function whiteListed(address member) external view returns (bool);
+
   function addToWhiteList(address _member) external returns (bool);
 
   function removeFromWhiteList(address _member) external returns (bool);

--- a/contracts/mocks/common/NXMTokenMock.sol
+++ b/contracts/mocks/common/NXMTokenMock.sol
@@ -7,6 +7,7 @@ import "../../interfaces/INXMToken.sol";
 
 contract NXMTokenMock is INXMToken, ERC20 {
 
+  mapping(address => bool) public whiteListed;
   mapping(address => uint) public isLockedForMV;
   address public operator;
 
@@ -53,12 +54,14 @@ contract NXMTokenMock is INXMToken, ERC20 {
     return true;
   }
 
-  function addToWhiteList(address /*_member*/) external returns (bool) {
-    // noop
+  function addToWhiteList(address member) external returns (bool) {
+    whiteListed[member] = true;
+    return true;
   }
 
-  function removeFromWhiteList(address /*_member*/) external returns (bool) {
-    // noop
+  function removeFromWhiteList(address member) external returns (bool) {
+    whiteListed[member] = false;
+    return true;
   }
 
   function changeOperator(address _newOperator) external returns (bool) {

--- a/contracts/modules/token/TokenController.sol
+++ b/contracts/modules/token/TokenController.sol
@@ -151,11 +151,21 @@ contract TokenController is ITokenController, LockHandler, MasterAwareV2 {
   }
 
   /**
-  * @dev Mints new token for an address
-  * @param _member address to reward the minted tokens
+  * @dev Mints new tokens for an address and checks if the address is a member
+  * @param _member address to send the minted tokens to
   * @param _amount number of tokens to mint
   */
   function mint(address _member, uint _amount) public override onlyInternal {
+    _mint(_member, _amount);
+  }
+
+  /**
+  * @dev Internal function to mint new tokens for an address and checks if the address is a member
+  * @param _member address to send the minted tokens to
+  * @param _amount number of tokens to mint
+  */
+  function _mint(address _member, uint _amount) internal {
+    require(token.whiteListed(_member), "TokenController: Address is not a member");
     token.mint(_member, _amount);
   }
 
@@ -542,7 +552,7 @@ contract TokenController is ITokenController, LockHandler, MasterAwareV2 {
 
   function mintStakingPoolNXMRewards(uint amount, uint poolId) external {
     require(msg.sender == _stakingPool(poolId), "TokenController: Caller not a staking pool");
-    token.mint(address(this), amount);
+    _mint(address(this), amount);
     stakingPoolNXMBalances[poolId].rewards += amount.toUint128();
   }
 

--- a/contracts/modules/token/TokenController.sol
+++ b/contracts/modules/token/TokenController.sol
@@ -161,6 +161,7 @@ contract TokenController is ITokenController, LockHandler, MasterAwareV2 {
 
   /**
   * @dev Internal function to mint new tokens for an address and checks if the address is a member
+  * @dev Other internal functions in this contract should use _mint and never token.mint directly
   * @param _member address to send the minted tokens to
   * @param _amount number of tokens to mint
   */

--- a/test/unit/TokenController/mint.js
+++ b/test/unit/TokenController/mint.js
@@ -30,4 +30,16 @@ describe('mint', function () {
 
     expect(balanceMember1).to.equal(initialBalanceMember1.add(amount));
   });
+
+  it('reverts when minting to non-members', async function () {
+    const fixture = await loadFixture(setup);
+    const { tokenController } = fixture.contracts;
+    const [internalContract] = fixture.accounts.internalContracts;
+    const [nonMember] = fixture.accounts.nonMembers;
+
+    const amount = parseEther('10');
+    await expect(tokenController.connect(internalContract).mint(nonMember.address, amount)).to.be.revertedWith(
+      'TokenController: Address is not a member',
+    );
+  });
 });

--- a/test/unit/TokenController/setup.js
+++ b/test/unit/TokenController/setup.js
@@ -22,6 +22,8 @@ async function setup() {
     nxm.address,
   ]);
 
+  await nxm.addToWhiteList(tokenController.address);
+
   const master = await ethers.deployContract('MasterMock');
   await master.enrollGovernance(accounts.governanceContracts[0].address);
   await master.enrollInternal(internal.address);


### PR DESCRIPTION
## Context

Previously the mint function from TokenController did not check if the destination address is a member or not.

## Changes proposed in this pull request

This PR introduces an internal function `_mint` that performs this checks. All other TC functions should use it instead of directly calling the token contract.

## Test plan

Added a new test to check for revert when the destination address is not a member.

## Checklist

- [ ] Rebased the base branch
- [ ] Attached corresponding Github issue
- [ ] Prefixed the name with the type of change (i.e. feat, chore, test)
- [ ] Performed a self-review of my own code
- [ ] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [ ] Didn't generate new warnings
- [ ] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
