### PR TITLE
Chore: testnet address whitelisting

### DIFF
--- a/contracts/mocks/Testnet/TestnetMemberRoles.sol
+++ b/contracts/mocks/Testnet/TestnetMemberRoles.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity ^0.8.18;
+
+import "../../modules/governance/MemberRoles.sol";
+
+contract TestnetMemberRoles is MemberRoles {
+
+  constructor(address tokenAddress) MemberRoles(tokenAddress) {
+  }
+
+  function joinOnTestnet(address _userAddress) public {
+
+    require(!isMember(_userAddress), "MemberRoles: This address is already a member");
+
+    tokenController().addToWhitelist(_userAddress);
+    _updateRole(_userAddress, uint(Role.Member), true);
+
+    emit MemberJoined(_userAddress, 0);
+  }
+
+}

--- a/deployments/build.js
+++ b/deployments/build.js
@@ -40,6 +40,7 @@ const contractList = [
   'TokenController',
   'wNXM',
   'YieldTokenIncidents',
+  'TestnetMemberRoles',
 ];
 
 const updateVersion = () => {

--- a/deployments/package.json
+++ b/deployments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexusmutual/deployments",
-  "version": "2.4.1",
+  "version": "2.4.2-rc.0",
   "description": "Nexus Mutual deployed contract addresses and abis",
   "typings": "./dist/index.d.ts",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "typechain": "hardhat typechain",
     "deployments:build": "node deployments/build.js",
     "deployments:publish:next": "cd deployments && npm publish --access public --tag next",
-    "deployments:publish:latest": "cd deployments && npm publish --access public"
+    "deployments:publish:latest": "cd deployments && npm publish --access public",
+    "deployments:publish:rc": "cd deployments && npm publish --access public --tag rc"
   }
 }

--- a/scripts/deploy/whitelist.js
+++ b/scripts/deploy/whitelist.js
@@ -1,0 +1,22 @@
+const { ethers, artifacts, run } = require('hardhat');
+
+const MR = '0x055CC48f7968FD8640EF140610dd4038e1b03926';
+
+const main = async () => {
+  await run('compile');
+
+  const mrProxy = await ethers.getContractAt('OwnedUpgradeabilityProxy', MR);
+  const mrImplementationAddress = await mrProxy.implementation();
+
+  const { deployedBytecode } = await artifacts.readArtifact('TestnetMemberRoles');
+  await ethers.provider.send('tenderly_setCode', [mrImplementationAddress, deployedBytecode]);
+
+  console.log('MR patched');
+};
+
+main()
+  .then(() => process.exit(0))
+  .catch(error => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/mocks/whitelistAndFundAccounts.js
+++ b/scripts/mocks/whitelistAndFundAccounts.js
@@ -1,0 +1,26 @@
+const { ethers } = require('hardhat');
+
+const MR = '0x055CC48f7968FD8640EF140610dd4038e1b03926';
+
+const accounts = [''];
+
+const main = async () => {
+  const mr = await ethers.getContractAt('TestnetMemberRoles', MR);
+
+  for (const account of accounts) {
+    await mr.joinOnTestnet(account);
+  }
+  console.log('Whitelisted accounts: ', accounts);
+
+  // Funding the accounts
+  const amount = ethers.utils.hexValue(ethers.utils.parseUnits('10000', 'ether').toHexString());
+  await ethers.provider.send('tenderly_addBalance', [accounts, amount]);
+  console.log('Funded accounts: ', accounts);
+};
+
+main()
+  .then(() => process.exit(0))
+  .catch(error => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Context

This PR is based on changes from https://github.com/NexusMutual/smart-contracts/pull/1060. We need to support UI internal testing.

## Changes proposed in this pull request

- it adds the `TestnetMemberRoles` contract to `deployments` package build script so we can use the whitelist method (`joinOnTestnet`) in UI (see proposal PR here: https://github.com/NexusMutual/frontend-next/pull/308) for self-sevice purposes
- it adds a whitelist & funding accounts script under `mocks` if we want/need to manually run these ops


## Test plan

- run `HARDHAT_NETWORK=tenderly node scripts/deploy/whitelist.js` (make sure to set `TENDERLY_PROVIDER_URL` in `.env` to a valid Tenderly Fork RPC URL)
- run `HARDHAT_NETWORK=tenderly node scripts/mocks/whitelistAndFundAccounts.js` 

## Checklist

- [ ] Rebased the base branch
- [ ] Attached corresponding Github issue
- [ ] Prefixed the name with the type of change (i.e. feat, chore, test)
- [ ] Performed a self-review of my own code
- [ ] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [ ] Didn't generate new warnings
- [ ] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
