### PR TITLE
feat: Add Assessment.unstakeFor method

### DIFF
--- a/contracts/interfaces/IAssessment.sol
+++ b/contracts/interfaces/IAssessment.sol
@@ -131,6 +131,8 @@ interface IAssessment {
 
   function unstake(uint96 amount, address to) external;
 
+  function unstakeFor(address staker, uint96 amount, address to) external;
+
   function withdrawRewards(
     address user,
     uint104 batchSize
@@ -174,4 +176,20 @@ interface IAssessment {
   event FraudProcessed(uint assessmentId, address assessor, Poll poll);
   event FraudSubmitted(bytes32 root);
 
+  /* ========== ERRORS ========== */
+
+  error InvalidAmount(uint maxUnstakeAmount);
+  error StakeLockedForAssessment(uint lockupExpiry);
+  error StakeLockedForGovernance(uint lockupExpiry);
+  error NotMember(address nonMember);
+  error NoWithdrawableRewards();
+  error InvalidMerkleProof();
+
+  // Votes
+  error AssessmentIdsVotesLengthMismatch();
+  error AssessmentIdsIpfsLengthMismatch();
+  error AlreadyVoted();
+  error StakeRequired();
+  error VotingClosed();
+  error AcceptVoteRequired();
 }

--- a/contracts/interfaces/ITokenController.sol
+++ b/contracts/interfaces/ITokenController.sol
@@ -24,12 +24,48 @@ interface ITokenController {
     uint96 deadline;
   }
 
+  /* ========== VIEWS ========== */
+
+  function token() external view returns (INXMToken);
+
   function coverInfo(uint id) external view returns (
     uint16 claimCount,
     bool hasOpenClaim,
     bool hasAcceptedClaim,
     uint96 requestedPayoutAmount
   );
+
+  function getLockReasons(address _of) external view returns (bytes32[] memory reasons);
+
+  function totalSupply() external view returns (uint);
+
+  function totalBalanceOf(address _of) external view returns (uint amount);
+
+  function totalBalanceOfWithoutDelegations(address _of) external view returns (uint amount);
+
+  function getTokenPrice() external view returns (uint tokenPrice);
+
+  function getPendingRewards(address member) external view returns (uint);
+
+  function tokensLocked(address _of, bytes32 _reason) external view returns (uint256 amount);
+  
+  function getWithdrawableCoverNotes(
+    address coverOwner
+  ) external view returns (
+    uint[] memory coverIds,
+    bytes32[] memory lockReasons,
+    uint withdrawableAmount
+  );
+
+  function getStakingPoolManager(uint poolId) external view returns (address manager);
+
+  function getManagerStakingPools(address manager) external view returns (uint[] memory poolIds);
+
+  function isStakingPoolManager(address member) external view returns (bool);
+
+  function getStakingPoolOwnershipOffer(uint poolId) external view returns (address proposedManager, uint deadline);
+
+  /* ========== MUTATIVE FUNCTIONS ========== */
 
   function withdrawCoverNote(
     address _of,
@@ -53,26 +89,6 @@ interface ITokenController {
 
   function withdrawClaimAssessmentTokens(address[] calldata users) external;
 
-  function getLockReasons(address _of) external view returns (bytes32[] memory reasons);
-
-  function totalSupply() external view returns (uint);
-
-  function totalBalanceOf(address _of) external view returns (uint amount);
-
-  function totalBalanceOfWithoutDelegations(address _of) external view returns (uint amount);
-
-  function getTokenPrice() external view returns (uint tokenPrice);
-
-  function token() external view returns (INXMToken);
-
-  function getStakingPoolManager(uint poolId) external view returns (address manager);
-
-  function getManagerStakingPools(address manager) external view returns (uint[] memory poolIds);
-
-  function isStakingPoolManager(address member) external view returns (bool);
-
-  function getStakingPoolOwnershipOffer(uint poolId) external view returns (address proposedManager, uint deadline);
-
   function transferStakingPoolsOwnership(address from, address to) external;
 
   function assignStakingPoolManager(uint poolId, address manager) external;
@@ -94,16 +110,4 @@ interface ITokenController {
   function burnStakedNXM(uint amount, uint poolId) external;
 
   function stakingPoolNXMBalances(uint poolId) external view returns(uint128 rewards, uint128 deposits);
-
-  function tokensLocked(address _of, bytes32 _reason) external view returns (uint256 amount);
-
-  function getWithdrawableCoverNotes(
-    address coverOwner
-  ) external view returns (
-    uint[] memory coverIds,
-    bytes32[] memory lockReasons,
-    uint withdrawableAmount
-  );
-
-  function getPendingRewards(address member) external view returns (uint);
 }

--- a/contracts/mocks/generic/AssessmentGeneric.sol
+++ b/contracts/mocks/generic/AssessmentGeneric.sol
@@ -17,54 +17,58 @@ contract AssessmentGeneric is IAssessment {
   mapping(address => mapping(uint => bool)) public hasAlreadyVotedOn;
 
   function getAssessmentsCount() external virtual view returns (uint) {
-    revert("Unsupported");
+    revert("getAssessmentsCount unsupported");
   }
 
   function getPoll(uint) external virtual view returns (Poll memory) {
-    revert("Unsupported");
+    revert("getPoll unsupported");
   }
 
-  function getRewards(address) external pure returns (uint, uint, uint) {
-    revert("Unsupported");
+  function getRewards(address) external virtual view returns (uint, uint, uint) {
+    revert("getRewards unsupported");
   }
 
   function getVoteCountOfAssessor(address) external virtual view returns (uint) {
-    revert("Unsupported");
+    revert("getVoteCountOfAssessor unsupported");
   }
 
   function stake(uint96) external pure {
-    revert("Unsupported");
+    revert("stake unsupported");
   }
 
   function unstake(uint96, address) external pure {
-    revert("Unsupported");
+    revert("unstake unsupported");
+  }
+
+  function unstakeFor(address, uint96, address) external pure {
+    revert("unstakeFor unsupported");
   }
 
   function withdrawRewards(address, uint104) external virtual returns (uint, uint) {
-    revert("Unsupported");
+    revert("withdrawRewards unsupported");
   }
 
   function withdrawRewardsTo(address, uint104) external virtual returns (uint, uint) {
-    revert("Unsupported");
+    revert("withdrawRewardsTo unsupported");
   }
 
   function startAssessment(uint, uint) external virtual returns (uint) {
-    revert("Unsupported");
+    revert("startAssessment unsupported");
   }
 
   function castVotes(uint[] calldata, bool[] calldata, string[] calldata, uint96) external virtual pure {
-    revert("Unsupported");
+    revert("castVotes unsupported");
   }
 
   function submitFraud(bytes32) external pure {
-    revert("Unsupported");
+    revert("submitFraud unsupported");
   }
 
   function processFraud(uint256, bytes32[] calldata, address, uint256, uint96, uint16, uint256) external pure {
-    revert("Unsupported");
+    revert("processFraud unsupported");
   }
 
   function updateUintParameters(UintParams[] calldata, uint[] calldata) external pure {
-    revert("Unsupported");
+    revert("updateUintParameters unsupported");
   }
 }

--- a/contracts/mocks/generic/TokenControllerGeneric.sol
+++ b/contracts/mocks/generic/TokenControllerGeneric.sol
@@ -15,123 +15,123 @@ contract TokenControllerGeneric is ITokenController {
     uint[] calldata,
     uint[] calldata
   ) external pure {
-    revert("Unsupported");
+    revert("withdrawCoverNote unsupported");
   }
 
   function changeOperator(address) external pure {
-    revert("Unsupported");
+    revert("changeOperator unsupported");
   }
 
   function operatorTransfer(address, address, uint) external virtual returns (bool) {
-    revert("Unsupported");
+    revert("operatorTransfer unsupported");
   }
 
   function burnFrom(address, uint) external virtual returns (bool) {
-    revert("Unsupported");
+    revert("burnFrom unsupported");
   }
 
   function addToWhitelist(address) external virtual {
-    revert("Unsupported");
+    revert("addToWhitelist unsupported");
   }
 
   function removeFromWhitelist(address) external virtual {
-    revert("Unsupported");
+    revert("removeFromWhitelist unsupported");
   }
 
   function mint(address, uint) external virtual {
-    revert("Unsupported");
+    revert("mint unsupported");
   }
 
   function lockForMemberVote(address, uint) external pure {
-    revert("Unsupported");
+    revert("lockForMemberVote unsupported");
   }
 
   function withdrawClaimAssessmentTokens(address[] calldata) external pure {
-    revert("Unsupported");
+    revert("withdrawClaimAssessmentTokens unsupported");
   }
 
   function getLockReasons(address) external pure returns (bytes32[] memory) {
-    revert("Unsupported");
+    revert("getLockReasons unsupported");
   }
 
   function totalSupply() external virtual view returns (uint) {
-    revert("Unsupported");
+    revert("totalSupply unsupported");
   }
 
   function totalBalanceOf(address) external pure returns (uint) {
-    revert("Unsupported");
+    revert("totalBalanceOf unsupported");
   }
 
   function totalBalanceOfWithoutDelegations(address) external pure returns (uint) {
-    revert("Unsupported");
+    revert("totalBalanceOfWithoutDelegations unsupported");
   }
 
   function getTokenPrice() external pure returns (uint) {
-    revert("Unsupported");
+    revert("getTokenPrice unsupported");
   }
 
   function getStakingPoolManager(uint) external virtual view returns (address) {
-    revert("Unsupported");
+    revert("getStakingPoolManager unsupported");
   }
 
   function getManagerStakingPools(address) external pure returns (uint[] memory) {
-    revert("Unsupported");
+    revert("getManagerStakingPools unsupported");
   }
 
   function isStakingPoolManager(address) external virtual view returns (bool) {
-    revert("Unsupported");
+    revert("isStakingPoolManager unsupported");
   }
 
   function getStakingPoolOwnershipOffer(uint) external pure returns (address, uint) {
-    revert("Unsupported");
+    revert("getStakingPoolOwnershipOffer unsupported");
   }
 
   function transferStakingPoolsOwnership(address, address) external virtual {
-    revert("Unsupported");
+    revert("transferStakingPoolsOwnership unsupported");
   }
 
   function assignStakingPoolManager(uint, address) external virtual {
-    revert("Unsupported");
+    revert("assignStakingPoolManager unsupported");
   }
 
   function createStakingPoolOwnershipOffer(uint, address, uint) external pure {
-    revert("Unsupported");
+    revert("createStakingPoolOwnershipOffer unsupported");
   }
 
   function acceptStakingPoolOwnershipOffer(uint) external pure {
-    revert("Unsupported");
+    revert("acceptStakingPoolOwnershipOffer unsupported");
   }
 
   function cancelStakingPoolOwnershipOffer(uint) external pure {
-    revert("Unsupported");
+    revert("cancelStakingPoolOwnershipOffer unsupported");
   }
 
   function mintStakingPoolNXMRewards(uint, uint) external virtual {
-    revert("Unsupported");
+    revert("mintStakingPoolNXMRewards unsupported");
   }
 
   function burnStakingPoolNXMRewards(uint, uint) external virtual {
-    revert("Unsupported");
+    revert("burnStakingPoolNXMRewards unsupported");
   }
 
   function depositStakedNXM(address, uint, uint) external virtual {
-    revert("Unsupported");
+    revert("depositStakedNXM unsupported");
   }
 
   function withdrawNXMStakeAndRewards(address, uint, uint, uint) external virtual {
-    revert("Unsupported");
+    revert("withdrawNXMStakeAndRewards unsupported");
   }
 
   function burnStakedNXM(uint, uint) external virtual {
-    revert("Unsupported");
+    revert("burnStakedNXM unsupported");
   }
 
   function stakingPoolNXMBalances(uint) external virtual view returns(uint128, uint128) {
-    revert("Unsupported");
+    revert("stakingPoolNXMBalances unsupported");
   }
 
   function tokensLocked(address, bytes32) external virtual view returns (uint256) {
-    revert("Unsupported");
+    revert("tokensLocked unsupported");
   }
 
   function getWithdrawableCoverNotes(address) external virtual view returns (
@@ -139,10 +139,10 @@ contract TokenControllerGeneric is ITokenController {
     bytes32[] memory,
     uint
   ) {
-    revert("Unsupported");
+    revert("getWithdrawableCoverNotes unsupported");
   }
 
   function getPendingRewards(address) external virtual view returns (uint) {
-    revert("Unsupported");
+    revert("getPendingRewards unsupported");
   }
 }

--- a/contracts/mocks/modules/AssessmentViewer/AVMockAssessment.sol
+++ b/contracts/mocks/modules/AssessmentViewer/AVMockAssessment.sol
@@ -2,13 +2,10 @@
 
 pragma solidity >=0.5.0;
 
-import {IAssessment} from "../../../interfaces/IAssessment.sol";
+import {AssessmentGeneric} from "../../generic/AssessmentGeneric.sol";
 
-contract AVMockAssessment is IAssessment {
+contract AVMockAssessment is AssessmentGeneric {
 
-  Configuration public override config;
-  mapping(address => Stake) public override stakeOf;
-  mapping(address => Vote[]) public override votesOf;
   uint totalPendingAmountInNXM;
   uint withdrawableAmountInNXM;
   uint withdrawableUntilIndex;
@@ -64,61 +61,5 @@ contract AVMockAssessment is IAssessment {
 
   function getRewards(address) external view override returns (uint, uint, uint) {
     return (totalPendingAmountInNXM, withdrawableAmountInNXM, withdrawableUntilIndex);
-  }
-
-  /* ========== NOT YET IMPLEMENTED ========== */
-
-  function getAssessmentsCount() external pure override returns (uint) {
-    revert("getAssessmentsCount not yet implemented");
-  }
-
-  function assessments(uint) external pure override returns (Poll memory, uint128, uint128) {
-    revert("assessments not yet implemented");
-  }
-
-  function getPoll(uint) external pure override returns (Poll memory) {
-    revert("getPoll not yet implemented");
-  }
-
-  function hasAlreadyVotedOn(address, uint) external pure override returns (bool) {
-    revert("hasAlreadyVotedOn not yet implemented");
-  }
-
-  /* === MUTATIVE FUNCTIONS ==== */
-
-  function stake(uint96) external pure override {
-    revert("stake not yet implemented");
-  }
-
-  function unstake(uint96, address) external pure override {
-    revert("unstake not yet implemented");
-  }
-
-  function withdrawRewards(address, uint104) external pure override returns (uint, uint) {
-    revert("withdrawRewards not yet implemented");
-  }
-
-  function withdrawRewardsTo(address, uint104) external pure override returns (uint, uint) {
-    revert("withdrawRewardsTo not yet implemented");
-  }
-
-  function startAssessment(uint, uint) external pure override returns (uint) {
-    revert("startAssessment not yet implemented");
-  }
-
-  function castVotes(uint[] calldata, bool[] calldata, string[] calldata, uint96) external pure override {
-    revert("castVotes not yet implemented");
-  }
-
-  function submitFraud(bytes32) external pure override {
-    revert("submitFraud not yet implemented");
-  }
-
-  function processFraud(uint256, bytes32[] calldata, address, uint256, uint96, uint16, uint256) external pure override {
-    revert("processFraud not yet implemented");
-  }
-
-  function updateUintParameters(UintParams[] calldata, uint[] calldata) external pure override {
-    revert("updateUintParameters not yet implemented");
   }
 }

--- a/contracts/modules/assessment/Assessment.sol
+++ b/contracts/modules/assessment/Assessment.sol
@@ -132,7 +132,7 @@ contract Assessment is IAssessment, MasterAwareV2 {
   /// @param to      The member address where the NXM is transfered to. Useful for switching
   ///                membership during stake lockup period and thus allowing the user to withdraw
   ///                their staked amount to the new address when possible.
-  function unstake(uint96 amount, address to) external whenNotPaused {
+  function unstake(uint96 amount, address to) external override whenNotPaused {
     _unstake(msg.sender, amount, to);
   }
 
@@ -145,7 +145,7 @@ contract Assessment is IAssessment, MasterAwareV2 {
   /// @param to      The member address where the NXM is transfered to. Useful for switching
   ///                membership during stake lockup period and thus allowing the user to withdraw
   ///                their staked amount to the new address when possible.
-  function unstakeFor(address staker, uint96 amount, address to) external whenNotPaused {
+  function unstakeFor(address staker, uint96 amount, address to) external override whenNotPaused {
     _unstake(staker, amount, to);
   }
 

--- a/test/unit/Assessment/helpers.js
+++ b/test/unit/Assessment/helpers.js
@@ -125,7 +125,7 @@ const finalizePoll = async assessment => {
   const { timestamp } = await ethers.provider.getBlock('latest');
   const { minVotingPeriodInDays, payoutCooldownInDays } = await assessment.config();
 
-  await setTime(timestamp + daysToSeconds(minVotingPeriodInDays + payoutCooldownInDays));
+  await setTime(timestamp + daysToSeconds(minVotingPeriodInDays + payoutCooldownInDays) + 1);
 };
 
 const generateRewards = async ({ assessment, individualClaims, staker }) => {

--- a/test/unit/Assessment/processFraud.js
+++ b/test/unit/Assessment/processFraud.js
@@ -32,9 +32,8 @@ describe('processFraud', function () {
         fraudCount: 0,
         merkleTree,
       });
-      await expect(
-        assessment.processFraud(0, proof, honestMember.address, 0, parseEther('100'), 0, 100),
-      ).to.be.revertedWith('Invalid merkle proof');
+      const processFraud = assessment.processFraud(0, proof, honestMember.address, 0, parseEther('100'), 0, 100);
+      await expect(processFraud).to.be.revertedWithCustomError(assessment, 'InvalidMerkleProof');
     }
 
     {
@@ -45,9 +44,8 @@ describe('processFraud', function () {
         fraudCount: 0,
         merkleTree,
       });
-      await expect(
-        assessment.processFraud(0, proof, fraudulentMember.address, 0, parseEther('200'), 0, 100),
-      ).to.be.revertedWith('Invalid merkle proof');
+      const processFraud = assessment.processFraud(0, proof, fraudulentMember.address, 0, parseEther('200'), 0, 100);
+      await expect(processFraud).to.be.revertedWithCustomError(assessment, 'InvalidMerkleProof');
     }
 
     {
@@ -58,9 +56,8 @@ describe('processFraud', function () {
         fraudCount: 1,
         merkleTree,
       });
-      await expect(
-        assessment.processFraud(0, proof, fraudulentMember.address, 1, parseEther('100'), 0, 100),
-      ).to.be.revertedWith('Invalid merkle proof');
+      const processFraud = assessment.processFraud(0, proof, fraudulentMember.address, 1, parseEther('100'), 0, 100);
+      await expect(processFraud).to.be.revertedWithCustomError(assessment, 'InvalidMerkleProof');
     }
 
     {
@@ -71,9 +68,8 @@ describe('processFraud', function () {
         fraudCount: 0,
         merkleTree,
       });
-      await expect(
-        assessment.processFraud(0, proof, fraudulentMember.address, 0, parseEther('100'), 0, 100),
-      ).not.to.be.revertedWith('Invalid merkle proof');
+      const processFraud = assessment.processFraud(0, proof, fraudulentMember.address, 0, parseEther('100'), 0, 100);
+      await expect(processFraud).to.not.be.revertedWithCustomError(assessment, 'InvalidMerkleProof');
     }
   });
 

--- a/test/unit/Assessment/unstakeFor.js
+++ b/test/unit/Assessment/unstakeFor.js
@@ -7,33 +7,33 @@ const { setup } = require('./setup');
 const { parseEther } = ethers.utils;
 const ONE_DAY_SECONDS = 24 * 60 * 60;
 
-describe('unstake', function () {
-  it("decreases the user's stake", async function () {
+describe('unstakeFor', function () {
+  it("decreases the staker's stake", async function () {
     const fixture = await loadFixture(setup);
     const { assessment } = fixture.contracts;
-    const user = fixture.accounts.members[0];
+    const [user, otherUser] = fixture.accounts.members;
     await assessment.connect(user).stake(parseEther('100'));
 
     {
-      await assessment.connect(user).unstake(parseEther('10'), user.address);
+      await assessment.connect(otherUser).unstakeFor(user.address, parseEther('10'), user.address);
       const { amount } = await assessment.stakeOf(user.address);
       expect(amount).to.be.equal(parseEther('90'));
     }
 
     {
-      await assessment.connect(user).unstake(parseEther('10'), user.address);
+      await assessment.connect(otherUser).unstakeFor(user.address, parseEther('10'), user.address);
       const { amount } = await assessment.stakeOf(user.address);
       expect(amount).to.be.equal(parseEther('80'));
     }
 
     {
-      await assessment.connect(user).unstake(parseEther('30'), user.address);
+      await assessment.connect(otherUser).unstakeFor(user.address, parseEther('30'), user.address);
       const { amount } = await assessment.stakeOf(user.address);
       expect(amount).to.be.equal(parseEther('50'));
     }
 
     {
-      await assessment.connect(user).unstake(parseEther('50'), user.address);
+      await assessment.connect(otherUser).unstakeFor(user.address, parseEther('50'), user.address);
       const { amount } = await assessment.stakeOf(user.address);
       expect(amount).to.be.equal(parseEther('0'));
     }
@@ -47,14 +47,14 @@ describe('unstake', function () {
 
     {
       const nxmBalanceBefore = await nxm.balanceOf(user1.address);
-      await assessment.connect(user1).unstake(parseEther('50'), user1.address);
+      await assessment.connect(user1).unstakeFor(user1.address, parseEther('50'), user1.address);
       const nxmBalanceAfter = await nxm.balanceOf(user1.address);
       expect(nxmBalanceAfter).to.be.equal(nxmBalanceBefore.add(parseEther('50')));
     }
 
     {
       const nxmBalanceBefore = await nxm.balanceOf(user2.address);
-      await assessment.connect(user1).unstake(parseEther('50'), user2.address);
+      await assessment.connect(user1).unstakeFor(user1.address, parseEther('50'), user2.address);
       const nxmBalanceAfter = await nxm.balanceOf(user2.address);
       expect(nxmBalanceAfter).to.be.equal(nxmBalanceBefore.add(parseEther('50')));
     }
@@ -63,7 +63,7 @@ describe('unstake', function () {
   it("reverts if less than stakeLockupPeriodInDays passed since the staker's last vote", async function () {
     const fixture = await loadFixture(setup);
     const { assessment, individualClaims } = fixture.contracts;
-    const user = fixture.accounts.members[0];
+    const [user, otherUser] = fixture.accounts.members;
     const amount = parseEther('100');
 
     await assessment.connect(user).stake(amount);
@@ -72,37 +72,38 @@ describe('unstake', function () {
     const { timestamp } = await ethers.provider.getBlock('latest'); // store the block.timestamp on time of vote
     await assessment.connect(user).castVotes([0], [true], ['Assessment data hash'], 0);
 
-    const unstakeBeforeExpiry = assessment.connect(user).unstake(amount, user.address);
-    await expect(unstakeBeforeExpiry).to.be.revertedWithCustomError(assessment, 'StakeLockedForAssessment');
+    const unstakeForBeforeExpiry = assessment.connect(otherUser).unstakeFor(user.address, amount, user.address);
+    await expect(unstakeForBeforeExpiry).to.be.revertedWithCustomError(assessment, 'StakeLockedForAssessment');
 
     const { stakeLockupPeriodInDays } = await assessment.config();
     for (let dayCount = 1; dayCount < stakeLockupPeriodInDays; dayCount++) {
       await setTime(timestamp + dayCount * ONE_DAY_SECONDS);
-      const unstake = assessment.connect(user).unstake(amount, user.address);
-      await expect(unstake).to.be.revertedWithCustomError(assessment, 'StakeLockedForAssessment');
+      const unstakeFor = assessment.connect(otherUser).unstakeFor(user.address, amount, user.address);
+      await expect(unstakeFor).to.be.revertedWithCustomError(assessment, 'StakeLockedForAssessment');
     }
 
     await setTime(timestamp + stakeLockupPeriodInDays * ONE_DAY_SECONDS);
-    const unstakeAtExpiry = assessment.connect(user).unstake(amount, user.address);
-    await expect(unstakeAtExpiry).to.be.revertedWithCustomError(assessment, 'StakeLockedForAssessment');
+    const unstakeForAtExpiry = assessment.connect(otherUser).unstakeFor(user.address, amount, user.address);
+    await expect(unstakeForAtExpiry).to.be.revertedWithCustomError(assessment, 'StakeLockedForAssessment');
   });
 
   it('reverts if system is paused', async function () {
     const fixture = await loadFixture(setup);
     const { assessment, master } = fixture.contracts;
-    const [user] = fixture.accounts.members;
+    const [user, otherUser] = fixture.accounts.members;
     await master.setEmergencyPause(true);
 
-    await expect(assessment.unstake(parseEther('100'), user.address)).to.revertedWith('System is paused');
+    const unstakeFor = assessment.connect(otherUser).unstakeFor(user.address, parseEther('100'), user.address);
+    await expect(unstakeFor).to.be.revertedWith('System is paused');
   });
 
   it('does not revert if amount is 0', async function () {
     const fixture = await loadFixture(setup);
     const { assessment } = fixture.contracts;
-    const user = fixture.accounts.members[0];
+    const [user, otherUser] = fixture.accounts.members;
     await assessment.connect(user).stake(parseEther('100'));
 
-    await expect(assessment.connect(user).unstake(0, user.address)).to.not.reverted;
+    await expect(assessment.connect(otherUser).unstakeFor(user.address, 0, user.address)).to.not.be.reverted;
   });
 
   it('reverts with InvalidAmount user has no stake to unstake', async function () {
@@ -114,15 +115,15 @@ describe('unstake', function () {
     await expect(unstake).to.be.revertedWithCustomError(assessment, 'InvalidAmount').withArgs(0);
   });
 
-  it('reverts with InvalidAmount if amount is bigger than the stake', async function () {
+  it('reverts if amount is bigger than the stake', async function () {
     const fixture = await loadFixture(setup);
     const { assessment } = fixture.contracts;
-    const [user] = fixture.accounts.members;
+    const [user, otherUser] = fixture.accounts.members;
     const stakeAmount = parseEther('100');
     await assessment.connect(user).stake(stakeAmount);
 
-    const unstake = assessment.connect(user).unstake(stakeAmount.add(1), user.address);
-    await expect(unstake).to.be.revertedWithCustomError(assessment, 'InvalidAmount').withArgs(stakeAmount);
+    const unstakeFor = assessment.connect(otherUser).unstakeFor(user.address, stakeAmount.add(1), user.address);
+    await expect(unstakeFor).to.be.revertedWithCustomError(assessment, 'InvalidAmount').withArgs(stakeAmount);
   });
 
   it('emits StakeWithdrawn event with staker, destination and amount', async function () {
@@ -133,20 +134,20 @@ describe('unstake', function () {
 
     {
       const amount = parseEther('10');
-      await expect(assessment.connect(user1).unstake(amount, user1.address))
+      await expect(assessment.connect(user1).unstakeFor(user1.address, amount, user1.address))
         .to.emit(assessment, 'StakeWithdrawn')
         .withArgs(user1.address, user1.address, amount);
     }
 
     {
       const amount = parseEther('20');
-      await expect(assessment.connect(user1).unstake(amount, user2.address))
+      await expect(assessment.connect(user1).unstakeFor(user1.address, amount, user2.address))
         .to.emit(assessment, 'StakeWithdrawn')
         .withArgs(user1.address, user2.address, amount);
     }
   });
 
-  it('reverts if attempting to stake while NXM is locked for voting in governance', async function () {
+  it('reverts if attempting to unstake while NXM is locked for voting in governance', async function () {
     const fixture = await loadFixture(setup);
     const { nxm, assessment } = fixture.contracts;
     const [user, otherUser] = fixture.accounts.members;
@@ -154,21 +155,21 @@ describe('unstake', function () {
     await assessment.connect(user).stake(parseEther('100'));
     await nxm.setLock(user.address, 100);
 
-    const unstake = assessment.connect(user).unstake(parseEther('100'), otherUser.address);
-    await expect(unstake).to.be.revertedWithCustomError(assessment, 'StakeLockedForGovernance');
+    const unstakeFor = assessment.connect(otherUser).unstakeFor(user.address, parseEther('100'), otherUser.address);
+    await expect(unstakeFor).to.be.revertedWithCustomError(assessment, 'StakeLockedForGovernance');
   });
 
   it('allows to unstake to own address while NXM is locked for voting in governance', async function () {
     const fixture = await loadFixture(setup);
     const { nxm, assessment } = fixture.contracts;
-    const [user] = fixture.accounts.members;
+    const [user, otherUser] = fixture.accounts.members;
     const amount = parseEther('100');
 
     await assessment.connect(user).stake(amount);
     const balanceBefore = await nxm.balanceOf(user.address);
 
     await nxm.setLock(user.address, 100);
-    await assessment.connect(user).unstake(amount, user.address);
+    await assessment.connect(otherUser).unstakeFor(user.address, amount, user.address);
 
     const balanceAfter = await nxm.balanceOf(user.address);
     expect(balanceAfter).to.be.equal(balanceBefore.add(amount));

--- a/test/unit/Assessment/withdrawRewards.js
+++ b/test/unit/Assessment/withdrawRewards.js
@@ -15,10 +15,11 @@ describe('withdrawRewards', function () {
     const fixture = await loadFixture(setup);
     const { assessment } = fixture.contracts;
     const [user] = fixture.accounts.members;
+
     await assessment.connect(user).stake(parseEther('10'));
-    await expect(assessment.connect(user).withdrawRewards(user.address, 0)).to.be.revertedWith(
-      'No withdrawable rewards',
-    );
+
+    const withdrawRewards = assessment.connect(user).withdrawRewards(user.address, 0);
+    await expect(withdrawRewards).to.be.revertedWithCustomError(assessment, 'NoWithdrawableRewards');
   });
 
   it("allows any address to call but the reward is withdrawn to the staker's address", async function () {
@@ -206,9 +207,8 @@ describe('withdrawRewards', function () {
 
     await generateRewards({ assessment, individualClaims, staker });
 
-    await expect(assessment.connect(staker).withdrawRewards(nonMember.address, 0)).to.be.revertedWith(
-      'Destination address is not a member',
-    );
+    const withdrawRewards = assessment.connect(staker).withdrawRewards(nonMember.address, 0);
+    await expect(withdrawRewards).to.be.revertedWithCustomError(assessment, 'NotMember').withArgs(nonMember.address);
   });
 
   it('reverts if assessment rewards already claimed', async function () {
@@ -233,9 +233,8 @@ describe('withdrawRewards', function () {
     expect(stakerBalanceAfter).to.be.equal(stakerBalanceBefore.add(totalRewardInNXM));
     expect(stakeOfAfter.rewardsWithdrawableFromIndex).to.be.equal(stakeOfBefore.rewardsWithdrawableFromIndex.add(1));
 
-    await expect(assessment.connect(staker).withdrawRewards(staker.address, 0)).to.be.revertedWith(
-      'No withdrawable rewards',
-    );
+    const withdrawRewards = assessment.connect(staker).withdrawRewards(staker.address, 0);
+    await expect(withdrawRewards).to.be.revertedWithCustomError(assessment, 'NoWithdrawableRewards');
   });
 
   it('withdraws zero amount if poll is not final', async function () {

--- a/test/unit/Assessment/withdrawRewardsTo.js
+++ b/test/unit/Assessment/withdrawRewardsTo.js
@@ -13,10 +13,11 @@ describe('withdrawRewardsTo', function () {
     const fixture = await loadFixture(setup);
     const { assessment } = fixture.contracts;
     const [user] = fixture.accounts.members;
+
     await assessment.connect(user).stake(parseEther('10'));
-    await expect(assessment.connect(user).withdrawRewardsTo(user.address, 0)).to.be.revertedWith(
-      'No withdrawable rewards',
-    );
+
+    const withdrawRewardsTo = assessment.connect(user).withdrawRewardsTo(user.address, 0);
+    await expect(withdrawRewardsTo).to.be.revertedWithCustomError(assessment, 'NoWithdrawableRewards');
   });
 
   it('reverts when not called by the owner of the rewards ', async function () {
@@ -32,10 +33,10 @@ describe('withdrawRewardsTo', function () {
     const { totalRewardInNXM } = await assessment.assessments(0);
     const nonMemberBalanceBefore = await nxm.balanceOf(nonMember.address);
     const stakerBalanceBefore = await nxm.balanceOf(staker.address);
-    await setNextBlockBaseFee('0');
-    await expect(
-      assessment.connect(nonMember).withdrawRewardsTo(staker.address, 0, { gasPrice: 0 }),
-    ).to.be.revertedWith('No withdrawable rewards');
+
+    const withdrawRewardsTo = assessment.connect(nonMember).withdrawRewardsTo(staker.address, 0);
+    await expect(withdrawRewardsTo).to.be.revertedWithCustomError(assessment, 'NoWithdrawableRewards');
+
     await setNextBlockBaseFee('0');
     await expect(assessment.connect(staker).withdrawRewardsTo(staker.address, 0, { gasPrice: 0 })).not.to.be.reverted;
     const nonMemberBalanceAfter = await nxm.balanceOf(nonMember.address);
@@ -198,7 +199,7 @@ describe('withdrawRewardsTo', function () {
     const fixture = await loadFixture(setup);
     const { assessment, individualClaims } = fixture.contracts;
     const [user1] = fixture.accounts.members;
-    const nonMember = '0xDECAF00000000000000000000000000000000000';
+    const nonMember = '0xDeCAf00000000000000000000000000000000000';
 
     await individualClaims.connect(user1).submitClaim(0, 0, parseEther('100'), '');
     await assessment.connect(user1).stake(parseEther('10'));
@@ -206,9 +207,8 @@ describe('withdrawRewardsTo', function () {
 
     await finalizePoll(assessment);
 
-    await expect(assessment.connect(user1).withdrawRewardsTo(nonMember, 0)).to.be.revertedWith(
-      'Destination address is not a member',
-    );
+    const withdrawRewardsTo = assessment.connect(user1).withdrawRewardsTo(nonMember, 0);
+    await expect(withdrawRewardsTo).to.be.revertedWithCustomError(assessment, 'NotMember').withArgs(nonMember);
   });
 
   it('should withdraw multiple rewards consecutively', async function () {
@@ -338,9 +338,8 @@ describe('withdrawRewardsTo', function () {
     expect(stakerBalanceAfter).to.be.equal(stakerBalanceBefore.add(totalRewardInNXM));
     expect(stakeOfAfter.rewardsWithdrawableFromIndex).to.be.equal(stakeOfBefore.rewardsWithdrawableFromIndex.add(1));
 
-    await expect(assessment.connect(staker).withdrawRewardsTo(staker.address, 0)).to.be.revertedWith(
-      'No withdrawable rewards',
-    );
+    const withdrawRewardsTo = assessment.connect(staker).withdrawRewardsTo(staker.address, 0);
+    await expect(withdrawRewardsTo).to.be.revertedWithCustomError(assessment, 'NoWithdrawableRewards');
   });
 
   it('withdraws zero amount if poll is not final', async function () {


### PR DESCRIPTION
## Context

Relates to: https://github.com/NexusMutual/smart-contracts/issues/1173

The methods for withdrawing NXM need to support address params so that another contract can do a batch withdrawal on behalf of the user.

Below is the list of methods (only `unstakeFor` is not implemented):

* `AS.unstakeFor`
* TC.withdrawPendingRewards
* stakingPool(poolId).withdraw
* TC.withdrawCoverNote
* TC.withdrawClaimAssessmentTokens
* legacyPooledStaking.withdrawForUser
* legacyPooledStaking.withdrawReward

NOTE: this PR is behind https://github.com/NexusMutual/smart-contracts/pull/1164

## Changes proposed in this pull request

* add `unstakeFor`
* replace Assessment requires with custom errors
* add / update unit tests
* chore
  * add Views / Mutative Function sections to ITokenController
  * add method name on revert for TokenControllerGeneric for clarity

## Test plan

* add `unstakeFor` unit tests
* update Assessment unit tests for custom errrors

## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
