### PR TITLE
Add decimals function to Aggregator interface

### DIFF
--- a/contracts/interfaces/IPriceFeedOracle.sol
+++ b/contracts/interfaces/IPriceFeedOracle.sol
@@ -3,6 +3,7 @@
 pragma solidity >=0.5.0;
 
 interface Aggregator {
+  function decimals() external view returns (uint8);
   function latestAnswer() external view returns (int);
 }
 


### PR DESCRIPTION
## Context

Add `decimals` function to the `Aggregator` interface in the `IPriceFeedOracle.sol` file so the frontend can read it.