### PR TITLE
Add usdc to allowedSafeTransferAssets in SwapOperator

### DIFF
--- a/contracts/modules/capital/SwapOperator.sol
+++ b/contracts/modules/capital/SwapOperator.sol
@@ -83,6 +83,7 @@ contract SwapOperator is ISwapOperator {
     address _enzymeV4VaultProxyAddress,
     address _safe,
     address _dai,
+    address _usdc,
     IEnzymeFundValueCalculatorRouter _enzymeFundValueCalculatorRouter,
     uint _minPoolEth
   ) {
@@ -97,6 +98,7 @@ contract SwapOperator is ISwapOperator {
     minPoolEth = _minPoolEth;
     safe = _safe;
     allowedSafeTransferAssets[_dai] = true;
+    allowedSafeTransferAssets[_usdc] = true;
     allowedSafeTransferAssets[ETH] = true;
   }
 

--- a/test/fork/cover-re.js
+++ b/test/fork/cover-re.js
@@ -268,6 +268,7 @@ describe('coverRe', function () {
       EnzymeAdress.ENZYMEV4_VAULT_PROXY_ADDRESS,
       GNOSIS_SAFE_ADDRESS, // _safe
       Address.DAI_ADDRESS, // _dai
+      Address.USDC_ADDRESS, // _usdc
       EnzymeAdress.ENZYME_FUND_VALUE_CALCULATOR_ROUTER,
       0, // Min Pool ETH
     ]);

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -184,6 +184,7 @@ async function setup() {
     AddressZero, // _enzymeV4VaultProxyAddress
     AddressZero, // _safe
     dai.address, // _dai
+    usdc.address, // _usdc
     AddressZero, // _enzymeFundValueCalculatorRouter
     '0',
   ]);

--- a/test/unit/SwapOperator/setup.js
+++ b/test/unit/SwapOperator/setup.js
@@ -100,6 +100,7 @@ async function setup() {
     enzymeV4Vault.address,
     await owner.getAddress(), // _safe
     dai.address,
+    usdc.address,
     enzymeFundValueCalculatorRouter.address,
     parseEther('1'),
   );


### PR DESCRIPTION
## Context

SwapOperator needs to be able to send usdc from the pool to the Safe

## Changes proposed in this pull request

Add usdc support for safe transfers in the SwapOperator


## Test plan



## Checklist

- [x] Rebased the base branch
- [ ] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
