### PR TITLE
Feature: Move ipfs hashes to storage

### DIFF
--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -147,7 +147,7 @@ interface ICover {
   error CoverAmountIsZero();
 
   // Products
-  error ProductDoesntExist();
+  error ProductNotFound();
   error ProductDeprecated();
   error UnexpectedProductId();
 

--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -138,7 +138,6 @@ interface ICover {
   event CoverEdited(uint indexed coverId, uint indexed productId, uint indexed segmentId, address buyer, string ipfsMetadata);
 
   // Auth
-  error OnlyMemberRolesCanOperateTransfer();
   error OnlyOwnerOrApproved();
 
   // Cover details
@@ -149,23 +148,18 @@ interface ICover {
 
   // Products
   error ProductDoesntExist();
-  error ProductTypeNotFound();
-  error ProductDoesntExistOrIsDeprecated();
-  error InvalidProductType();
+  error ProductDeprecated();
   error UnexpectedProductId();
 
   // Cover and payment assets
   error CoverAssetNotSupported();
   error InvalidPaymentAsset();
   error UnexpectedCoverAsset();
-  error UnsupportedCoverAssets();
   error UnexpectedEthSent();
   error EditNotSupported();
 
   // Price & Commission
   error PriceExceedsMaxPremiumInAsset();
-  error InitialPriceRatioBelowGlobalMinPriceRatio();
-  error InitialPriceRatioAbove100Percent();
   error CommissionRateTooHigh();
 
   // ETH transfers
@@ -175,11 +169,8 @@ interface ICover {
   error ReturningEthRemainderToSenderFailed();
 
   // Misc
-  error AlreadyInitialized();
   error ExpiredCoversCannotBeEdited();
   error CoverNotYetExpired(uint coverId);
-  error CoverAlreadyExpired(uint coverId);
   error InsufficientCoverAmountAllocated();
   error UnexpectedPoolId();
-  error CapacityReductionRatioAbove100Percent();
 }

--- a/contracts/interfaces/ICoverProducts.sol
+++ b/contracts/interfaces/ICoverProducts.sol
@@ -34,6 +34,13 @@ struct ProductType {
 
 interface ICoverProducts {
 
+  /* storage structs */
+
+  struct Metadata {
+    string ipfsHash;
+    uint timestamp;
+  }
+
   /* io structs */
 
   struct ProductParam {

--- a/contracts/interfaces/ICoverProducts.sol
+++ b/contracts/interfaces/ICoverProducts.sol
@@ -120,6 +120,7 @@ interface ICoverProducts {
   error PoolNotAllowedForThisProduct(uint productId);
   error StakingPoolDoesNotExist();
   error MismatchedArrayLengths();
+  error MetadataRequired();
 
   // Misc
   error UnsupportedCoverAssets();

--- a/contracts/interfaces/ICoverProducts.sol
+++ b/contracts/interfaces/ICoverProducts.sol
@@ -79,6 +79,14 @@ interface ICoverProducts {
   // add grace period function?
   function getProductWithType(uint productId) external view returns (Product memory, ProductType memory);
 
+  function getLatestProductMetadata(uint productId) external view returns (Metadata memory);
+
+  function getLatestProductTypeMetadata(uint productTypeId) external view returns (Metadata memory);
+
+  function getProductMetadata(uint productId) external view returns (Metadata[] memory);
+
+  function getProductTypeMetadata(uint productTypeId) external view returns (Metadata[] memory);
+
   function getAllowedPools(uint productId) external view returns (uint[] memory _allowedPools);
 
   function getAllowedPoolsCount(uint productId) external view returns (uint);

--- a/contracts/interfaces/ICoverProducts.sol
+++ b/contracts/interfaces/ICoverProducts.sol
@@ -105,30 +105,18 @@ interface ICoverProducts {
 
   /* ========== EVENTS ========== */
 
-  event ProductSet(uint id, string ipfsMetadata);
-  event ProductTypeSet(uint id, string ipfsMetadata);
-
-  // Products
-  error ProductDoesntExist();
+  // Products and product types
+  error ProductNotFound();
   error ProductTypeNotFound();
   error ProductDeprecated();
-  error InvalidProductType();
-  error UnexpectedProductId();
   error PoolNotAllowedForThisProduct(uint productId);
   error StakingPoolDoesNotExist();
-
-  // Cover and payment assets
-  error UnsupportedCoverAssets();
-  error UnexpectedEthSent();
-
-  // Price & Commission
-  error PriceExceedsMaxPremiumInAsset();
-  error TargetPriceBelowGlobalMinPriceRatio();
-  error InitialPriceRatioBelowGlobalMinPriceRatio();
-  error InitialPriceRatioAbove100Percent();
-  error CommissionRateTooHigh();
+  error MismatchedArrayLengths();
 
   // Misc
+  error UnsupportedCoverAssets();
+  error InitialPriceRatioBelowGlobalMinPriceRatio();
+  error InitialPriceRatioAbove100Percent();
   error CapacityReductionRatioAbove100Percent();
 
 }

--- a/contracts/mocks/generic/CoverProductsGeneric.sol
+++ b/contracts/mocks/generic/CoverProductsGeneric.sol
@@ -45,6 +45,22 @@ contract CoverProductsGeneric is ICoverProducts {
     revert("Unsupported");
   }
 
+  function getLatestProductMetadata(uint) external virtual view returns (Metadata memory) {
+    revert("Unsupported");
+  }
+
+  function getLatestProductTypeMetadata(uint) external virtual view returns (Metadata memory) {
+    revert("Unsupported");
+  }
+
+  function getProductMetadata(uint) external virtual view returns (Metadata[] memory) {
+    revert("Unsupported");
+  }
+
+  function getProductTypeMetadata(uint) external virtual view returns (Metadata[] memory) {
+    revert("Unsupported");
+  }
+
   function getAllowedPools(uint) external virtual view returns (uint[] memory) {
     revert("Unsupported");
   }

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -136,7 +136,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard, Mu
       ICoverProducts _coverProducts = coverProducts();
 
       if (_coverProducts.getProductCount() <= params.productId) {
-        revert ProductDoesntExist();
+        revert ProductNotFound();
       }
 
       (

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -145,7 +145,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard, Mu
       ) = _coverProducts.getProductWithType(params.productId);
 
       if (product.isDeprecated) {
-        revert ProductDoesntExistOrIsDeprecated();
+        revert ProductDeprecated();
       }
 
       if (!isCoverAssetSupported(params.coverAsset, product.coverAssets)) {

--- a/contracts/modules/cover/CoverProducts.sol
+++ b/contracts/modules/cover/CoverProducts.sol
@@ -125,7 +125,7 @@ contract CoverProducts is ICoverProducts, MasterAwareV2, Multicall {
       uint productId = productIds[i];
 
       if (productId >= productCount) {
-        revert ProductDoesntExist();
+        revert ProductNotFound();
       }
 
       initialPrices[i] = _products[productId].initialPriceRatio;
@@ -143,7 +143,7 @@ contract CoverProducts is ICoverProducts, MasterAwareV2, Multicall {
       uint productId = productIds[i];
 
       if (productId >= productCount) {
-        revert ProductDoesntExist();
+        revert ProductNotFound();
       }
 
       capacityReductionRatios[i] = _products[productId].capacityReductionRatio;
@@ -166,7 +166,7 @@ contract CoverProducts is ICoverProducts, MasterAwareV2, Multicall {
       uint productId = params[i].productId;
 
       if (productId >= productCount) {
-        revert ProductDoesntExist();
+        revert ProductNotFound();
       }
 
       // if there is a list of allowed pools for this product - the new pool didn't exist yet
@@ -210,7 +210,7 @@ contract CoverProducts is ICoverProducts, MasterAwareV2, Multicall {
       Product calldata product = param.product;
 
       if (product.productType >= _productTypes.length) {
-        revert InvalidProductType();
+        revert ProductTypeNotFound();
       }
 
       if (unsupportedCoverAssetsBitmap & product.coverAssets != 0) {
@@ -250,7 +250,7 @@ contract CoverProducts is ICoverProducts, MasterAwareV2, Multicall {
 
       // Existing product
       if (param.productId >= _products.length) {
-        revert ProductDoesntExist();
+        revert ProductNotFound();
       }
 
       Product storage newProductValue = _products[param.productId];
@@ -301,12 +301,20 @@ contract CoverProducts is ICoverProducts, MasterAwareV2, Multicall {
     uint[] calldata productIds,
     string[] calldata ipfsMetadata
   ) external onlyAdvisoryBoard {
-    require(productIds.length == ipfsMetadata.length, "CoverProducts: length mismatch");
+
+    if (productIds.length != ipfsMetadata.length) {
+      revert MismatchedArrayLengths();
+    }
+
     uint productCount = _products.length;
 
     for (uint i = 0; i < productIds.length; i++) {
       uint productId = productIds[i];
-      require(productId < productCount, "CoverProducts: product does not exist");
+
+      if (productId >= productCount) {
+        revert ProductNotFound();
+      }
+
       productMetadata[productId].push(Metadata(ipfsMetadata[i], block.timestamp));
     }
   }
@@ -315,12 +323,20 @@ contract CoverProducts is ICoverProducts, MasterAwareV2, Multicall {
     uint[] calldata productTypeIds,
     string[] calldata ipfsMetadata
   ) external onlyAdvisoryBoard {
-    require(productTypeIds.length == ipfsMetadata.length, "CoverProducts: length mismatch");
+
+    if (productTypeIds.length != ipfsMetadata.length) {
+      revert MismatchedArrayLengths();
+    }
+
     uint productTypeCount = _productTypes.length;
 
     for (uint i = 0; i < productTypeIds.length; i++) {
       uint productTypeId = productTypeIds[i];
-      require(productTypeId < productTypeCount, "CoverProducts: product type does not exist");
+
+      if (productTypeId >= productTypeCount) {
+        revert ProductTypeNotFound();
+      }
+
       productTypeMetadata[productTypeId].push(Metadata(ipfsMetadata[i], block.timestamp));
     }
   }

--- a/contracts/modules/cover/CoverProducts.sol
+++ b/contracts/modules/cover/CoverProducts.sol
@@ -286,7 +286,7 @@ contract CoverProducts is ICoverProducts, MasterAwareV2, Multicall {
           revert MetadataRequired();
         }
 
-        productTypeMetadata[param.productTypeId].push(Metadata(param.ipfsMetadata, block.timestamp));
+        productTypeMetadata[_productTypes.length].push(Metadata(param.ipfsMetadata, block.timestamp));
         productTypeNames[_productTypes.length] = param.productTypeName;
         _productTypes.push(param.productType);
 
@@ -389,7 +389,7 @@ contract CoverProducts is ICoverProducts, MasterAwareV2, Multicall {
 
   /* ========== DEPENDENCIES ========== */
 
-  function migrateCoverProductsz() external {
+  function migrateCoverProducts() external {
     require(_products.length == 0, "CoverProducts: _products already migrated");
     require(_productTypes.length == 0, "CoverProducts: _productTypes already migrated");
 

--- a/contracts/modules/cover/CoverProducts.sol
+++ b/contracts/modules/cover/CoverProducts.sol
@@ -78,25 +78,25 @@ contract CoverProducts is ICoverProducts, MasterAwareV2, Multicall {
     productType = _productTypes[product.productType];
   }
 
-  function getLatestProductMetadata(uint productId) public view returns (Metadata memory) {
+  function getLatestProductMetadata(uint productId) external view returns (Metadata memory) {
     uint metadataLength = productMetadata[productId].length;
     return metadataLength > 0
       ? productMetadata[productId][metadataLength - 1]
       : Metadata("", 0);
   }
 
-  function getLatestProductTypeMetadata(uint productTypeId) public view returns (Metadata memory) {
+  function getLatestProductTypeMetadata(uint productTypeId) external view returns (Metadata memory) {
     uint metadataLength = productTypeMetadata[productTypeId].length;
     return metadataLength > 0
       ? productTypeMetadata[productTypeId][metadataLength - 1]
       : Metadata("", 0);
   }
 
-  function getProductMetadata(uint productId) public view returns (Metadata[] memory) {
+  function getProductMetadata(uint productId) external view returns (Metadata[] memory) {
     return productMetadata[productId];
   }
 
-  function getProductTypeMetadata(uint productTypeId) public view returns (Metadata[] memory) {
+  function getProductTypeMetadata(uint productTypeId) external view returns (Metadata[] memory) {
     return productTypeMetadata[productTypeId];
   }
 

--- a/contracts/modules/cover/CoverProducts.sol
+++ b/contracts/modules/cover/CoverProducts.sol
@@ -268,8 +268,9 @@ contract CoverProducts is ICoverProducts, MasterAwareV2, Multicall {
         productNames[param.productId] = param.productName;
       }
 
-      // can push empty metadata when updating to "remove" it
-      productMetadata[param.productId].push(Metadata(param.ipfsMetadata, block.timestamp));
+      if (bytes(param.ipfsMetadata).length > 0) {
+        productMetadata[param.productId].push(Metadata(param.ipfsMetadata, block.timestamp));
+      }
     }
   }
 

--- a/scripts/migrate-cover-products-metadata.js
+++ b/scripts/migrate-cover-products-metadata.js
@@ -1,0 +1,59 @@
+require('dotenv').config();
+const fs = require('node:fs/promises');
+const { ethers } = require('hardhat');
+const { addresses } = require('@nexusmutual/deployments');
+
+// run command: HARDHAT_NETWORK=mainnet node scripts/migrate-cover-products-metadata.js
+
+const main = async () => {
+  const LegacyCover = [
+    'event ProductSet(uint256 id, string ipfsMetadata)',
+    'event ProductTypeSet(uint256 id, string ipfsMetadata)',
+  ];
+
+  const cover = await ethers.getContractAt(LegacyCover, addresses.Cover);
+  const coverProducts = await ethers.getContractAt('CoverProducts', ethers.constants.AddressZero);
+
+  const productSetFilter = cover.filters.ProductSet();
+  const productTypesFilter = cover.filters.ProductTypeSet();
+
+  const productSetEvents = await cover.queryFilter(productSetFilter, 16792244); // Cover deploy block
+  const productTypesEvents = await cover.queryFilter(productTypesFilter, 16792244);
+
+  const productsMetadata = productSetEvents
+    .sort((a, b) => a.blockNumber - b.blockNumber)
+    .map(({ blockNumber, args }) => ({ id: args.id.toNumber(), ipfsMetadata: args.ipfsMetadata, blockNumber }))
+    .filter(event => event.ipfsMetadata !== '');
+
+  const productTypesMetadata = productTypesEvents
+    .sort((a, b) => a.blockNumber - b.blockNumber)
+    .map(({ blockNumber, args }) => ({ id: args.id.toNumber(), ipfsMetadata: args.ipfsMetadata, blockNumber }));
+
+  const setProductsMetadataTx = await coverProducts.populateTransaction.setProductsMetadata(
+    productsMetadata.map(({ id }) => id),
+    productsMetadata.map(({ ipfsMetadata }) => ipfsMetadata),
+  );
+
+  const setProductTypesMetadataTx = await coverProducts.populateTransaction.setProductTypesMetadata(
+    productTypesMetadata.map(({ id }) => id),
+    productTypesMetadata.map(({ ipfsMetadata }) => ipfsMetadata),
+  );
+
+  await fs.writeFile('productsMetadata.json', JSON.stringify(productsMetadata, null, 2));
+  await fs.writeFile('productTypesMetadata.json', JSON.stringify(productTypesMetadata, null, 2));
+
+  console.log(`Found ${productsMetadata.length} products ipfs hashes`);
+  console.log(`Found ${productTypesMetadata.length} product types ipfs hashes`);
+
+  console.log('\nSet products metadata tx:', setProductsMetadataTx.data);
+  console.log('\nSet product types metadata tx:', setProductTypesMetadataTx.data);
+};
+
+main()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch(error => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/migrate-cover-products-metadata.js
+++ b/scripts/migrate-cover-products-metadata.js
@@ -20,14 +20,19 @@ const main = async () => {
   const productSetEvents = await cover.queryFilter(productSetFilter, 16792244); // Cover deploy block
   const productTypesEvents = await cover.queryFilter(productTypesFilter, 16792244);
 
-  const productsMetadata = productSetEvents
+  const latestProductsMetadata = productSetEvents
     .sort((a, b) => a.blockNumber - b.blockNumber)
     .map(({ blockNumber, args }) => ({ id: args.id.toNumber(), ipfsMetadata: args.ipfsMetadata, blockNumber }))
-    .filter(event => event.ipfsMetadata !== '');
+    .reduce((acc, item) => ({ ...acc, [item.id]: item }), {});
 
-  const productTypesMetadata = productTypesEvents
+  const productsMetadata = Object.values(latestProductsMetadata).filter(event => event.ipfsMetadata !== '');
+
+  const latestProductTypesMetadata = productTypesEvents
     .sort((a, b) => a.blockNumber - b.blockNumber)
-    .map(({ blockNumber, args }) => ({ id: args.id.toNumber(), ipfsMetadata: args.ipfsMetadata, blockNumber }));
+    .map(({ blockNumber, args }) => ({ id: args.id.toNumber(), ipfsMetadata: args.ipfsMetadata, blockNumber }))
+    .reduce((acc, item) => ({ ...acc, [item.id]: item }), {});
+
+  const productTypesMetadata = Object.values(latestProductTypesMetadata);
 
   const setProductsMetadataTx = await coverProducts.populateTransaction.setProductsMetadata(
     productsMetadata.map(({ id }) => id),

--- a/test/integration/Cover/buyCover.js
+++ b/test/integration/Cover/buyCover.js
@@ -349,7 +349,7 @@ describe('buyCover', function () {
           [{ poolId: 1, coverAmountInAsset: amount }],
           { value: amount },
         ),
-    ).to.revertedWithCustomError(cover, 'ProductDoesntExistOrIsDeprecated');
+    ).to.revertedWithCustomError(cover, 'ProductDeprecated');
   });
 });
 

--- a/test/integration/StakingProducts/setProducts.js
+++ b/test/integration/StakingProducts/setProducts.js
@@ -112,7 +112,7 @@ describe('setProducts', function () {
           productId: nonExistentProductId,
         },
       ]),
-    ).to.be.revertedWithCustomError(coverProducts, 'ProductDoesntExist');
+    ).to.be.revertedWithCustomError(coverProducts, 'ProductNotFound');
   });
 
   it('should fail to set product that is not allowed', async function () {

--- a/test/unit/Cover/buyCover.js
+++ b/test/unit/Cover/buyCover.js
@@ -486,7 +486,7 @@ describe('buyCover', function () {
         poolAllocationRequest,
         { value: '0' },
       ),
-    ).to.be.revertedWithCustomError(cover, 'ProductDoesntExist');
+    ).to.be.revertedWithCustomError(cover, 'ProductNotFound');
   });
 
   it('should revert if cover asset does not exist', async function () {

--- a/test/unit/Cover/buyCover.js
+++ b/test/unit/Cover/buyCover.js
@@ -1436,7 +1436,7 @@ describe('buyCover', function () {
       cover.connect(coverBuyer).buyCover(buyCoverParams, [poolAllocationRequestTemplate], {
         value: expectedPremium,
       }),
-    ).to.be.revertedWithCustomError(cover, 'ProductDoesntExistOrIsDeprecated');
+    ).to.be.revertedWithCustomError(cover, 'ProductDeprecated');
   });
 
   it('should be able to buy cover on a previously deprecated product', async function () {
@@ -1536,6 +1536,6 @@ describe('buyCover', function () {
     // edit cover
     await expect(
       cover.connect(coverBuyer).buyCover(editCoverParams, [poolAllocationRequestTemplate], { value: expectedPremium }),
-    ).to.be.revertedWithCustomError(cover, 'ProductDoesntExistOrIsDeprecated');
+    ).to.be.revertedWithCustomError(cover, 'ProductDeprecated');
   });
 });

--- a/test/unit/CoverProducts/setProductTypes.js
+++ b/test/unit/CoverProducts/setProductTypes.js
@@ -3,8 +3,8 @@ const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 const setup = require('./setup');
 const { resultAsObject } = require('../../utils/').results;
-const { MaxUint256 } = ethers.constants;
 
+const { MaxUint256 } = ethers.constants;
 const ipfsMetadata = 'ipfs metadata';
 
 //  coverProducts.ProductType

--- a/test/unit/CoverProducts/setProductTypesMetadata.js
+++ b/test/unit/CoverProducts/setProductTypesMetadata.js
@@ -1,0 +1,66 @@
+const { ethers } = require('hardhat');
+const { expect } = require('chai');
+const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
+const setup = require('./setup');
+
+describe('setProductTypesMetadata', function () {
+  it('should revert if called by address not on advisory board', async function () {
+    const fixture = await loadFixture(setup);
+    const { coverProducts } = fixture;
+    const [member] = fixture.accounts.members;
+    await expect(coverProducts.connect(member).setProductTypesMetadata([], [])).to.be.revertedWith(
+      'Caller is not an advisory board member',
+    );
+  });
+
+  it('should revert if array lengths differ', async function () {
+    const fixture = await loadFixture(setup);
+    const { coverProducts } = fixture;
+    const [advisoryBoardMember] = fixture.accounts.advisoryBoardMembers;
+    await expect(
+      coverProducts.connect(advisoryBoardMember).setProductTypesMetadata([1, 2], ['']),
+    ).to.be.revertedWithCustomError(coverProducts, 'MismatchedArrayLengths');
+  });
+
+  it('should revert if the product does not exist', async function () {
+    const fixture = await loadFixture(setup);
+    const { coverProducts } = fixture;
+    const [advisoryBoardMember] = fixture.accounts.advisoryBoardMembers;
+    const inexistentProductTypeId = (await coverProducts.getProductTypeCount()).add(7);
+    await expect(
+      coverProducts.connect(advisoryBoardMember).setProductTypesMetadata([inexistentProductTypeId], ['']),
+    ).to.be.revertedWithCustomError(coverProducts, 'ProductTypeNotFound');
+  });
+
+  it('should revert if the ipfs hash is an empty string', async function () {
+    const fixture = await loadFixture(setup);
+    const { coverProducts } = fixture;
+    const [advisoryBoardMember] = fixture.accounts.advisoryBoardMembers;
+    const productTypeId = 0;
+    await expect(
+      coverProducts.connect(advisoryBoardMember).setProductTypesMetadata([productTypeId], ['']),
+    ).to.be.revertedWithCustomError(coverProducts, 'MetadataRequired');
+  });
+
+  it('should push new metadata for product type', async function () {
+    const fixture = await loadFixture(setup);
+    const { coverProducts } = fixture;
+    const [advisoryBoardMember] = fixture.accounts.advisoryBoardMembers;
+
+    const productTypeId = 0;
+    const initialMetadata = await coverProducts.getProductTypeMetadata(productTypeId);
+
+    const tx = await coverProducts.connect(advisoryBoardMember).setProductTypesMetadata([productTypeId], ['ipfs-hash']);
+    const receipt = await tx.wait();
+    const { timestamp } = await ethers.provider.getBlock(receipt.blockNumber);
+
+    const updatedMetadata = await coverProducts.getProductTypeMetadata(productTypeId);
+
+    expect(initialMetadata.length).to.equal(1);
+    expect(updatedMetadata.length).to.equal(2);
+
+    const metadataItem = updatedMetadata[1];
+    expect(metadataItem.ipfsHash).to.equal('ipfs-hash');
+    expect(metadataItem.timestamp).to.equal(timestamp);
+  });
+});

--- a/test/unit/CoverProducts/setProducts.js
+++ b/test/unit/CoverProducts/setProducts.js
@@ -109,7 +109,7 @@ describe('setProducts', function () {
     const productParams = { ...productParamsTemplate, productId };
     await expect(
       coverProducts.connect(advisoryBoardMember0).setProducts([productParams]),
-    ).to.be.revertedWithCustomError(coverProducts, 'ProductDoesntExist');
+    ).to.be.revertedWithCustomError(coverProducts, 'ProductNotFound');
   });
 
   it('should revert if updated coverAssets are unsupported', async function () {
@@ -246,7 +246,7 @@ describe('setProducts', function () {
     const productParams = { ...productParamsTemplate, product: { ...productTemplate, productType: 99 } };
     await expect(
       coverProducts.connect(advisoryBoardMember0).setProducts([productParams]),
-    ).to.be.revertedWithCustomError(coverProducts, 'InvalidProductType');
+    ).to.be.revertedWithCustomError(coverProducts, 'ProductTypeNotFound');
   });
 
   it('should store product name for existing product', async function () {

--- a/test/unit/CoverProducts/setProducts.js
+++ b/test/unit/CoverProducts/setProducts.js
@@ -30,21 +30,50 @@ describe('setProducts', function () {
     allowedPools: [],
   };
 
-  it('should add a single product and emit ProductSet event', async function () {
+  it('should add a single product', async function () {
     const fixture = await loadFixture(setup);
     const { coverProducts } = fixture;
     const [advisoryBoardMember0] = fixture.accounts.advisoryBoardMembers;
     const productParams = { ...productParamsTemplate };
     const expectedProductId = await coverProducts.getProductCount();
-    await expect(coverProducts.connect(advisoryBoardMember0).setProducts([productParams]))
-      .to.emit(coverProducts, 'ProductSet')
-      .withArgs(expectedProductId, defaultIpfsData);
+    await coverProducts.connect(advisoryBoardMember0).setProducts([productParams]);
     const product = resultAsObject(await coverProducts.getProduct(expectedProductId));
     const expectedProduct = productParams.product;
     expect(product).to.deep.equal(expectedProduct);
   });
 
-  it('should edit a single product and emit ProductSet event with updated args', async function () {
+  it('should set the metadata of the newly added product', async function () {
+    const fixture = await loadFixture(setup);
+    const { coverProducts } = fixture;
+    const [advisoryBoardMember0] = fixture.accounts.advisoryBoardMembers;
+    const productParams = { ...productParamsTemplate };
+    const expectedProductId = await coverProducts.getProductCount();
+
+    const tx = await coverProducts.connect(advisoryBoardMember0).setProducts([productParams]);
+    const receipt = await tx.wait();
+    const { timestamp } = await ethers.provider.getBlock(receipt.blockNumber);
+
+    const actualProductMetadata = await coverProducts.getLatestProductMetadata(expectedProductId);
+
+    expect(actualProductMetadata.timestamp).to.be.equal(timestamp);
+    expect(actualProductMetadata.ipfsHash).to.be.equal(productParams.ipfsMetadata);
+  });
+
+  it('should leave the metadata of the newly added product empty', async function () {
+    const fixture = await loadFixture(setup);
+    const { coverProducts } = fixture;
+    const [advisoryBoardMember0] = fixture.accounts.advisoryBoardMembers;
+    const productParams = { ...productParamsTemplate, ipfsMetadata: '' };
+    const expectedProductId = await coverProducts.getProductCount();
+
+    await coverProducts.connect(advisoryBoardMember0).setProducts([productParams]);
+    const actualProductMetadata = await coverProducts.getLatestProductMetadata(expectedProductId);
+
+    expect(actualProductMetadata.ipfsHash).to.be.equal('');
+    expect(actualProductMetadata.timestamp).to.be.equal(0);
+  });
+
+  it('should edit a single product', async function () {
     const fixture = await loadFixture(setup);
     const { coverProducts } = fixture;
     const [advisoryBoardMember0] = fixture.accounts.advisoryBoardMembers;
@@ -55,14 +84,61 @@ describe('setProducts', function () {
     const capacityReductionRatio = 500;
     const product = { ...productParams.product, capacityReductionRatio };
     const productId = (await coverProducts.getProductCount()).sub(1);
-    const ipfsMetadata = 'new ipfs hash';
-    const editParams = { ...productParams, ipfsMetadata, productId, product };
-    await expect(coverProducts.connect(advisoryBoardMember0).setProducts([editParams]))
-      .to.emit(coverProducts, 'ProductSet')
-      .withArgs(productId, ipfsMetadata);
+    const editParams = { ...productParams, productId, product };
+    await coverProducts.connect(advisoryBoardMember0).setProducts([editParams]);
     const actualProduct = resultAsObject(await coverProducts.getProduct(productId));
     const expectedProduct = editParams.product;
     expect(actualProduct).to.deep.equal(expectedProduct);
+  });
+
+  it('should update metadata when editing the product if the new value is empty', async function () {
+    const fixture = await loadFixture(setup);
+    const { coverProducts } = fixture;
+    const [advisoryBoardMember0] = fixture.accounts.advisoryBoardMembers;
+    const expectedProductId = await coverProducts.getProductCount();
+
+    // add
+    const addProductParams = { ...productParamsTemplate };
+    await coverProducts.connect(advisoryBoardMember0).setProducts([addProductParams]);
+
+    // update
+    const newMetadata = ''; // empty
+    const updateProductParams = {
+      ...productParamsTemplate,
+      productId: expectedProductId,
+      ipfsMetadata: newMetadata,
+    };
+    await coverProducts.connect(advisoryBoardMember0).setProducts([updateProductParams]);
+
+    const productMetadata = await coverProducts.getProductMetadata(expectedProductId);
+
+    expect(productMetadata.length).to.be.equal(2);
+    expect(productMetadata[1].ipfsHash).to.be.equal(newMetadata);
+  });
+
+  it('should update metadata when editing the product if the new value is not empty', async function () {
+    const fixture = await loadFixture(setup);
+    const { coverProducts } = fixture;
+    const [advisoryBoardMember0] = fixture.accounts.advisoryBoardMembers;
+    const expectedProductId = await coverProducts.getProductCount();
+
+    // add
+    const addProductParams = { ...productParamsTemplate };
+    await coverProducts.connect(advisoryBoardMember0).setProducts([addProductParams]);
+
+    // update
+    const newMetadata = 'non-empty-ipfs-hash';
+    const updateProductParams = {
+      ...productParamsTemplate,
+      productId: expectedProductId,
+      ipfsMetadata: newMetadata,
+    };
+    await coverProducts.connect(advisoryBoardMember0).setProducts([updateProductParams]);
+
+    const productMetadata = await coverProducts.getProductMetadata(expectedProductId);
+
+    expect(productMetadata.length).to.be.equal(2);
+    expect(productMetadata[1].ipfsHash).to.be.equal(newMetadata);
   });
 
   it('should revert if called by address not on advisory board', async function () {
@@ -83,9 +159,7 @@ describe('setProducts', function () {
     const previousProductsCount = await coverProducts.getProductCount();
     const newProductsCount = 40;
     const productParams = Array.from({ length: newProductsCount }, () => ({ ...productParamsTemplate }));
-    await expect(coverProducts.connect(advisoryBoardMember0).setProducts(productParams))
-      .to.emit(coverProducts, 'ProductSet')
-      .withArgs(40, defaultIpfsData);
+    await coverProducts.connect(advisoryBoardMember0).setProducts(productParams);
     const products = await coverProducts.getProducts();
     expect(products.length).to.be.equal(previousProductsCount.add(newProductsCount).toNumber());
   });
@@ -134,17 +208,14 @@ describe('setProducts', function () {
     const [advisoryBoardMember0] = fixture.accounts.advisoryBoardMembers;
     const productId = await coverProducts.getProductCount();
     const productParams = { ...productParamsTemplate };
-    await expect(coverProducts.connect(advisoryBoardMember0).setProducts([productParams]))
-      .to.emit(coverProducts, 'ProductSet')
-      .withArgs(productId, defaultIpfsData);
-    {
-      const coverAssets = parseInt('1111', 2); // ETH DAI, USDC and WBTC supported
-      const product = { ...productTemplate, coverAssets };
-      const productParams = { ...productParamsTemplate, product, productId };
-      await expect(
-        coverProducts.connect(advisoryBoardMember0).setProducts([productParams]),
-      ).to.be.revertedWithCustomError(coverProducts, 'UnsupportedCoverAssets');
-    }
+    await coverProducts.connect(advisoryBoardMember0).setProducts([productParams]);
+
+    const coverAssets = parseInt('1111', 2); // ETH DAI, USDC and WBTC supported
+    const product = { ...productTemplate, coverAssets };
+    const updatedProductParams = { ...productParamsTemplate, product, productId };
+    await expect(
+      coverProducts.connect(advisoryBoardMember0).setProducts([updatedProductParams]),
+    ).to.be.revertedWithCustomError(coverProducts, 'UnsupportedCoverAssets');
   });
 
   it('should revert if initialPriceRatio > 100', async function () {
@@ -165,17 +236,14 @@ describe('setProducts', function () {
     const [advisoryBoardMember0] = fixture.accounts.advisoryBoardMembers;
     const productId = await coverProducts.getProductCount();
     const productParams = { ...productParamsTemplate };
-    await expect(coverProducts.connect(advisoryBoardMember0).setProducts([productParams]))
-      .to.emit(coverProducts, 'ProductSet')
-      .withArgs(productId, defaultIpfsData);
-    {
-      const initialPriceRatio = priceDenominator + 1;
-      const product = { ...productTemplate, initialPriceRatio };
-      const productParams = { ...productParamsTemplate, product, productId };
-      await expect(
-        coverProducts.connect(advisoryBoardMember0).setProducts([productParams]),
-      ).to.be.revertedWithCustomError(coverProducts, 'InitialPriceRatioAbove100Percent');
-    }
+    await coverProducts.connect(advisoryBoardMember0).setProducts([productParams]);
+
+    const initialPriceRatio = priceDenominator + 1;
+    const product = { ...productTemplate, initialPriceRatio };
+    const updatedProductParams = { ...productParamsTemplate, product, productId };
+    await expect(
+      coverProducts.connect(advisoryBoardMember0).setProducts([updatedProductParams]),
+    ).to.be.revertedWithCustomError(coverProducts, 'InitialPriceRatioAbove100Percent');
   });
 
   it('should revert if initialPriceRatio is below GLOBAL_MIN_PRICE_RATIO', async function () {
@@ -227,9 +295,7 @@ describe('setProducts', function () {
     const [advisoryBoardMember0] = fixture.accounts.advisoryBoardMembers;
     const productId = await coverProducts.getProductCount();
     const productParams = { ...productParamsTemplate };
-    await expect(coverProducts.connect(advisoryBoardMember0).setProducts([productParams]))
-      .to.emit(coverProducts, 'ProductSet')
-      .withArgs(productId, defaultIpfsData);
+    await coverProducts.connect(advisoryBoardMember0).setProducts([productParams]);
 
     const capacityReductionRatio = capacityFactor + 1; // 100.01 %
     const product = { ...productTemplate, capacityReductionRatio };

--- a/test/unit/CoverProducts/setProducts.js
+++ b/test/unit/CoverProducts/setProducts.js
@@ -92,7 +92,7 @@ describe('setProducts', function () {
     expect(actualProduct).to.deep.equal(expectedProduct);
   });
 
-  it('should update metadata when editing the product if the new value is empty', async function () {
+  it('should not update metadata when editing the product if the new value is empty', async function () {
     const fixture = await loadFixture(setup);
     const { coverProducts } = fixture;
     const [advisoryBoardMember0] = fixture.accounts.advisoryBoardMembers;
@@ -112,9 +112,11 @@ describe('setProducts', function () {
     await coverProducts.connect(advisoryBoardMember0).setProducts([updateProductParams]);
 
     const productMetadata = await coverProducts.getProductMetadata(expectedProductId);
+    expect(productMetadata.length).to.be.equal(1);
+    expect(productMetadata[0].ipfsHash).to.be.equal(addProductParams.ipfsMetadata);
 
-    expect(productMetadata.length).to.be.equal(2);
-    expect(productMetadata[1].ipfsHash).to.be.equal(newMetadata);
+    const latestMetadata = await coverProducts.getLatestProductMetadata(expectedProductId);
+    expect(latestMetadata.ipfsHash).to.be.equal(addProductParams.ipfsMetadata);
   });
 
   it('should update metadata when editing the product if the new value is not empty', async function () {

--- a/test/unit/CoverProducts/setProducts.js
+++ b/test/unit/CoverProducts/setProducts.js
@@ -1,7 +1,8 @@
 const { ethers } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
-const setup = require('../Cover/setup');
+const setup = require('./setup');
+
 const { resultAsObject } = require('../utils').results;
 const { AddressZero, MaxUint256 } = ethers.constants;
 

--- a/test/unit/CoverProducts/setProductsMetadata.js
+++ b/test/unit/CoverProducts/setProductsMetadata.js
@@ -1,0 +1,56 @@
+const { ethers } = require('hardhat');
+const { expect } = require('chai');
+const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
+const setup = require('./setup');
+
+describe('setProductsMetadata', function () {
+  it('should revert if called by address not on advisory board', async function () {
+    const fixture = await loadFixture(setup);
+    const { coverProducts } = fixture;
+    const [member] = fixture.accounts.members;
+    await expect(coverProducts.connect(member).setProductsMetadata([], [])).to.be.revertedWith(
+      'Caller is not an advisory board member',
+    );
+  });
+
+  it('should revert if array lengths differ', async function () {
+    const fixture = await loadFixture(setup);
+    const { coverProducts } = fixture;
+    const [advisoryBoardMember] = fixture.accounts.advisoryBoardMembers;
+    await expect(
+      coverProducts.connect(advisoryBoardMember).setProductsMetadata([1, 2], ['']),
+    ).to.be.revertedWithCustomError(coverProducts, 'MismatchedArrayLengths');
+  });
+
+  it('should revert if the product does not exist', async function () {
+    const fixture = await loadFixture(setup);
+    const { coverProducts } = fixture;
+    const [advisoryBoardMember] = fixture.accounts.advisoryBoardMembers;
+    const inexistentProductId = (await coverProducts.getProductCount()).add(7);
+    await expect(
+      coverProducts.connect(advisoryBoardMember).setProductsMetadata([inexistentProductId], ['']),
+    ).to.be.revertedWithCustomError(coverProducts, 'ProductNotFound');
+  });
+
+  it('should push new metadata for product', async function () {
+    const fixture = await loadFixture(setup);
+    const { coverProducts } = fixture;
+    const [advisoryBoardMember] = fixture.accounts.advisoryBoardMembers;
+
+    const productId = 1;
+    const initialMetadata = await coverProducts.getProductMetadata(productId);
+
+    const tx = await coverProducts.connect(advisoryBoardMember).setProductsMetadata([productId], ['ipfs-hash']);
+    const receipt = await tx.wait();
+    const { timestamp } = await ethers.provider.getBlock(receipt.blockNumber);
+
+    const updatedMetadata = await coverProducts.getProductMetadata(productId);
+
+    expect(initialMetadata.length).to.equal(1);
+    expect(updatedMetadata.length).to.equal(2);
+
+    const metadataItem = updatedMetadata[1];
+    expect(metadataItem.ipfsHash).to.equal('ipfs-hash');
+    expect(metadataItem.timestamp).to.equal(timestamp);
+  });
+});

--- a/test/unit/StakingPool/requestAllocation.js
+++ b/test/unit/StakingPool/requestAllocation.js
@@ -1683,7 +1683,7 @@ describe('requestAllocation', function () {
       ),
     ).to.be.revertedWithCustomError(stakingPool, 'InsufficientCapacity');
 
-    stakingPool.connect(fixture.coverSigner).requestAllocation(
+    await stakingPool.connect(fixture.coverSigner).requestAllocation(
       maxCoverAmount, // exact available amount
       previousPremium,
       secondAllocationRequest,


### PR DESCRIPTION
## Context

Up until now the ipfs hashes of the products and product types were emitted as events which made it a bit more difficult for the frontend to fetch them without an indexer. Given those events are only triggered by AB members there aren't a lot of them.


## Changes proposed in this pull request

This PR the ipfs hashes from being emitted as events into contract storage. Those can be added when adding/editing the product or product type or by pushing them individually without a product edit.

## Test plan

Added unit tests for all functions that deal with metadata as well as a migration script that fetches all events from the Cover contract and outputs the tx data that an AB can manually send to set the metadata in the CoverProducts contract.

## Checklist

- [x] Rebased the base branch
- [ ] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
