### PR TITLE
Add const assertion for generated abis

### DIFF
--- a/deployments/build.js
+++ b/deployments/build.js
@@ -91,10 +91,9 @@ const generateAbisTs = () => {
     const abi = fs.readFileSync(path.join(outDir, 'abis', `${name}.json`));
     // Add `as const` to assert the abi as a readonly object for Wagmi type safety
     // Read more here: https://wagmi.sh/core/typescript#const-assert-abis-typed-data
-    const constAssertedAbi = `export const ${name} = ${abi} as const;`;
-    return constAssertedAbi;
+    return `export const ${name} = ${abi} as const;`;
   });
-  const dict = `export const abis = {\n  ${contractNames.join(',\n  ')}\n};`;
+  const dict = `export const abis = {\n  ${contractNames.join(',\n  ')},\n} as const;`;
 
   const content = [...exports, dict].join('\n') + '\n';
 

--- a/deployments/build.js
+++ b/deployments/build.js
@@ -87,11 +87,16 @@ const generateAbisTs = () => {
 
   const contractNames = contractList.map(contract => (typeof contract === 'string' ? contract : contract[1]));
 
-  const imports = contractNames.map(name => `import ${name} from './abis/${name}.json';`);
-  const exports = contractNames.map(name => `export { default as ${name} } from './abis/${name}.json';`);
+  const exports = contractNames.map(name => {
+    const abi = fs.readFileSync(path.join(outDir, 'abis', `${name}.json`));
+    // Add `as const` to assert the abi as a readonly object for Wagmi type safety
+    // Read more here: https://wagmi.sh/core/typescript#const-assert-abis-typed-data
+    const constAssertedAbi = `export const ${name} = ${abi} as const;`;
+    return constAssertedAbi;
+  });
   const dict = `export const abis = {\n  ${contractNames.join(',\n  ')}\n};`;
 
-  const content = [...imports, ...exports, dict].join('\n') + '\n';
+  const content = [...exports, dict].join('\n') + '\n';
 
   fs.writeFileSync(path.join(outDir, 'abis.ts'), content);
 };


### PR DESCRIPTION
## Context

We need const assertion of the abis for Wagmi type safety on FE.
Read more about this here: https://wagmi.sh/core/typescript#const-assert-abis-typed-data

## Changes proposed in this pull request

Used the JSON abi files to create the abi const-assert object.

## Test plan

Run `npm run deployments:build `.
Check `generated/abis.ts` file. It should contain the abis with const assertion.

## Checklist

- [ ] Rebased the base branch
- [ ] Attached corresponding Github issue
- [ ] Prefixed the name with the type of change (i.e. feat, chore, test)
- [ ] Performed a self-review of my own code
- [ ] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [ ] Didn't generate new warnings
- [ ] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
