### PR TITLE
fix: separate allowed pools from fixed price

### DIFF
--- a/contracts/interfaces/ICoverProducts.sol
+++ b/contracts/interfaces/ICoverProducts.sol
@@ -90,6 +90,7 @@ interface ICoverProducts {
   error InvalidProductType();
   error UnexpectedProductId();
   error PoolNotAllowedForThisProduct(uint productId);
+  error StakingPoolDoesNotExist();
 
   // Cover and payment assets
   error UnsupportedCoverAssets();

--- a/contracts/interfaces/IStakingProducts.sol
+++ b/contracts/interfaces/IStakingProducts.sol
@@ -96,6 +96,8 @@ interface IStakingProducts {
 
   function stakingPool(uint poolId) external view returns (IStakingPool);
 
+  function getStakingPoolCount() external view returns (uint);
+
   function createStakingPool(
     bool isPrivatePool,
     uint initialPoolFee,

--- a/contracts/mocks/generic/StakingProductsGeneric.sol
+++ b/contracts/mocks/generic/StakingProductsGeneric.sol
@@ -53,6 +53,10 @@ contract StakingProductsGeneric is IStakingProducts {
     revert("Unsupported");
   }
 
+  function getStakingPoolCount() external virtual view returns (uint) {
+    revert("Unsupported");
+  }
+
   function createStakingPool(bool, uint, uint, ProductInitializationParams[] calldata, string calldata)
   external virtual returns (uint, address) {
     revert("Unsupported");

--- a/contracts/mocks/modules/Cover/COMockStakingProducts.sol
+++ b/contracts/mocks/modules/Cover/COMockStakingProducts.sol
@@ -120,6 +120,10 @@ contract COMockStakingProducts is StakingProductsGeneric {
     return (poolId, stakingPoolAddress);
   }
 
+  function getStakingPoolCount() external override pure returns (uint) {
+    return 1;
+  }
+
   /* dependencies */
 
   function tokenController() internal view returns (ITokenController) {

--- a/contracts/modules/cover/CoverProducts.sol
+++ b/contracts/modules/cover/CoverProducts.sol
@@ -179,6 +179,7 @@ contract CoverProducts is ICoverProducts, MasterAwareV2, Multicall {
     uint unsupportedCoverAssetsBitmap = type(uint).max;
     uint globalMinPriceRatio = cover().getGlobalMinPriceRatio();
 
+    uint poolCount = stakingProducts().getStakingPoolCount();
     Asset[] memory assets = pool().getAssets();
     uint assetsLength = assets.length;
 
@@ -215,7 +216,11 @@ contract CoverProducts is ICoverProducts, MasterAwareV2, Multicall {
       }
 
       if (param.allowedPools.length > 0) {
-        requirePoolExists(param.allowedPools);
+        for (uint j = 0; j < param.allowedPools.length; j++) {
+          if (param.allowedPools[j] > poolCount) {
+            revert StakingPoolDoesNotExist();
+          }
+        }
       }
 
       // New product has id == uint256.max
@@ -304,15 +309,6 @@ contract CoverProducts is ICoverProducts, MasterAwareV2, Multicall {
     for (uint i = 0; i < productIds.length; i++) {
       if (!isPoolAllowed(productIds[i], poolId) ) {
         revert PoolNotAllowedForThisProduct(productIds[i]);
-      }
-    }
-  }
-
-  function requirePoolExists(uint[] calldata poolIds) internal view {
-    uint poolCount = stakingProducts().getStakingPoolCount();
-    for (uint i = 0; i < poolIds.length; i++) {
-      if (poolIds[i] > poolCount) {
-        revert StakingPoolDoesNotExist();
       }
     }
   }

--- a/contracts/modules/staking/StakingProducts.sol
+++ b/contracts/modules/staking/StakingProducts.sol
@@ -558,6 +558,10 @@ contract StakingProducts is IStakingProducts, MasterAwareV2, Multicall {
     );
   }
 
+  function getStakingPoolCount() external view returns (uint) {
+    return IStakingPoolFactory(stakingPoolFactory).stakingPoolCount();
+  }
+
   function createStakingPool(
     bool isPrivatePool,
     uint initialPoolFee,

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -394,123 +394,23 @@ async function setup() {
     },
   ]);
 
-  const productList = [
-    {
-      productName: 'Product 0',
-      productId: MaxUint256,
-      ipfsMetadata: 'product 0 metadata',
-      product: {
-        productType: 0, // Protocol Cover
-        yieldTokenAddress: AddressZero,
-        coverAssets: 0, // Use fallback
-        initialPriceRatio: 100,
-        capacityReductionRatio: 0,
-        useFixedPrice: false,
-      },
-      allowedPools: [],
+  const defaultProduct = {
+    productName: 'Product 0',
+    productId: MaxUint256,
+    ipfsMetadata: 'product 0 metadata',
+    product: {
+      productType: 0, // Protocol Cover
+      yieldTokenAddress: AddressZero,
+      coverAssets: 0, // Use fallback
+      initialPriceRatio: 100,
+      capacityReductionRatio: 0,
+      useFixedPrice: false,
     },
-    {
-      productName: 'Product 1',
-      productId: MaxUint256,
-      ipfsMetadata: 'product 1 metadata',
-      product: {
-        productType: 1, // Custody Cover
-        yieldTokenAddress: AddressZero,
-        coverAssets: 0, // Use fallback
-        initialPriceRatio: 100,
-        capacityReductionRatio: 0,
-        useFixedPrice: false,
-      },
-      allowedPools: [],
-    },
-    {
-      productName: 'Product 2',
-      productId: MaxUint256,
-      ipfsMetadata: 'product 2 metadata',
-      product: {
-        productType: 2, // Yield Token Cover
-        yieldTokenAddress: ybETH.address,
-        coverAssets: 0b01, // ETH
-        initialPriceRatio: 500,
-        capacityReductionRatio: 0,
-        useFixedPrice: false,
-      },
-      allowedPools: [],
-    },
-    {
-      productName: 'Product 3',
-      productId: MaxUint256,
-      ipfsMetadata: 'product 3 metadata',
-      product: {
-        productType: 2, // Yield Token Cover
-        yieldTokenAddress: ybDAI.address,
-        coverAssets: 0b10, // DAI
-        initialPriceRatio: 100,
-        capacityReductionRatio: 0,
-        useFixedPrice: false,
-      },
-      allowedPools: [],
-    },
-    {
-      productName: 'Product 4',
-      productId: MaxUint256,
-      ipfsMetadata: 'product 4 metadata',
-      product: {
-        productType: 0, // Protocol Cover
-        yieldTokenAddress: AddressZero,
-        coverAssets: 0, // Use fallback
-        initialPriceRatio: 500,
-        capacityReductionRatio: 0,
-        useFixedPrice: true,
-      },
-      allowedPools: [1, 7],
-    },
-    {
-      productName: 'Product 5',
-      productId: MaxUint256,
-      ipfsMetadata: 'product 5 metadata',
-      product: {
-        productType: 2, // Yield Token Cover
-        yieldTokenAddress: ybUSDC.address,
-        coverAssets: 0b10000, // USDC
-        initialPriceRatio: 100,
-        capacityReductionRatio: 0,
-        useFixedPrice: false,
-      },
-      allowedPools: [],
-    },
-    {
-      productName: 'Product 6',
-      productId: MaxUint256,
-      ipfsMetadata: 'product 6 metadata',
-      product: {
-        productType: 0, // Protocol Cover
-        yieldTokenAddress: ybUSDC.address,
-        coverAssets: 0b10000, // use usdc
-        initialPriceRatio: 100,
-        capacityReductionRatio: 0,
-        useFixedPrice: false,
-      },
-      allowedPools: [3],
-    },
-    {
-      productName: 'Product 7',
-      productId: MaxUint256,
-      ipfsMetadata: 'product 7 metadata',
-      product: {
-        productType: 0, // Protocol Cover
-        yieldTokenAddress: AddressZero,
-        coverAssets: 0, // Use fallback
-        initialPriceRatio: 100,
-        capacityReductionRatio: 0,
-        useFixedPrice: true,
-        isDeprecated: true,
-      },
-      allowedPools: [],
-    },
-  ];
+    allowedPools: [],
+  };
 
-  await coverProducts.setProducts(productList);
+  // set default product
+  await coverProducts.setProducts([defaultProduct]);
 
   await gv.changeMasterAddress(master.address);
 
@@ -679,7 +579,7 @@ async function setup() {
   const DEFAULT_PRODUCTS = [product];
   const DEFAULT_POOL_FEE = '5';
 
-  for (let i = 0; i < 5; i++) {
+  for (let i = 0; i < 10; i++) {
     await stakingProducts.connect(stakingPoolManagers[i]).createStakingPool(
       false, // isPrivatePool,
       DEFAULT_POOL_FEE, // initialPoolFee
@@ -694,6 +594,111 @@ async function setup() {
 
     fixture.contracts['stakingPool' + poolId] = stakingPoolInstance;
   }
+
+  // set the rest of the products
+  const productList = [
+    {
+      productName: 'Product 1',
+      productId: MaxUint256,
+      ipfsMetadata: 'product 1 metadata',
+      product: {
+        productType: 1, // Custody Cover
+        yieldTokenAddress: AddressZero,
+        coverAssets: 0, // Use fallback
+        initialPriceRatio: 100,
+        capacityReductionRatio: 0,
+        useFixedPrice: false,
+      },
+      allowedPools: [],
+    },
+    {
+      productName: 'Product 2',
+      productId: MaxUint256,
+      ipfsMetadata: 'product 2 metadata',
+      product: {
+        productType: 2, // Yield Token Cover
+        yieldTokenAddress: ybETH.address,
+        coverAssets: 0b01, // ETH
+        initialPriceRatio: 500,
+        capacityReductionRatio: 0,
+        useFixedPrice: false,
+      },
+      allowedPools: [],
+    },
+    {
+      productName: 'Product 3',
+      productId: MaxUint256,
+      ipfsMetadata: 'product 3 metadata',
+      product: {
+        productType: 2, // Yield Token Cover
+        yieldTokenAddress: ybDAI.address,
+        coverAssets: 0b10, // DAI
+        initialPriceRatio: 100,
+        capacityReductionRatio: 0,
+        useFixedPrice: false,
+      },
+      allowedPools: [],
+    },
+    {
+      productName: 'Product 4',
+      productId: MaxUint256,
+      ipfsMetadata: 'product 4 metadata',
+      product: {
+        productType: 0, // Protocol Cover
+        yieldTokenAddress: AddressZero,
+        coverAssets: 0, // Use fallback
+        initialPriceRatio: 500,
+        capacityReductionRatio: 0,
+        useFixedPrice: true,
+      },
+      allowedPools: [1, 7],
+    },
+    {
+      productName: 'Product 5',
+      productId: MaxUint256,
+      ipfsMetadata: 'product 5 metadata',
+      product: {
+        productType: 2, // Yield Token Cover
+        yieldTokenAddress: ybUSDC.address,
+        coverAssets: 0b10000, // USDC
+        initialPriceRatio: 100,
+        capacityReductionRatio: 0,
+        useFixedPrice: false,
+      },
+      allowedPools: [],
+    },
+    {
+      productName: 'Product 6',
+      productId: MaxUint256,
+      ipfsMetadata: 'product 6 metadata',
+      product: {
+        productType: 0, // Protocol Cover
+        yieldTokenAddress: ybUSDC.address,
+        coverAssets: 0b10000, // use usdc
+        initialPriceRatio: 100,
+        capacityReductionRatio: 0,
+        useFixedPrice: false,
+      },
+      allowedPools: [],
+    },
+    {
+      productName: 'Product 7',
+      productId: MaxUint256,
+      ipfsMetadata: 'product 7 metadata',
+      product: {
+        productType: 0, // Protocol Cover
+        yieldTokenAddress: AddressZero,
+        coverAssets: 0, // Use fallback
+        initialPriceRatio: 100,
+        capacityReductionRatio: 0,
+        useFixedPrice: true,
+        isDeprecated: true,
+      },
+      allowedPools: [],
+    },
+  ];
+
+  await coverProducts.setProducts(productList);
 
   const config = {
     TRANCHE_DURATION: await fixture.contracts.stakingPool1.TRANCHE_DURATION(),
@@ -714,7 +719,7 @@ async function setup() {
   fixture.config = config;
   fixture.accounts = accounts;
   fixture.DEFAULT_PRODUCTS = DEFAULT_PRODUCTS;
-  fixture.productList = productList;
+  fixture.productList = [defaultProduct, ...productList];
 
   return fixture;
 }

--- a/test/unit/Cover/setup.js
+++ b/test/unit/Cover/setup.js
@@ -157,7 +157,7 @@ async function setup() {
         isDeprecated: false,
         useFixedPrice: true,
       },
-      allowedPools: [0],
+      allowedPools: [1],
     },
     {
       productName: 'Product C',
@@ -172,7 +172,7 @@ async function setup() {
         isDeprecated: false,
         useFixedPrice: true,
       },
-      allowedPools: [0],
+      allowedPools: [1],
     },
     {
       productName: 'Product D',

--- a/test/unit/CoverProducts/setProducts.js
+++ b/test/unit/CoverProducts/setProducts.js
@@ -90,6 +90,17 @@ describe('setProducts', function () {
     expect(products.length).to.be.equal(previousProductsCount.add(newProductsCount).toNumber());
   });
 
+  it('should revert if trying to add a product with non existing pool in allowedPools', async function () {
+    const fixture = await loadFixture(setup);
+    const { coverProducts } = fixture;
+    const [advisoryBoardMember0] = fixture.accounts.advisoryBoardMembers;
+    const productParams = { ...productParamsTemplate, allowedPools: [99] };
+    await expect(coverProducts.connect(advisoryBoardMember0).setProducts([productParams])).to.revertedWithCustomError(
+      coverProducts,
+      'StakingPoolDoesNotExist',
+    );
+  });
+
   it('should revert if trying to edit a non-existing product', async function () {
     const fixture = await loadFixture(setup);
     const { coverProducts } = fixture;

--- a/test/utils/accounts.js
+++ b/test/utils/accounts.js
@@ -8,9 +8,9 @@ const assignRoles = accounts => ({
   internalContracts: accounts.slice(15, 20),
   nonInternalContracts: accounts.slice(20, 25),
   governanceContracts: accounts.slice(25, 30),
-  stakingPoolManagers: accounts.slice(30, 35),
-  emergencyAdmin: accounts[35],
-  generalPurpose: accounts.slice(36),
+  stakingPoolManagers: accounts.slice(30, 40),
+  emergencyAdmin: accounts[40],
+  generalPurpose: accounts.slice(41),
 });
 
 const getAccounts = async () => {


### PR DESCRIPTION
## Context

If `useFixedPrice` is set to `false`, while updating product there is no way to change allowed pools

closes #859

## Changes proposed in this pull request

- Remove check for useFixedPrice to add allowed pools
- Add a validation of the allowedPools
- Update the allowedPools for product


## Test plan

- Added a new test for setting the product with invalid allowedPools


## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
