### PR TITLE
fix: Only unlink if file exists

### DIFF
--- a/scripts/products/get-setProducts-txdata.js
+++ b/scripts/products/get-setProducts-txdata.js
@@ -207,7 +207,9 @@ const main = async productsDataFilePath => {
   );
 
   // Clean up the temporary metadata file after successful upload
-  fs.unlinkSync(metadataFilePath);
+  if (fs.existsSync(metadataFilePath)) {
+    fs.unlinkSync(metadataFilePath);
+  }
 
   console.log('Tx input: ', productEntries);
 


### PR DESCRIPTION
## Context

`fs.unlinkSync` throws an error if the metadata file does not exists (i.e. when there is no IPFS data to upload)

## Changes proposed in this pull request

* only call `fs.unlinkSync` if the metadata file path exists

## Test plan

* manually tested on this week's listing


## Checklist

- [x] Rebased the base branch
- [ ] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
