### PR TITLE
Fix: Add a check on expandDeposit if tokens are locked

### DIFF
--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -1127,7 +1127,7 @@ contract StakingPool is IStakingPool, Multicall {
       revert NotTokenOwnerOrApproved();
     }
 
-    if (block.timestamp <= nxm.isLockedForMV(msg.sender) && topUpAmount > 0) {
+    if (topUpAmount > 0 && block.timestamp <= nxm.isLockedForMV(msg.sender)) {
       revert NxmIsLockedForGovernanceVote();
     }
 

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -1127,7 +1127,7 @@ contract StakingPool is IStakingPool, Multicall {
       revert NotTokenOwnerOrApproved();
     }
 
-    if (block.timestamp <= nxm.isLockedForMV(msg.sender)) {
+    if (block.timestamp <= nxm.isLockedForMV(msg.sender) && topUpAmount > 0) {
       revert NxmIsLockedForGovernanceVote();
     }
 

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -1127,6 +1127,10 @@ contract StakingPool is IStakingPool, Multicall {
       revert NotTokenOwnerOrApproved();
     }
 
+    if (block.timestamp <= nxm.isLockedForMV(msg.sender)) {
+      revert NxmIsLockedForGovernanceVote();
+    }
+
     uint _firstActiveTrancheId = block.timestamp / TRANCHE_DURATION;
 
     {

--- a/test/unit/StakingPool/extendDeposit.js
+++ b/test/unit/StakingPool/extendDeposit.js
@@ -149,14 +149,13 @@ describe('extendDeposit', function () {
     const { firstActiveTrancheId, maxTranche } = await getTranches();
 
     await generateRewards(stakingPool, fixture.coverSigner);
-    const topUpAmount = parseEther('50');
 
     // Simulate member vote lock
-    await nxm.setLock(user.address, topUpAmount);
+    await nxm.setLock(user.address, 3 * 24 * 60 * 60); // 3 days in seconds
 
     const extendDeposit = stakingPool
       .connect(user)
-      .extendDeposit(depositNftId, firstActiveTrancheId, maxTranche, topUpAmount);
+      .extendDeposit(depositNftId, firstActiveTrancheId, maxTranche, parseEther('50'));
 
     await expect(extendDeposit).to.be.revertedWithCustomError(stakingPool, 'NxmIsLockedForGovernanceVote');
   });
@@ -174,8 +173,7 @@ describe('extendDeposit', function () {
     const lastAccNxmUpdateBefore = await stakingPool.getLastAccNxmUpdate();
 
     // Simulate member vote lock
-    const topUpAmount = parseEther('50');
-    await nxm.setLock(user.address, topUpAmount);
+    await nxm.setLock(user.address, 3 * 24 * 60 * 60); // 3 days in seconds);
 
     await stakingPool.connect(user).extendDeposit(depositNftId, firstActiveTrancheId, maxTranche, 0);
 


### PR DESCRIPTION
## Context

Issue: #995 


## Changes proposed in this pull request

Added a check if the token is locked before expanding the deposit


## Test plan

Please describe the tests cases that you ran to verify your changes. Add further instructions on 
how to run them if needed (i.e. migration / deployment scripts, env vars, etc).


## Checklist

- [ ] Rebased the base branch
- [ ] Attached corresponding Github issue
- [ ] Prefixed the name with the type of change (i.e. feat, chore, test)
- [ ] Performed a self-review of my own code
- [ ] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [ ] Didn't generate new warnings
- [ ] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
