### PR TITLE
Fix: skip deallocations when burning in grace period

### DIFF
--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -1213,7 +1213,7 @@ contract StakingPool is IStakingPool, Multicall {
       emit StakeBurned(amount);
     }
 
-    // do not deallocate if in grace period
+    // do not deallocate if the cover has expired (grace period)
     if (params.start + params.period <= block.timestamp) {
       return;
     }


### PR DESCRIPTION
## Context

When a burn is triggered while the cover is in grace period the deallocation is redundant since it will be done when the bucket expiration is processed.

## Changes proposed in this pull request

The newly added code skips deallocations if the cover is expired.

## Test plan

Added a test to ensure the allocations stay the same.

## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
