### PR TITLE
Fix/allowed pools migration

### DIFF
--- a/contracts/interfaces/ILegacyCover.sol
+++ b/contracts/interfaces/ILegacyCover.sol
@@ -12,7 +12,7 @@ interface ILegacyCover {
 
   function productNames(uint productId) external view returns (string memory);
 
-  function allowedPools(uint productId) external view returns (uint[] memory);
+  function allowedPools(uint productId, uint index) external view returns (uint);
 
   function productTypes(uint id) external view returns (ProductType memory);
 

--- a/contracts/modules/cover/CoverProducts.sol
+++ b/contracts/modules/cover/CoverProducts.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.18;
 import "@openzeppelin/contracts-v4/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts-v4/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts-v4/token/ERC20/utils/SafeERC20.sol";
+import "hardhat/console.sol";
 
 import "../../abstract/MasterAwareV2.sol";
 import "../../abstract/Multicall.sol";
@@ -320,7 +321,16 @@ contract CoverProducts is ICoverProducts, MasterAwareV2, Multicall {
     for (uint i = 0; i < _productsToMigrate.length; i++) {
       _products.push(_productsToMigrate[i]);
       productNames[i] = _cover.productNames(i);
-      allowedPools[i] = _cover.allowedPools(i);
+
+      /*
+      * Currently only products with fixed price have allowed pools
+      * And all of them have only one allowed pool that's why we fetch only the first one
+      */
+      if (_productsToMigrate[i].useFixedPrice && !_productsToMigrate[i].isDeprecated) {
+        uint _allowedPool = _cover.allowedPools(i, 0);
+        allowedPools[i] = [_allowedPool];
+      }
+
     }
 
     for (uint i = 0; i < _productTypeCount; i++) {


### PR DESCRIPTION
## Context

Since allowed pool is a mapping of productId and array of poolIds, it needs to be fetched one by one with allowedPools(productId, index). Currently all the products if they have allowed pool they are with fixedPrice and have only one allowed pool, that's why we fetch only the first one.

Also there are 3 products that have fix price, but they are depricated and this one more reason why we don't migrate allowed pools for products that are depricated.


## Changes proposed in this pull request

Modify the `migrateProductsAndProductTypes` to also migrate allowed pools for products that have fixed price and are not depricated


## Test plan

Tests will be included in the fork tests


## Checklist

- [x] Rebased the base branch
- [ ] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [x] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
