### PR TITLE
feat: Add EthInjected and EthExtracted events

### DIFF
--- a/contracts/interfaces/IRamm.sol
+++ b/contracts/interfaces/IRamm.sol
@@ -93,6 +93,8 @@ interface IRamm {
   event ObservationUpdated(uint32 timestamp, uint64 priceCumulativeAbove, uint64 priceCumulativeBelow);
   event BudgetRemoved();
   event SwapPauseConfigured(bool paused);
+  event EthInjected(uint value);
+  event EthExtracted(uint value);
 
   // Pause
   error SystemPaused();

--- a/contracts/modules/capital/Ramm.sol
+++ b/contracts/modules/capital/Ramm.sol
@@ -389,18 +389,17 @@ contract Ramm is IRamm, MasterAwareV2, ReentrancyGuard {
   }
 
   function calculateNxm(
-    uint stateNxm,
+    State memory state,
     uint eth,
-    uint stateEth,
-    uint stateRatchetSpeed,
     uint elapsed,
     uint capital,
     uint supply,
     bool isAbove
   ) internal pure returns (uint) {
-
-    uint nxm = stateNxm * eth / stateEth;
-    uint r = elapsed * stateRatchetSpeed;
+    
+    uint stateNxm = isAbove ? state.nxmA : state.nxmB;
+    uint nxm = stateNxm * eth / state.eth;
+    uint r = elapsed * state.ratchetSpeed;
 
     uint buffer = isAbove ? PRICE_BUFFER_DENOMINATOR + PRICE_BUFFER : PRICE_BUFFER_DENOMINATOR - PRICE_BUFFER;
     uint bufferedCapital = capital * buffer / PRICE_BUFFER_DENOMINATOR;

--- a/contracts/modules/capital/Ramm.sol
+++ b/contracts/modules/capital/Ramm.sol
@@ -178,7 +178,11 @@ contract Ramm is IRamm, MasterAwareV2, ReentrancyGuard {
     Observation[3] memory _observations = observations;
 
     // current state
-    State memory state = _getReserves(initialState, capital, supply, mcrValue, block.timestamp);
+    (
+      State memory state,
+      uint injected,
+      uint extracted
+    ) = _getReserves(initialState, capital, supply, mcrValue, block.timestamp);
     _observations = _updateTwap(initialState, _observations, block.timestamp, capital, supply, mcrValue);
 
     {
@@ -232,7 +236,11 @@ contract Ramm is IRamm, MasterAwareV2, ReentrancyGuard {
     Observation[3] memory _observations = observations;
 
     // current state
-    State memory state = _getReserves(initialState, capital, supply, mcrValue, block.timestamp);
+    (
+      State memory state,
+      uint injected,
+      uint extracted
+    ) = _getReserves(initialState, capital, supply, mcrValue, block.timestamp);
     _observations = _updateTwap(initialState, _observations, block.timestamp, capital, supply, mcrValue);
 
     {
@@ -309,10 +317,17 @@ contract Ramm is IRamm, MasterAwareV2, ReentrancyGuard {
    * @return _budget The current ETH budget used for injection
    */
   function getReserves() external view returns (uint _ethReserve, uint nxmA, uint nxmB, uint _budget) {
+
     uint capital = pool().getPoolValueInEth();
     uint supply = tokenController().totalSupply();
     uint mcrValue = mcr().getMCR();
-    State memory state = _getReserves(loadState(), capital, supply, mcrValue, block.timestamp);
+
+    (
+      State memory state,
+      /* injected */,
+      /* extracted */
+    ) = _getReserves(loadState(), capital, supply, mcrValue, block.timestamp);
+
     return (state.eth, state.nxmA, state.nxmB, state.budget);
   }
 
@@ -437,7 +452,11 @@ contract Ramm is IRamm, MasterAwareV2, ReentrancyGuard {
     uint supply = tokenController().totalSupply();
     uint mcrValue = mcr().getMCR();
 
-    State memory state = _getReserves(loadState(), capital, supply, mcrValue, block.timestamp);
+    (
+      State memory state,
+      /* injected */,
+      /* extracted */
+    ) = _getReserves(loadState(), capital, supply, mcrValue, block.timestamp);
 
     return (
       1 ether * state.eth / state.nxmA,
@@ -633,7 +652,11 @@ contract Ramm is IRamm, MasterAwareV2, ReentrancyGuard {
     Observation[3] memory _observations = observations;
 
     // current state
-    State memory state = _getReserves(initialState, capital, supply, mcrValue, block.timestamp);
+    (
+      State memory state,
+      uint injected,
+      uint extracted
+    ) = _getReserves(initialState, capital, supply, mcrValue, block.timestamp);
     _observations = _updateTwap(initialState, _observations, block.timestamp, capital, supply, mcrValue);
 
     for (uint i = 0; i < _observations.length; i++) {
@@ -675,7 +698,11 @@ contract Ramm is IRamm, MasterAwareV2, ReentrancyGuard {
         continue;
       }
 
-      State memory state = _getReserves(previousState, capital, supply, mcrValue, observationTimestamp);
+      (
+        State memory state,
+        /* injected */,
+        /* extracted */
+      ) = _getReserves(previousState, capital, supply, mcrValue, observationTimestamp);
 
       newObservations[observationIndex] = getObservation(
         previousState,
@@ -702,7 +729,11 @@ contract Ramm is IRamm, MasterAwareV2, ReentrancyGuard {
     Observation[3] memory _observations = observations;
 
     // current state
-    State memory state = _getReserves(initialState, capital, supply, mcrValue, block.timestamp);
+    (
+      State memory state,
+      uint injected,
+      uint extracted
+    ) = _getReserves(initialState, capital, supply, mcrValue, block.timestamp);
     _observations = _updateTwap(initialState, _observations, block.timestamp, capital, supply, mcrValue);
 
     // sstore observations and state
@@ -766,8 +797,12 @@ contract Ramm is IRamm, MasterAwareV2, ReentrancyGuard {
     State memory initialState = loadState();
     Observation[3] memory _observations = observations;
 
-    // current state
-    State memory state = _getReserves(initialState, capital, supply, mcrValue, block.timestamp);
+    (
+      State memory state,
+      /* injected */,
+      /* extracted */
+    ) = _getReserves(initialState, capital, supply, mcrValue, block.timestamp);
+
     _observations = _updateTwap(initialState, _observations, block.timestamp, capital, supply, mcrValue);
 
     return _getInternalPrice(state, _observations, capital, supply, block.timestamp);

--- a/contracts/modules/capital/Ramm.sol
+++ b/contracts/modules/capital/Ramm.sol
@@ -207,6 +207,13 @@ contract Ramm is IRamm, MasterAwareV2, ReentrancyGuard {
 
     storeState(state);
 
+    if (injected > 0) {
+      emit EthInjected(injected);
+    }
+    if (extracted > 0) {
+      emit EthExtracted(extracted);
+    }
+
     for (uint i = 0; i < _observations.length; i++) {
       observations[i] = _observations[i];
     }
@@ -267,6 +274,13 @@ contract Ramm is IRamm, MasterAwareV2, ReentrancyGuard {
     }
 
     storeState(state);
+
+    if (injected > 0) {
+      emit EthInjected(injected);
+    }
+    if (extracted > 0) {
+      emit EthExtracted(extracted);
+    }
 
     for (uint i = 0; i < _observations.length; i++) {
       observations[i] = _observations[i];
@@ -669,6 +683,13 @@ contract Ramm is IRamm, MasterAwareV2, ReentrancyGuard {
     }
 
     storeState(state);
+
+    if (injected > 0) {
+      emit EthInjected(injected);
+    }
+    if (extracted > 0) {
+      emit EthExtracted(extracted);
+    }
   }
 
   function _updateTwap(
@@ -747,6 +768,13 @@ contract Ramm is IRamm, MasterAwareV2, ReentrancyGuard {
     }
 
     storeState(state);
+
+    if (injected > 0) {
+      emit EthInjected(injected);
+    }
+    if (extracted > 0) {
+      emit EthExtracted(extracted);
+    }
 
     return _getInternalPrice(state, _observations, capital, supply, block.timestamp);
   }

--- a/test/integration/Ramm/swap.js
+++ b/test/integration/Ramm/swap.js
@@ -71,7 +71,7 @@ describe('swap', function () {
     const capital = await p1.getPoolValueInEth();
     const supply = await tc.totalSupply();
     const mcrValue = await mcr.getMCR();
-    const state = await ra._getReserves(initState, capital, supply, mcrValue, nextBlockTimestamp);
+    const [state] = await ra._getReserves(initState, capital, supply, mcrValue, nextBlockTimestamp);
     const k = state.eth.mul(state.nxmA);
     const eth = state.eth.add(ethIn);
     const nxmA = k.div(eth);
@@ -121,7 +121,7 @@ describe('swap', function () {
     const capital = await p1.getPoolValueInEth();
     const supply = await tc.totalSupply();
     const mcrValue = await mcr.getMCR();
-    const state = await ra._getReserves(initState, capital, supply, mcrValue, nextBlockTimestamp);
+    const [state] = await ra._getReserves(initState, capital, supply, mcrValue, nextBlockTimestamp);
     const k = state.eth.mul(state.nxmB);
     const nxmB = state.nxmB.add(nxmIn);
     const eth = k.div(nxmB);

--- a/test/unit/Ramm/getInternalPrice.js
+++ b/test/unit/Ramm/getInternalPrice.js
@@ -22,7 +22,7 @@ describe('getInternalPrice', function () {
     }
     const { timestamp } = await ethers.provider.getBlock('latest');
     const currentTimestamp = PERIOD_SIZE.mul(10).add(timestamp);
-    const currentState = await ramm._getReserves(previousState, capital, supply, mcrValue, currentTimestamp);
+    const [currentState] = await ramm._getReserves(previousState, capital, supply, mcrValue, currentTimestamp);
 
     const observations = await ramm._updateTwap(
       previousState,

--- a/test/unit/Ramm/getInternalPriceAndUpdateTwap.js
+++ b/test/unit/Ramm/getInternalPriceAndUpdateTwap.js
@@ -23,7 +23,7 @@ describe('getInternalPriceAndUpdateTwap', function () {
     }
     const { timestamp } = await ethers.provider.getBlock('latest');
     const currentTimestamp = PERIOD_SIZE.mul(10).add(timestamp);
-    const currentState = await ramm._getReserves(previousState, capital, supply, mcrValue, currentTimestamp);
+    const [currentState] = await ramm._getReserves(previousState, capital, supply, mcrValue, currentTimestamp);
 
     const observations = await ramm._updateTwap(
       previousState,

--- a/test/unit/Ramm/getInternalPriceAndUpdateTwap.js
+++ b/test/unit/Ramm/getInternalPriceAndUpdateTwap.js
@@ -4,7 +4,13 @@ const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
 const { getState, setup } = require('./setup');
 const { setNextBlockTime } = require('../../utils/evm');
-const { calculateInternalPrice, getExpectedObservations } = require('./helpers');
+const {
+  calculateEthToExtract,
+  calculateEthToInject,
+  calculateInternalPrice,
+  getExpectedObservations,
+  setEthReserveValue,
+} = require('./helpers');
 
 describe('getInternalPriceAndUpdateTwap', function () {
   it('should return the internal price and update the twap', async function () {
@@ -85,5 +91,41 @@ describe('getInternalPriceAndUpdateTwap', function () {
       .withArgs(obsv2.timestamp, obsv2.priceCumulativeAbove, obsv2.priceCumulativeBelow)
       .to.emit(ramm, 'ObservationUpdated')
       .withArgs(obsv3.timestamp, obsv3.priceCumulativeAbove, obsv3.priceCumulativeBelow);
+  });
+
+  it('should emit EthInjected with the correct ETH injected value', async function () {
+    const fixture = await loadFixture(setup);
+    const { ramm } = fixture.contracts;
+
+    const { timestamp } = await ethers.provider.getBlock('latest');
+    const nextBlockTimestamp = timestamp + 5 * 60;
+
+    // Set ETH reserve < TARGET_LIQUIDITY (5000) to force injection
+    await setEthReserveValue(ramm.address, 4999);
+
+    const state = await ramm.loadState();
+    await setNextBlockTime(nextBlockTimestamp);
+
+    const expectedInjected = await calculateEthToInject(ramm, state, nextBlockTimestamp);
+    console.log('expectedInjected: ', expectedInjected);
+    await expect(ramm.getInternalPriceAndUpdateTwap()).to.emit(ramm, 'EthInjected').withArgs(expectedInjected);
+  });
+
+  it('should emit EthExtracted with the correct ETH extracted value', async function () {
+    const fixture = await loadFixture(setup);
+    const { ramm } = fixture.contracts;
+
+    const { timestamp } = await ethers.provider.getBlock('latest');
+    const nextBlockTimestamp = timestamp + 5 * 60;
+
+    // Set ETH reserve > TARGET_LIQUIDITY (5000) to force extraction
+    await setEthReserveValue(ramm.address, 5001);
+
+    const state = await ramm.loadState();
+    await setNextBlockTime(nextBlockTimestamp);
+
+    const expectedExtracted = await calculateEthToExtract(ramm, state, nextBlockTimestamp);
+    console.log('expectedExtracted: ', expectedExtracted);
+    await expect(ramm.getInternalPriceAndUpdateTwap()).to.emit(ramm, 'EthExtracted').withArgs(expectedExtracted);
   });
 });

--- a/test/unit/Ramm/getObservation.js
+++ b/test/unit/Ramm/getObservation.js
@@ -24,7 +24,7 @@ describe('getObservation', function () {
       ? maxTimeOnRatchetA.add(PERIOD_SIZE)
       : maxTimeOnRatchetB.add(PERIOD_SIZE);
 
-    const state = await ramm._getReserves(
+    const [state] = await ramm._getReserves(
       previousState,
       capital,
       supply,

--- a/test/unit/Ramm/getSpotPrices.js
+++ b/test/unit/Ramm/getSpotPrices.js
@@ -26,7 +26,7 @@ describe('getSpotPrices', function () {
     const supply = await tokenController.totalSupply();
     const mcrValue = await mcr.getMCR();
 
-    const { eth, nxmA, nxmB } = await ramm._getReserves(initialState, capital, supply, mcrValue, nextBlockTimestamp);
+    const [{ eth, nxmA, nxmB }] = await ramm._getReserves(initialState, capital, supply, mcrValue, nextBlockTimestamp);
 
     // buy price
     const expectedSpotPriceA = parseEther('1').mul(eth).div(nxmA);

--- a/test/unit/Ramm/helpers.js
+++ b/test/unit/Ramm/helpers.js
@@ -220,7 +220,7 @@ async function getExpectedObservations(
     const observationIndex = BigNumber.from(i).mod(GRANULARITY);
     const timestamp = Math.min(currentTimestamp.toNumber(), PERIOD_SIZE.mul(i).toNumber());
 
-    const state = await ramm._getReserves(previousState, capital, supply, mcrValue, timestamp);
+    const [state] = await ramm._getReserves(previousState, capital, supply, mcrValue, timestamp);
 
     const observationData = calculateObservation(
       state,

--- a/test/unit/Ramm/helpers.js
+++ b/test/unit/Ramm/helpers.js
@@ -318,7 +318,7 @@ async function setEthReserveValue(rammAddress, valueInEther) {
   // Update Slot1 to have new ethReserve value
   const newSlot1Value = await replaceHexValueInBitPos(slot1Value, newEtherReserve, 128);
   return ethers.provider.send('hardhat_setStorageAt', [rammAddress, SLOT_1_POSITION, newSlot1Value]);
-};
+}
 
 /**
  * Replaces a bit value in a hexadecimal string with a new value at a specific bit position.
@@ -337,7 +337,7 @@ function replaceHexValueInBitPos(origHex, newHexValue, bitPosition) {
   bufferNewVal.copy(bufferOrig, byteStart);
 
   return '0x' + bufferOrig.toString('hex');
-};
+}
 
 module.exports = {
   timeTillBv,

--- a/test/unit/Ramm/storeState.js
+++ b/test/unit/Ramm/storeState.js
@@ -24,7 +24,7 @@ describe('storeState', function () {
     const supply = await tokenController.totalSupply();
     const mcrValue = await mcr.getMCR();
 
-    const before = await ramm._getReserves(initialState, capital, supply, mcrValue, nextBlockTimestamp);
+    const [before] = await ramm._getReserves(initialState, capital, supply, mcrValue, nextBlockTimestamp);
 
     // buy NXM
     await setNextBlockTime(nextBlockTimestamp);

--- a/test/unit/Ramm/swap.js
+++ b/test/unit/Ramm/swap.js
@@ -39,7 +39,8 @@ const getStateAtBlockTimestamp = async (ramm, pool, mcr, tokenController, blockT
   const capital = await pool.getPoolValueInEth();
   const supply = await tokenController.totalSupply();
   const mcrValue = await mcr.getMCR();
-  return ramm._getReserves(initialState, capital, supply, mcrValue, blockTimestamp);
+  const [state] = await ramm._getReserves(initialState, capital, supply, mcrValue, blockTimestamp);
+  return state;
 };
 
 /**

--- a/test/utils/internalPrice.js
+++ b/test/utils/internalPrice.js
@@ -14,7 +14,7 @@ async function getInternalPrice(ramm, pool, tokenController, mcr, timestamp) {
     previousObservations[i] = await ramm.observations(i);
   }
 
-  const currentState = await ramm._getReserves(previousState, capital, supply, mcrValue, timestamp);
+  const [currentState] = await ramm._getReserves(previousState, capital, supply, mcrValue, timestamp);
 
   const observations = await ramm._updateTwap(
     previousState,


### PR DESCRIPTION
## Context

Add EthInjected and EthExtracted to emit the exact values injected / extracted.

The events should only be emitted once per function call and only on mutative functions (i.e. on storeState).

See ticket #993 for the discussion of the solution

#### NOTE:

This is behind PR #1008 

## Changes proposed in this pull request

* Add `EthInjected` & `EthExtracted` events
* Modify **adjustEth** and **_getReserves** to return injected and extracted values
* add emit EthInjected and EthExtracted events to the following mutative functions:
    * swapEthForNxm
    * swapNxmForEth
    * updateTwap
    * getInternalPriceAndUpdateTwap

## Test plan

* ramm.swapEthForNxm EthInjected & EthExtracted events tests
* ramm.swapNxmForEth EthInjected & EthExtracted events tests
* ramm.updateTwap EthInjected & EthExtracted events tests
* ramm.getInternalPriceAndUpdateTwap EthInjected & EthExtracted events tests

## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [x] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback

Closes #993