### PR TITLE
Add `recalculateActiveCoverInAsset` to Cover contract

### DIFF
--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -127,6 +127,8 @@ interface ICover {
     uint segmentId
   ) external view returns (CoverSegment memory);
 
+  function recalculateActiveCoverInAsset(uint coverAsset) external;
+
   function totalActiveCoverInAsset(uint coverAsset) external view returns (uint);
 
   function globalCapacityRatio() external view returns (uint);

--- a/contracts/mocks/CoverProducts/CoverProductsMockCover.sol
+++ b/contracts/mocks/CoverProducts/CoverProductsMockCover.sol
@@ -126,6 +126,10 @@ contract CoverProductsMockCover is ICover {
     revert("Unsupported");
   }
 
+  function recalculateActiveCoverInAsset(uint) external pure {
+    revert("Unsupported");
+  }
+
   function coverNFT() external pure returns (ICoverNFT) {
     revert("Unsupported");
   }

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -642,6 +642,18 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard, Mu
 
   /* ========== COVER ASSETS HELPERS ========== */
 
+  function recalculateActiveCoverInAsset(uint coverAsset) public {
+    uint lastUpdateBucketId = activeCover[coverAsset].lastBucketUpdateId;
+    uint totalActiveCover = 0;
+
+    for (uint i = 0; i < 52; i++) {
+      uint bucketId = lastUpdateBucketId + i;
+      totalActiveCover += activeCoverExpirationBuckets[coverAsset][bucketId];
+    }
+
+    activeCover[coverAsset].totalActiveCoverInAsset = totalActiveCover.toUint192();
+  }
+
   function totalActiveCoverInAsset(uint assetId) public view returns (uint) {
     return uint(activeCover[assetId].totalActiveCoverInAsset);
   }


### PR DESCRIPTION
## Context

Issue: #1049 

## Changes proposed in this pull request

Add new function that will recalculate bad active cover data


## Test plan

Please describe the tests cases that you ran to verify your changes. Add further instructions on 
how to run them if needed (i.e. migration / deployment scripts, env vars, etc).


## Checklist

- [ ] Rebased the base branch
- [ ] Attached corresponding Github issue
- [ ] Prefixed the name with the type of change (i.e. feat, chore, test)
- [ ] Performed a self-review of my own code
- [ ] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [ ] Didn't generate new warnings
- [ ] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
