### PR TITLE
bug: Update missing updates when expiring cover

### DIFF
--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -284,6 +284,16 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard, Mu
         0, // previous premium
         allocationRequest
       );
+
+    }
+
+    uint currentBucketId = block.timestamp / BUCKET_SIZE;
+    uint bucketAtExpiry = Math.divCeil(expiration, BUCKET_SIZE);
+
+    if (currentBucketId < bucketAtExpiry) {
+      // remove cover amount from from expiration buckets and totalActiveCoverInAsset without updating last bucket id
+      activeCoverExpirationBuckets[cover.coverAsset][bucketAtExpiry] -= lastSegment.amount;
+      activeCover[cover.coverAsset].totalActiveCoverInAsset -= lastSegment.amount;
     }
   }
 

--- a/test/integration/Cover/expireCover.js
+++ b/test/integration/Cover/expireCover.js
@@ -90,8 +90,8 @@ describe('expireCover', function () {
 
   it('should expire a cover', async function () {
     const fixture = await loadFixture(expireCoverSetup);
-    const { cover, stakingPool1, ra: ramm } = fixture.contracts;
-    const { BUCKET_DURATION, NXM_PER_ALLOCATION_UNIT } = fixture.config;
+    const { cover, stakingPool1 } = fixture.contracts;
+    const { BUCKET_DURATION } = fixture.config;
     const [coverBuyer] = fixture.accounts.members;
     const { amount, period, productId } = buyCoverFixture;
     const coverBuyerAddress = await coverBuyer.getAddress();
@@ -117,24 +117,15 @@ describe('expireCover', function () {
     const allocationsAfter = await stakingPool1.getActiveAllocations(productId);
 
     await increaseTime(BUCKET_DURATION.toNumber()); // go to next bucket
-    const internalPrice = await ramm.getInternalPrice();
-    await cover
-      .connect(coverBuyer)
-      .buyCover(
-        { ...buyCoverFixture, owner: coverBuyerAddress },
-        [{ poolId: 1, coverAmountInAsset: buyCoverFixture.amount }],
-        { value: amount },
-      );
 
     const totalCoverAmountAfter = await cover.totalActiveCoverInAsset(0);
     const allocationsAfterBucketExpiration = await stakingPool1.getActiveAllocations(productId);
-    const coverAmountInNXM = sum(allocationsAfterBucketExpiration).mul(NXM_PER_ALLOCATION_UNIT);
-    const expectedTotalActiveAmount = internalPrice.mul(coverAmountInNXM).div(parseEther('1'));
 
     expect(sum(allocationsWithCover)).not.to.be.equal(sum(allocationsAfter));
     expect(sum(initialAllocations)).to.be.equal(sum(allocationsAfter));
-    expect(sum(allocationsAfterBucketExpiration)).to.be.equal(sum(allocationsWithCover));
-    expect(totalCoverAmountAfter).to.be.equal(expectedTotalActiveAmount);
+    expect(sum(allocationsAfter)).to.be.equal(0);
+    expect(sum(allocationsAfterBucketExpiration)).to.be.equal(0);
+    expect(totalCoverAmountAfter).to.be.equal(0);
   });
 
   it('should emit an event on expire a cover', async function () {


### PR DESCRIPTION
## Context

There was no space in the Cover.sol contract so we didn't update activeCover in expireCover , we left it to be done when the whole bucket expires. This creates the delay saving in active cover amount.

Issue: #1043


## Changes proposed in this pull request

Add update to `activeCoverExpirationBuckets` and `activeCover` when expiring cover

## Test plan

Please describe the tests cases that you ran to verify your changes. Add further instructions on 
how to run them if needed (i.e. migration / deployment scripts, env vars, etc).


## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [x] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
