### PR TITLE
Feature/manager deposit lock

### DIFF
--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -343,7 +343,7 @@ contract StakingPool is IStakingPool, Multicall {
       revert PrivatePool();
     }
 
-    if (block.timestamp <= nxm.isLockedForMV(msg.sender)) {
+    if (block.timestamp <= nxm.isLockedForMV(msg.sender) && msg.sender != manager()) {
       revert NxmIsLockedForGovernanceVote();
     }
 


### PR DESCRIPTION
## Context

Issue: #802 

## Changes proposed in this pull request

Add a check if the manager is depositing so he's not blocked by the lock


## Test plan

Add a unit test when nxm is locked and manager tries to deposit


## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
