### PR TITLE
Chore: data types namespacing

### DIFF
--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -7,38 +7,17 @@ import "./IStakingNFT.sol";
 import "./IStakingPool.sol";
 import "./ICompleteStakingPoolFactory.sol";
 
-/* ========== DATA STRUCTURES ========== */
+/* io structs */
 
 enum ClaimMethod {
   IndividualClaims,
   YieldTokenIncidents
 }
 
-// Basically CoverStatus from QuotationData.sol but with the extra Migrated status to avoid
-// polluting Cover.sol state layout with new status variables.
-enum LegacyCoverStatus {
-  Active,
-  ClaimAccepted,
-  ClaimDenied,
-  CoverExpired,
-  ClaimSubmitted,
-  Requested,
-  Migrated
-}
-
-/* io structs */
-
 struct PoolAllocationRequest {
   uint40 poolId;
   bool skip;
   uint coverAmountInAsset;
-}
-
-struct RequestAllocationVariables {
-  uint previousPoolAllocationsLength;
-  uint previousPremiumInNXM;
-  uint refund;
-  uint coverAmountInNXM;
 }
 
 struct BuyCoverParams {
@@ -56,6 +35,23 @@ struct BuyCoverParams {
 }
 
 /* storage structs */
+
+struct Product {
+  uint16 productType;
+  address yieldTokenAddress;
+  // cover assets bitmap. each bit represents whether the asset with
+  // the index of that bit is enabled as a cover asset for this product
+  uint32 coverAssets;
+  uint16 initialPriceRatio;
+  uint16 capacityReductionRatio;
+  bool isDeprecated;
+  bool useFixedPrice;
+}
+
+struct ProductType {
+  uint8 claimMethod;
+  uint32 gracePeriod;
+}
 
 struct PoolAllocation {
   uint40 poolId;
@@ -79,31 +75,27 @@ struct CoverSegment {
   uint24 globalCapacityRatio;
 }
 
-struct Product {
-  uint16 productType;
-  address yieldTokenAddress;
-  // cover assets bitmap. each bit represents whether the asset with
-  // the index of that bit is enabled as a cover asset for this product
-  uint32 coverAssets;
-  uint16 initialPriceRatio;
-  uint16 capacityReductionRatio;
-  bool isDeprecated;
-  bool useFixedPrice;
-}
-
-struct ProductType {
-  uint8 claimMethod;
-  uint32 gracePeriod;
-}
-
-struct ActiveCover {
-  // Global active cover amount per asset.
-  uint192 totalActiveCoverInAsset;
-  // The last time activeCoverExpirationBuckets was updated
-  uint64 lastBucketUpdateId;
-}
-
 interface ICover {
+
+  /* ========== DATA STRUCTURES ========== */
+
+  /* internal structs */
+
+  struct RequestAllocationVariables {
+    uint previousPoolAllocationsLength;
+    uint previousPremiumInNXM;
+    uint refund;
+    uint coverAmountInNXM;
+  }
+
+  /* storage structs */
+
+  struct ActiveCover {
+    // Global active cover amount per asset.
+    uint192 totalActiveCoverInAsset;
+    // The last time activeCoverExpirationBuckets was updated
+    uint64 lastBucketUpdateId;
+  }
 
   /* ========== VIEWS ========== */
 

--- a/contracts/interfaces/ICoverBroker.sol
+++ b/contracts/interfaces/ICoverBroker.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-pragma solidity ^0.8.18;
+pragma solidity >=0.5.0;
 
 import "@openzeppelin/contracts-v4/token/ERC20/IERC20.sol";
 

--- a/contracts/interfaces/ICoverProducts.sol
+++ b/contracts/interfaces/ICoverProducts.sol
@@ -4,23 +4,6 @@ pragma solidity >=0.5.0;
 
 import "./ICover.sol";
 
-/* ========== DATA STRUCTURES ========== */
-
-struct ProductParam {
-  string productName;
-  uint productId;
-  string ipfsMetadata;
-  Product product;
-  uint[] allowedPools;
-}
-
-struct ProductTypeParam {
-  string productTypeName;
-  uint productTypeId;
-  string ipfsMetadata;
-  ProductType productType;
-}
-
 struct ProductInitializationParams {
   uint productId;
   uint8 weight;
@@ -29,6 +12,23 @@ struct ProductInitializationParams {
 }
 
 interface ICoverProducts {
+
+  /* ========== IO STRUCTURES ========== */
+
+  struct ProductParam {
+    string productName;
+    uint productId;
+    string ipfsMetadata;
+    Product product;
+    uint[] allowedPools;
+  }
+
+  struct ProductTypeParam {
+    string productTypeName;
+    uint productTypeId;
+    string ipfsMetadata;
+    ProductType productType;
+  }
 
   /* ========== VIEWS ========== */
 

--- a/contracts/interfaces/IIndividualClaims.sol
+++ b/contracts/interfaces/IIndividualClaims.sol
@@ -4,89 +4,89 @@ pragma solidity >=0.5.0;
 
 import "@openzeppelin/contracts-v4/token/ERC721/IERC721Receiver.sol";
 
-enum ClaimStatus { PENDING, ACCEPTED, DENIED }
-
-enum PayoutStatus { PENDING, COMPLETE, UNCLAIMED, DENIED }
-
-enum UintParams {
-  payoutRedemptionPeriodInDays,
-  minAssessmentDepositRatio,
-  maxRewardInNXMWad,
-  rewardRatio
-}
-
-struct Configuration {
-  // Number of days in which payouts can be redeemed
-  uint8 payoutRedemptionPeriodInDays;
-
-  // Ratio out of 1 ETH, used to calculate a flat ETH deposit required for claim submission.
-  // If the claim is accepted, the user will receive the deposit back when the payout is redeemed.
-  // (0-10000 bps i.e. double decimal precision)
-  uint16 minAssessmentDepositRatio;
-
-  // An amount of NXM representing the maximum reward amount given for any claim assessment.
-  uint16 maxRewardInNXMWad;
-
-  // Ratio used to calculate assessment rewards. (0-10000 i.e. double decimal precision).
-  uint16 rewardRatio;
-}
-
-// Holds the requested amount, NXM price, submission fee and other relevant details
-// such as parts of the corresponding cover details and the payout status.
-//
-// This structure has snapshots of claim-time states that are considered moving targets
-// but also parts of cover details that reduce the need of external calls. Everything is fitted
-// in a single word that contains:
-struct Claim {
-  // The index of the assessment, stored in Assessment.sol
-  uint80 assessmentId;
-
-  // The identifier of the cover on which this claim is submitted
-  uint32 coverId;
-
-  // The index of the cover segment on which this claim is submitted
-  uint16 segmentId;
-
-  // Amount requested as part of this claim up to the total cover amount
-  uint96 amount;
-
-  // The index of of the asset address stored at addressOfAsset which is expected at payout.
-  uint8 coverAsset;
-
-  // True if the payout is already redeemed. Prevents further payouts on the claim if it is
-  // accepted.
-  bool payoutRedeemed;
-}
-
-struct ClaimSubmission {
-  // The index of the claim, stored in Claims.sol
-  uint80 claimId;
-  // True when a previous submission exists
-  bool exists;
-}
-
-// Claim structure but in a human-friendly format.
-//
-// Contains aggregated values that give an overall view about the claim and other relevant
-// pieces of information such as cover period, asset symbol etc. This structure is not used in
-// any storage variables.
-struct ClaimDisplay {
-  uint id;
-  uint productId;
-  uint coverId;
-  uint assessmentId;
-  uint amount;
-  string assetSymbol;
-  uint assetIndex;
-  uint coverStart;
-  uint coverEnd;
-  uint pollStart;
-  uint pollEnd;
-  uint claimStatus;
-  uint payoutStatus;
-}
-
 interface IIndividualClaims {
+
+  enum ClaimStatus { PENDING, ACCEPTED, DENIED }
+
+  enum PayoutStatus { PENDING, COMPLETE, UNCLAIMED, DENIED }
+
+  enum UintParams {
+    payoutRedemptionPeriodInDays,
+    minAssessmentDepositRatio,
+    maxRewardInNXMWad,
+    rewardRatio
+  }
+
+  struct Configuration {
+    // Number of days in which payouts can be redeemed
+    uint8 payoutRedemptionPeriodInDays;
+
+    // Ratio out of 1 ETH, used to calculate a flat ETH deposit required for claim submission.
+    // If the claim is accepted, the user will receive the deposit back when the payout is redeemed.
+    // (0-10000 bps i.e. double decimal precision)
+    uint16 minAssessmentDepositRatio;
+
+    // An amount of NXM representing the maximum reward amount given for any claim assessment.
+    uint16 maxRewardInNXMWad;
+
+    // Ratio used to calculate assessment rewards. (0-10000 i.e. double decimal precision).
+    uint16 rewardRatio;
+  }
+
+  // Holds the requested amount, NXM price, submission fee and other relevant details
+  // such as parts of the corresponding cover details and the payout status.
+  //
+  // This structure has snapshots of claim-time states that are considered moving targets
+  // but also parts of cover details that reduce the need of external calls. Everything is fitted
+  // in a single word that contains:
+  struct Claim {
+    // The index of the assessment, stored in Assessment.sol
+    uint80 assessmentId;
+
+    // The identifier of the cover on which this claim is submitted
+    uint32 coverId;
+
+    // The index of the cover segment on which this claim is submitted
+    uint16 segmentId;
+
+    // Amount requested as part of this claim up to the total cover amount
+    uint96 amount;
+
+    // The index of of the asset address stored at addressOfAsset which is expected at payout.
+    uint8 coverAsset;
+
+    // True if the payout is already redeemed. Prevents further payouts on the claim if it is
+    // accepted.
+    bool payoutRedeemed;
+  }
+
+  struct ClaimSubmission {
+    // The index of the claim, stored in Claims.sol
+    uint80 claimId;
+    // True when a previous submission exists
+    bool exists;
+  }
+
+  // Claim structure but in a human-friendly format.
+  //
+  // Contains aggregated values that give an overall view about the claim and other relevant
+  // pieces of information such as cover period, asset symbol etc. This structure is not used in
+  // any storage variables.
+  struct ClaimDisplay {
+    uint id;
+    uint productId;
+    uint coverId;
+    uint assessmentId;
+    uint amount;
+    string assetSymbol;
+    uint assetIndex;
+    uint coverStart;
+    uint coverEnd;
+    uint pollStart;
+    uint pollEnd;
+    uint claimStatus;
+    uint payoutStatus;
+  }
 
   /* ========== VIEWS ========== */
 

--- a/contracts/interfaces/IPooledStaking.sol
+++ b/contracts/interfaces/IPooledStaking.sol
@@ -2,47 +2,47 @@
 
 pragma solidity >=0.5.0;
 
-struct Staker {
-  uint deposit; // total amount of deposit nxm
-  uint reward; // total amount that is ready to be claimed
-  address[] contracts; // list of contracts the staker has staked on
-
-  // staked amounts for each contract
-  mapping(address => uint) stakes;
-
-  // amount pending to be subtracted after all unstake requests will be processed
-  mapping(address => uint) pendingUnstakeRequestsTotal;
-
-  // flag to indicate the presence of this staker in the array of stakers of each contract
-  mapping(address => bool) isInContractStakers;
-}
-
-struct Burn {
-  uint amount;
-  uint burnedAt;
-  address contractAddress;
-}
-
-struct Reward {
-  uint amount;
-  uint rewardedAt;
-  address contractAddress;
-}
-
-struct UnstakeRequest {
-  uint amount;
-  uint unstakeAt;
-  address contractAddress;
-  address stakerAddress;
-  uint next; // id of the next unstake request in the linked list
-}
-
-struct ContractReward {
-  uint amount;
-  uint lastDistributionRound;
-}
-
 interface IPooledStaking {
+
+  struct Staker {
+    uint deposit; // total amount of deposit nxm
+    uint reward; // total amount that is ready to be claimed
+    address[] contracts; // list of contracts the staker has staked on
+
+    // staked amounts for each contract
+    mapping(address => uint) stakes;
+
+    // amount pending to be subtracted after all unstake requests will be processed
+    mapping(address => uint) pendingUnstakeRequestsTotal;
+
+    // flag to indicate the presence of this staker in the array of stakers of each contract
+    mapping(address => bool) isInContractStakers;
+  }
+
+  struct Burn {
+    uint amount;
+    uint burnedAt;
+    address contractAddress;
+  }
+
+  struct Reward {
+    uint amount;
+    uint rewardedAt;
+    address contractAddress;
+  }
+
+  struct UnstakeRequest {
+    uint amount;
+    uint unstakeAt;
+    address contractAddress;
+    address stakerAddress;
+    uint next; // id of the next unstake request in the linked list
+  }
+
+  struct ContractReward {
+    uint amount;
+    uint lastDistributionRound;
+  }
 
   function accumulateReward(address contractAddress, uint amount) external;
 

--- a/contracts/interfaces/IPriceFeedOracle.sol
+++ b/contracts/interfaces/IPriceFeedOracle.sol
@@ -6,12 +6,12 @@ interface Aggregator {
   function latestAnswer() external view returns (int);
 }
 
-struct OracleAsset {
-  Aggregator aggregator;
-  uint8 decimals;
-}
-
 interface IPriceFeedOracle {
+
+  struct OracleAsset {
+    Aggregator aggregator;
+    uint8 decimals;
+  }
 
   function ETH() external view returns (address);
   function assets(address) external view returns (Aggregator, uint8);

--- a/contracts/interfaces/IRamm.sol
+++ b/contracts/interfaces/IRamm.sol
@@ -6,44 +6,44 @@ import "./IPool.sol";
 import "./INXMToken.sol";
 import "./ITokenController.sol";
 
-// storage structs
-
-struct Slot0 {
-  uint128 nxmReserveA;
-  uint128 nxmReserveB;
-}
-
-struct Slot1 {
-  uint128 ethReserve;
-  uint88 budget;
-  uint32 updatedAt;
-  bool swapPaused; // emergency pause
-}
-
-struct Observation {
-  uint32 timestamp;
-  uint112 priceCumulativeAbove;
-  uint112 priceCumulativeBelow;
-}
-
-// memory structs
-
-struct State {
-  uint nxmA;
-  uint nxmB;
-  uint eth;
-  uint budget;
-  uint ratchetSpeedB;
-  uint timestamp;
-}
-
-struct Context {
-  uint capital;
-  uint supply;
-  uint mcr;
-}
-
 interface IRamm {
+
+  // storage structs
+
+  struct Slot0 {
+    uint128 nxmReserveA;
+    uint128 nxmReserveB;
+  }
+
+  struct Slot1 {
+    uint128 ethReserve;
+    uint88 budget;
+    uint32 updatedAt;
+    bool swapPaused; // emergency pause
+  }
+
+  struct Observation {
+    uint32 timestamp;
+    uint112 priceCumulativeAbove;
+    uint112 priceCumulativeBelow;
+  }
+
+  // memory structs
+
+  struct State {
+    uint nxmA;
+    uint nxmB;
+    uint eth;
+    uint budget;
+    uint ratchetSpeedB;
+    uint timestamp;
+  }
+
+  struct Context {
+    uint capital;
+    uint supply;
+    uint mcr;
+  }
 
   struct CumulativePriceCalculationProps {
     uint previousEthReserve;

--- a/contracts/interfaces/IStakingNFTDescriptor.sol
+++ b/contracts/interfaces/IStakingNFTDescriptor.sol
@@ -4,6 +4,12 @@ pragma solidity >=0.5.0;
 
 interface IStakingNFTDescriptor {
 
+  struct StakeData {
+    uint poolId;
+    uint stakeAmount;
+    uint tokenId;
+  }
+
   function tokenURI(uint tokenId) external view returns (string memory);
 
 }

--- a/contracts/interfaces/IStakingPool.sol
+++ b/contracts/interfaces/IStakingPool.sol
@@ -20,22 +20,13 @@ struct AllocationRequest {
   uint globalMinPrice;
 }
 
-struct StakedProductParam {
+struct BurnStakeParams {
+  uint allocationId;
   uint productId;
-  bool recalculateEffectiveWeight;
-  bool setTargetWeight;
-  uint8 targetWeight;
-  bool setTargetPrice;
-  uint96 targetPrice;
+  uint start;
+  uint period;
+  uint deallocationAmount;
 }
-
-  struct BurnStakeParams {
-    uint allocationId;
-    uint productId;
-    uint start;
-    uint period;
-    uint deallocationAmount;
-  }
 
 interface IStakingPool {
 

--- a/contracts/interfaces/IStakingProducts.sol
+++ b/contracts/interfaces/IStakingProducts.sol
@@ -7,6 +7,15 @@ import "./IStakingPool.sol";
 
 interface IStakingProducts {
 
+  struct StakedProductParam {
+    uint productId;
+    bool recalculateEffectiveWeight;
+    bool setTargetWeight;
+    uint8 targetWeight;
+    bool setTargetPrice;
+    uint96 targetPrice;
+  }
+
   struct Weights {
     uint32 totalEffectiveWeight;
     uint32 totalTargetWeight;

--- a/contracts/interfaces/IYieldTokenIncidents.sol
+++ b/contracts/interfaces/IYieldTokenIncidents.sol
@@ -2,60 +2,60 @@
 
 pragma solidity >=0.5.0;
 
-enum IncidentStatus { PENDING, ACCEPTED, DENIED, EXPIRED }
-
-enum UintParams {
-  payoutRedemptionPeriodInDays,
-  expectedPayoutRatio,
-  payoutDeductibleRatio,
-  maxRewardInNXMWad,
-  rewardRatio
-}
-
-struct Configuration {
-  // Number of days in which payouts can be redeemed
-  uint8 payoutRedemptionPeriodInDays;
-
-  // Ratio used to calculate potential payout of an incident
-  // (0-10000 bps i.e. double decimal precision)
-  uint16 expectedPayoutRatio;
-
-  // Ratio used to determine the deductible payout (0-10000 bps i.e. double decimal precision)
-  uint16 payoutDeductibleRatio;
-
-  // An amount of NXM representing the maximum reward amount given for any claim assessment.
-  uint16 maxRewardInNXMWad;
-
-  // Ratio used to calculate assessment rewards (0-10000 i.e. double decimal precision)
-  uint16 rewardRatio;
-}
-
-struct Incident {
-  uint80 assessmentId;
-
-  // Product identifier
-  uint24 productId;
-
-  // Timestamp marking the date of the incident used to verify the user's eligibility for a claim
-  // according to their cover period.
-  uint32 date;
-
-  // The price of the depegged token before the incident that resulted in the depeg.
-  uint96 priceBefore;
-}
-
-struct IncidentDisplay {
-  uint id;
-  uint productId;
-  uint priceBefore;
-  uint incidentDate;
-  uint pollStart;
-  uint pollEnd;
-  uint redeemableUntil;
-  uint status;
-}
-
 interface IYieldTokenIncidents {
+
+  enum IncidentStatus { PENDING, ACCEPTED, DENIED, EXPIRED }
+
+  enum UintParams {
+    payoutRedemptionPeriodInDays,
+    expectedPayoutRatio,
+    payoutDeductibleRatio,
+    maxRewardInNXMWad,
+    rewardRatio
+  }
+
+  struct Configuration {
+    // Number of days in which payouts can be redeemed
+    uint8 payoutRedemptionPeriodInDays;
+
+    // Ratio used to calculate potential payout of an incident
+    // (0-10000 bps i.e. double decimal precision)
+    uint16 expectedPayoutRatio;
+
+    // Ratio used to determine the deductible payout (0-10000 bps i.e. double decimal precision)
+    uint16 payoutDeductibleRatio;
+
+    // An amount of NXM representing the maximum reward amount given for any claim assessment.
+    uint16 maxRewardInNXMWad;
+
+    // Ratio used to calculate assessment rewards (0-10000 i.e. double decimal precision)
+    uint16 rewardRatio;
+  }
+
+  struct Incident {
+    uint80 assessmentId;
+
+    // Product identifier
+    uint24 productId;
+
+    // Timestamp marking the date of the incident used to verify the user's eligibility for a claim
+    // according to their cover period.
+    uint32 date;
+
+    // The price of the depegged token before the incident that resulted in the depeg.
+    uint96 priceBefore;
+  }
+
+  struct IncidentDisplay {
+    uint id;
+    uint productId;
+    uint priceBefore;
+    uint incidentDate;
+    uint pollStart;
+    uint pollEnd;
+    uint redeemableUntil;
+    uint status;
+  }
 
   /* ========== VIEWS ========== */
 

--- a/contracts/mocks/modules/Cover/COMockStakingPool.sol
+++ b/contracts/mocks/modules/Cover/COMockStakingPool.sol
@@ -97,10 +97,6 @@ contract COMockStakingPool is StakingPoolGeneric {
     return premiumPerYear * period / 365 days;
   }
 
-  function setProducts(StakedProductParam[] memory /*params*/) external {
-    activeStake = activeStake;
-  }
-
   function calculatePremium(uint priceRatio, uint coverAmount, uint period) public pure returns (uint) {
     return priceRatio * coverAmount / MAX_PRICE_RATIO * period / 365 days;
   }

--- a/contracts/mocks/modules/Incidents/ICMockCoverProducts.sol
+++ b/contracts/mocks/modules/Incidents/ICMockCoverProducts.sol
@@ -28,7 +28,6 @@ contract ICMockCoverProducts is CoverProductsGeneric {
 
   ProductType[] internal _productTypes;
 
-
   /* === CONSTANTS ==== */
 
   uint public REWARD_BPS = 5000;

--- a/contracts/modules/cover/CoverMigrator.sol
+++ b/contracts/modules/cover/CoverMigrator.sol
@@ -13,6 +13,18 @@ import "../../interfaces/ITokenController.sol";
 /// using the submitClaim claim function.
 contract CoverMigrator is MasterAwareV2 {
 
+  // Basically CoverStatus from QuotationData.sol but with the extra Migrated status to avoid
+  // polluting Cover.sol state layout with new status variables.
+  enum LegacyCoverStatus {
+    Active,
+    ClaimAccepted,
+    ClaimDenied,
+    CoverExpired,
+    ClaimSubmitted,
+    Requested,
+    Migrated
+  }
+
   event CoverMigrated(uint coverIdV1, uint coverIdV2, address newOwner);
 
   // v1

--- a/contracts/modules/staking/StakingNFTDescriptor.sol
+++ b/contracts/modules/staking/StakingNFTDescriptor.sol
@@ -11,12 +11,6 @@ import "../../libraries/DateTime.sol";
 import "../../libraries/FloatingPoint.sol";
 import "../../libraries/StakingPoolLibrary.sol";
 
-struct StakeData {
-  uint poolId;
-  uint stakeAmount;
-  uint tokenId;
-}
-
 contract StakingNFTDescriptor is IStakingNFTDescriptor {
   using Strings for uint;
   using DateTime for uint;


### PR DESCRIPTION
## Context

#1121

## Changes proposed in this pull request

Move enums and structs into their interfaces instead of having them at file level.
The `ClaimMethod` enum and the following structs that were left as is are because they're being referenced in other contracts.

```
ICoverProducts: ProductInitializationParams
IStakingPool: AllocationRequest, BurnStakeParams
IPool: SwapDetails, Asset
ICover: PoolAllocationRequest, BuyCoverParams, Product, ProductType, PoolAllocation, CoverData, CoverSegment
```

Note: There's also a workaround that can be used sometimes to avoid clashes in the future by importing only the desired symbols from the target file using the following syntax: `import { IIndividualClaims } from "./IIndividualClaims.sol";`. This way the `Configuration` struct wouldn't be imported. This won't always work, for example if you import two files while both are importing of everything from `IIndividualClaims.sol`.

## Test plan

Used the following script to generate a file that imports all interfaces:
```bash
cd contracts/interfaces
for i in *; do echo "import \"../../interfaces/$i\";"; done | grep -v IERC20.sol > ../ImportEverything.sol
```

IERC20 is excluded because of the ^0.5.0 pragma which breaks the import as there's more than one IERC20: one for 0.5 pragma, one for 0.8.

The generated contract compiled fine but I don't feel like it's a good idea to add it to git because:
1. It needs to be constantly updated as we add new contracts
2. It's not bulletproof - there can be still structs in other files (besides interfaces)

So instead of slowing down the compilation with newer files we should rather watch out for these issues when reviewing PRs.

## Checklist

- [ ] Rebased the base branch
- [ ] Attached corresponding Github issue
- [ ] Prefixed the name with the type of change (i.e. feat, chore, test)
- [ ] Performed a self-review of my own code
- [ ] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [ ] Didn't generate new warnings
- [ ] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
