### PR TITLE
Feat: Move staking pool metadata

### DIFF
--- a/contracts/interfaces/IStakingPool.sol
+++ b/contracts/interfaces/IStakingPool.sol
@@ -57,8 +57,7 @@ interface IStakingPool {
     bool isPrivatePool,
     uint initialPoolFee,
     uint maxPoolFee,
-    uint _poolId,
-    string memory ipfsDescriptionHash
+    uint _poolId
   ) external;
 
   function processExpirations(bool updateUntilCurrentTimestamp) external;
@@ -163,8 +162,6 @@ interface IStakingPool {
   event PoolPrivacyChanged(address indexed manager, bool isPrivate);
 
   event PoolFeeChanged(address indexed manager, uint newFee);
-
-  event PoolDescriptionSet(string ipfsDescriptionHash);
 
   event Withdraw(address indexed user, uint indexed tokenId, uint tranche, uint amountStakeWithdrawn, uint amountRewardsWithdrawn);
 

--- a/contracts/interfaces/IStakingProducts.sol
+++ b/contracts/interfaces/IStakingProducts.sol
@@ -47,6 +47,8 @@ interface IStakingProducts {
     uint bumpedPriceUpdateTime
   );
 
+  function getPoolManager(uint poolId) external view returns (address);
+
   /* ============= PRICING FUNCTIONS ============= */
 
   function getPremium(
@@ -116,6 +118,12 @@ interface IStakingProducts {
   ) external returns (uint poolId, address stakingPoolAddress);
 
   function changeStakingPoolFactoryOperator(address newOperator) external;
+
+  function setPoolMetadata(uint poolId, string memory ipfsHash) external;
+
+  function getPoolMetadata(uint poolId) external returns (string memory ipfsHash);
+
+  function setInitialMetadata(string[] calldata ipfsHashes) external;
 
   /* ============= EVENTS ============= */
 

--- a/contracts/mocks/generic/StakingPoolGeneric.sol
+++ b/contracts/mocks/generic/StakingPoolGeneric.sol
@@ -6,7 +6,7 @@ import "../../interfaces/IStakingPool.sol";
 
 contract StakingPoolGeneric is IStakingPool {
 
-  function initialize(bool, uint, uint, uint, string memory) external virtual {
+  function initialize(bool, uint, uint, uint) external virtual {
     revert("Unsupported");
   }
 

--- a/contracts/mocks/generic/StakingProductsGeneric.sol
+++ b/contracts/mocks/generic/StakingProductsGeneric.sol
@@ -28,6 +28,10 @@ contract StakingProductsGeneric is IStakingProducts {
     revert("Unsupported");
   }
 
+  function getPoolManager(uint) public pure override returns (address) {
+    revert("Unsupported");
+  }
+
   function getPremium(uint, uint, uint, uint, uint, uint, uint, bool, uint, uint) public virtual returns (uint) {
     revert("Unsupported");
   }
@@ -35,7 +39,6 @@ contract StakingProductsGeneric is IStakingProducts {
   function calculateFixedPricePremium(uint, uint, uint, uint, uint) public virtual pure returns (uint) {
     revert("Unsupported");
   }
-
 
   function calculatePremium(StakedProduct memory, uint, uint, uint, uint, uint, uint, uint, uint, uint) public virtual pure returns (uint, StakedProduct memory) {
     revert("Unsupported");
@@ -63,6 +66,18 @@ contract StakingProductsGeneric is IStakingProducts {
   }
 
   function changeStakingPoolFactoryOperator(address) external virtual pure {
+    revert("Unsupported");
+  }
+
+  function setPoolMetadata(uint, string memory) external pure {
+    revert("Unsupported");
+  }
+
+  function getPoolMetadata(uint) external pure returns (string memory) {
+    revert("Unsupported");
+  }
+
+  function setInitialMetadata(string[] calldata) external pure {
     revert("Unsupported");
   }
 }

--- a/contracts/mocks/modules/Cover/COMockStakingPool.sol
+++ b/contracts/mocks/modules/Cover/COMockStakingPool.sol
@@ -54,14 +54,12 @@ contract COMockStakingPool is StakingPoolGeneric {
     bool _isPrivatePool,
     uint _initialPoolFee,
     uint _maxPoolFee,
-    uint _poolId,
-    string calldata _ipfsDescriptionHash /* ipfsDescriptionHash */
+    uint _poolId
   ) external override {
     isPrivatePool = _isPrivatePool;
     poolFee = uint8(_initialPoolFee);
     maxPoolFee = uint8(_maxPoolFee);
     poolId = uint40(_poolId);
-    ipfsHash = _ipfsDescriptionHash;
   }
 
   function requestAllocation(

--- a/contracts/mocks/modules/Cover/COMockStakingProducts.sol
+++ b/contracts/mocks/modules/Cover/COMockStakingProducts.sol
@@ -70,7 +70,7 @@ contract COMockStakingProducts is StakingProductsGeneric {
     uint initialPoolFee,
     uint maxPoolFee,
     ProductInitializationParams[] memory productInitParams,
-    string calldata ipfsDescriptionHash
+    string calldata /*ipfsDescriptionHash*/
   ) external override returns (uint /*poolId*/, address /*stakingPoolAddress*/) {
 
     uint numProducts = productInitParams.length;
@@ -110,8 +110,7 @@ contract COMockStakingProducts is StakingProductsGeneric {
       isPrivatePool,
       initialPoolFee,
       maxPoolFee,
-      poolId,
-      ipfsDescriptionHash
+      poolId
     );
 
     tokenController().assignStakingPoolManager(poolId, msg.sender);

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -173,8 +173,7 @@ contract StakingPool is IStakingPool, Multicall {
     bool _isPrivatePool,
     uint _initialPoolFee,
     uint _maxPoolFee,
-    uint _poolId,
-    string  calldata ipfsDescriptionHash
+    uint _poolId
   ) external {
 
     if (msg.sender != address(stakingProducts)) {
@@ -193,8 +192,6 @@ contract StakingPool is IStakingPool, Multicall {
     poolFee = uint8(_initialPoolFee);
     maxPoolFee = uint8(_maxPoolFee);
     poolId = _poolId.toUint40();
-
-    emit PoolDescriptionSet(ipfsDescriptionHash);
   }
 
   // updateUntilCurrentTimestamp forces rewards update until current timestamp not just until
@@ -1313,10 +1310,6 @@ contract StakingPool is IStakingPool, Multicall {
   function setPoolPrivacy(bool _isPrivatePool) external onlyManager {
     isPrivatePool = _isPrivatePool;
     emit PoolPrivacyChanged(msg.sender, _isPrivatePool);
-  }
-
-  function setPoolDescription(string memory ipfsDescriptionHash) external onlyManager {
-    emit PoolDescriptionSet(ipfsDescriptionHash);
   }
 
   /* fixes */

--- a/contracts/modules/staking/StakingProducts.sol
+++ b/contracts/modules/staking/StakingProducts.sol
@@ -15,15 +15,26 @@ import "../../libraries/StakingPoolLibrary.sol";
 contract StakingProducts is IStakingProducts, MasterAwareV2, Multicall {
   using SafeUintCast for uint;
 
+  // pool id => product id => Product
+  mapping(uint => mapping(uint => StakedProduct)) private _products;
+  // pool id => { totalEffectiveWeight, totalTargetWeight }
+  mapping(uint => Weights) public weights;
+
+  address public immutable coverContract;
+  address public immutable stakingPoolFactory;
+
   uint public constant SURGE_PRICE_RATIO = 2 ether;
   uint public constant SURGE_THRESHOLD_RATIO = 90_00; // 90.00%
   uint public constant SURGE_THRESHOLD_DENOMINATOR = 100_00; // 100.00%
+
   // base price bump
   // +0.2% for each 1% of capacity used, ie +20% for 100%
   uint public constant PRICE_BUMP_RATIO = 20_00; // 20%
+
   // bumped price smoothing
   // 0.5% per day
   uint public constant PRICE_CHANGE_PER_DAY = 200; // 2%
+
   uint public constant INITIAL_PRICE_DENOMINATOR = 100_00;
   uint public constant TARGET_PRICE_DENOMINATOR = 100_00;
   uint public constant MAX_TOTAL_WEIGHT = 20_00; // 20x
@@ -40,14 +51,6 @@ contract StakingProducts is IStakingProducts, MasterAwareV2, Multicall {
   uint public constant ONE_NXM = 1 ether;
   uint public constant ALLOCATION_UNITS_PER_NXM = 100;
   uint public constant NXM_PER_ALLOCATION_UNIT = ONE_NXM / ALLOCATION_UNITS_PER_NXM;
-
-  // pool id => product id => Product
-  mapping(uint => mapping(uint => StakedProduct)) private _products;
-  // pool id => { totalEffectiveWeight, totalTargetWeight }
-  mapping(uint => Weights) public weights;
-
-  address public immutable coverContract;
-  address public immutable stakingPoolFactory;
 
   constructor(address _coverContract, address _stakingPoolFactory) {
     coverContract = _coverContract;

--- a/test/unit/StakingPool/burnStake.js
+++ b/test/unit/StakingPool/burnStake.js
@@ -27,7 +27,6 @@ const poolInitParams = {
   initialPoolFee: 5, // 5%
   maxPoolFee: 5, // 5%
   products: [initialProduct],
-  ipfsDescriptionHash: 'Description Hash',
 };
 
 const productTypeFixture = {

--- a/test/unit/StakingPool/burnStake.js
+++ b/test/unit/StakingPool/burnStake.js
@@ -77,7 +77,7 @@ async function burnStakeSetup() {
   const fixture = await loadFixture(setup);
   const { stakingPool, stakingProducts, coverProducts } = fixture;
   const [staker] = fixture.accounts.members;
-  const { poolId, initialPoolFee, maxPoolFee, products, ipfsDescriptionHash } = poolInitParams;
+  const { poolId, initialPoolFee, maxPoolFee, products } = poolInitParams;
 
   await coverProducts.setProductType(productTypeFixture, initialProduct.productId);
   await coverProducts.setProduct(coverProductTemplate, initialProduct.productId);
@@ -87,7 +87,6 @@ async function burnStakeSetup() {
     initialPoolFee,
     maxPoolFee,
     poolId,
-    ipfsDescriptionHash,
   );
 
   await stakingProducts.connect(fixture.stakingProductsSigner).setInitialProducts(poolId, products);

--- a/test/unit/StakingPool/depositTo.js
+++ b/test/unit/StakingPool/depositTo.js
@@ -31,7 +31,6 @@ const poolInitParams = {
   initialPoolFee: 5, // 5%
   maxPoolFee: 5, // 5%
   products: [productParams],
-  ipfsDescriptionHash: 'Description Hash',
 };
 
 const managerDepositId = 0;

--- a/test/unit/StakingPool/depositTo.js
+++ b/test/unit/StakingPool/depositTo.js
@@ -43,14 +43,13 @@ async function depositToSetup() {
   const fixture = await loadFixture(setup);
   const { stakingPool, stakingProducts, tokenController } = fixture;
   const { defaultSender: manager } = fixture.accounts;
-  const { poolId, initialPoolFee, maxPoolFee, products, ipfsDescriptionHash } = poolInitParams;
+  const { poolId, initialPoolFee, maxPoolFee, products } = poolInitParams;
 
   await stakingPool.connect(fixture.stakingProductsSigner).initialize(
     false, // isPrivatePool
     initialPoolFee,
     maxPoolFee,
     poolId,
-    ipfsDescriptionHash,
   );
   await tokenController.setStakingPoolManager(poolId, manager.address);
 

--- a/test/unit/StakingPool/extendDeposit.js
+++ b/test/unit/StakingPool/extendDeposit.js
@@ -27,7 +27,6 @@ const poolInitParams = {
   initialPoolFee: 5, // 5%
   maxPoolFee: 5, // 5%
   products: [productParams],
-  ipfsDescriptionHash: 'Description Hash',
 };
 
 const depositNftId = 1;

--- a/test/unit/StakingPool/extendDeposit.js
+++ b/test/unit/StakingPool/extendDeposit.js
@@ -39,10 +39,8 @@ async function extendDepositSetup() {
   const [user] = fixture.accounts.members;
   const manager = fixture.accounts.defaultSender;
 
-  const { poolId, initialPoolFee, maxPoolFee, products, ipfsDescriptionHash } = poolInitParams;
-  await stakingPool
-    .connect(fixture.stakingProductsSigner)
-    .initialize(false, initialPoolFee, maxPoolFee, poolId, ipfsDescriptionHash);
+  const { poolId, initialPoolFee, maxPoolFee, products } = poolInitParams;
+  await stakingPool.connect(fixture.stakingProductsSigner).initialize(false, initialPoolFee, maxPoolFee, poolId);
   await tokenController.setStakingPoolManager(poolId, manager.address);
 
   await stakingProducts.connect(fixture.stakingProductsSigner).setInitialProducts(poolId, products);

--- a/test/unit/StakingPool/initialize.js
+++ b/test/unit/StakingPool/initialize.js
@@ -15,7 +15,6 @@ const initializeParams = {
   initialPoolFee: 5, // 5%
   maxPoolFee: 5, // 5%
   products: [product0],
-  ipfsDescriptionHash: 'Description Hash',
 };
 
 describe('initialize', function () {

--- a/test/unit/StakingPool/initialize.js
+++ b/test/unit/StakingPool/initialize.js
@@ -22,16 +22,14 @@ describe('initialize', function () {
   it('reverts if cover contract is not the caller', async function () {
     const fixture = await loadFixture(setup);
     const { stakingPool, stakingProductsSigner } = fixture;
-    const { poolId, initialPoolFee, maxPoolFee, isPrivatePool, ipfsDescriptionHash } = initializeParams;
+    const { poolId, initialPoolFee, maxPoolFee, isPrivatePool } = initializeParams;
 
     await expect(
-      stakingPool.initialize(isPrivatePool, initialPoolFee, maxPoolFee, poolId, ipfsDescriptionHash),
+      stakingPool.initialize(isPrivatePool, initialPoolFee, maxPoolFee, poolId),
     ).to.be.revertedWithCustomError(stakingPool, 'OnlyStakingProductsContract');
 
     await expect(
-      stakingPool
-        .connect(stakingProductsSigner)
-        .initialize(isPrivatePool, initialPoolFee, maxPoolFee, poolId, ipfsDescriptionHash),
+      stakingPool.connect(stakingProductsSigner).initialize(isPrivatePool, initialPoolFee, maxPoolFee, poolId),
     ).to.not.be.reverted;
   });
 
@@ -39,35 +37,29 @@ describe('initialize', function () {
     const fixture = await loadFixture(setup);
     const { stakingPool, stakingProductsSigner } = fixture;
 
-    const { poolId, maxPoolFee, isPrivatePool, ipfsDescriptionHash } = initializeParams;
+    const { poolId, maxPoolFee, isPrivatePool } = initializeParams;
 
     await expect(
-      stakingPool
-        .connect(stakingProductsSigner)
-        .initialize(isPrivatePool, maxPoolFee + 1, maxPoolFee, poolId, ipfsDescriptionHash),
+      stakingPool.connect(stakingProductsSigner).initialize(isPrivatePool, maxPoolFee + 1, maxPoolFee, poolId),
     ).to.be.revertedWithCustomError(stakingPool, 'PoolFeeExceedsMax');
   });
 
   it('reverts if max pool fee is 100%', async function () {
     const fixture = await loadFixture(setup);
     const { stakingPool, stakingProductsSigner } = fixture;
-    const { poolId, initialPoolFee, isPrivatePool, ipfsDescriptionHash } = initializeParams;
+    const { poolId, initialPoolFee, isPrivatePool } = initializeParams;
 
     await expect(
-      stakingPool
-        .connect(stakingProductsSigner)
-        .initialize(isPrivatePool, initialPoolFee, 100, poolId, ipfsDescriptionHash),
+      stakingPool.connect(stakingProductsSigner).initialize(isPrivatePool, initialPoolFee, 100, poolId),
     ).to.be.revertedWithCustomError(stakingPool, 'MaxPoolFeeAbove100');
   });
 
   it('correctly initialize pool parameters', async function () {
     const fixture = await loadFixture(setup);
     const { stakingPool, stakingProductsSigner } = fixture;
-    const { poolId, initialPoolFee, maxPoolFee, isPrivatePool, ipfsDescriptionHash } = initializeParams;
+    const { poolId, initialPoolFee, maxPoolFee, isPrivatePool } = initializeParams;
 
-    await stakingPool
-      .connect(stakingProductsSigner)
-      .initialize(isPrivatePool, initialPoolFee, maxPoolFee, poolId, ipfsDescriptionHash);
+    await stakingPool.connect(stakingProductsSigner).initialize(isPrivatePool, initialPoolFee, maxPoolFee, poolId);
 
     expect(await stakingPool.getPoolFee()).to.be.equal(initialPoolFee);
     expect(await stakingPool.getMaxPoolFee()).to.be.equal(maxPoolFee);

--- a/test/unit/StakingPool/processExpirations.js
+++ b/test/unit/StakingPool/processExpirations.js
@@ -38,7 +38,6 @@ const poolInitParams = {
   initialPoolFee: 5, // 5%
   maxPoolFee: 5, // 5%
   products: [productParams],
-  ipfsDescriptionHash: 'Description Hash',
 };
 
 async function proccessExpirationSetup() {

--- a/test/unit/StakingPool/processExpirations.js
+++ b/test/unit/StakingPool/processExpirations.js
@@ -44,11 +44,9 @@ const poolInitParams = {
 async function proccessExpirationSetup() {
   const fixture = await loadFixture(setup);
   const { stakingPool, stakingProducts } = fixture;
-  const { poolId, initialPoolFee, maxPoolFee, products, ipfsDescriptionHash } = poolInitParams;
+  const { poolId, initialPoolFee, maxPoolFee, products } = poolInitParams;
 
-  await stakingPool
-    .connect(fixture.stakingProductsSigner)
-    .initialize(false, initialPoolFee, maxPoolFee, poolId, ipfsDescriptionHash);
+  await stakingPool.connect(fixture.stakingProductsSigner).initialize(false, initialPoolFee, maxPoolFee, poolId);
 
   await stakingProducts.connect(fixture.stakingProductsSigner).setInitialProducts(poolId, products);
 

--- a/test/unit/StakingPool/requestAllocation.js
+++ b/test/unit/StakingPool/requestAllocation.js
@@ -120,13 +120,12 @@ async function requestAllocationSetup() {
   // Initialize staking pool
   const poolId = 1;
   const isPrivatePool = false;
-  const ipfsDescriptionHash = 'Staking pool 1';
   const maxPoolFee = 10; // 10%
   const initialPoolFee = 7; // 7%
 
   await stakingPool
     .connect(fixture.stakingProductsSigner)
-    .initialize(isPrivatePool, initialPoolFee, maxPoolFee, poolId, ipfsDescriptionHash);
+    .initialize(isPrivatePool, initialPoolFee, maxPoolFee, poolId);
 
   await stakingProducts
     .connect(fixture.stakingProductsSigner)

--- a/test/unit/StakingPool/setPoolFee.js
+++ b/test/unit/StakingPool/setPoolFee.js
@@ -44,12 +44,12 @@ const initializeParams = {
 async function setPoolFeeSetup() {
   const fixture = await loadFixture(setup);
   const { stakingPool, stakingProducts, tokenController } = fixture;
-  const { poolId, initialPoolFee, maxPoolFee, products, isPrivatePool, ipfsDescriptionHash } = initializeParams;
+  const { poolId, initialPoolFee, maxPoolFee, products, isPrivatePool } = initializeParams;
   const manager = fixture.accounts.defaultSender;
 
   await stakingPool
     .connect(fixture.stakingProductsSigner)
-    .initialize(isPrivatePool, initialPoolFee, maxPoolFee, poolId, ipfsDescriptionHash);
+    .initialize(isPrivatePool, initialPoolFee, maxPoolFee, poolId);
   await tokenController.setStakingPoolManager(poolId, manager.address);
 
   await stakingProducts.connect(fixture.stakingProductsSigner).setInitialProducts(poolId, products);

--- a/test/unit/StakingPool/setPoolFee.js
+++ b/test/unit/StakingPool/setPoolFee.js
@@ -38,7 +38,6 @@ const initializeParams = {
   initialPoolFee: 5, // 5%
   maxPoolFee: 5, // 5%
   products: [product],
-  ipfsDescriptionHash: 'Description Hash',
 };
 
 async function setPoolFeeSetup() {

--- a/test/unit/StakingPool/setPoolPrivacy.js
+++ b/test/unit/StakingPool/setPoolPrivacy.js
@@ -15,7 +15,6 @@ const initializeParams = {
   initialPoolFee: 5, // 5%
   maxPoolFee: 5, // 5%
   products: [product0],
-  ipfsDescriptionHash: 'Descrition Hash',
 };
 
 async function setPoolPrivacySetup() {

--- a/test/unit/StakingPool/setPoolPrivacy.js
+++ b/test/unit/StakingPool/setPoolPrivacy.js
@@ -23,11 +23,11 @@ async function setPoolPrivacySetup() {
   const { stakingPool, stakingProducts, tokenController } = fixture;
   const manager = fixture.accounts.defaultSender;
 
-  const { poolId, initialPoolFee, maxPoolFee, products, isPrivatePool, ipfsDescriptionHash } = initializeParams;
+  const { poolId, initialPoolFee, maxPoolFee, products, isPrivatePool } = initializeParams;
 
   await stakingPool
     .connect(fixture.stakingProductsSigner)
-    .initialize(isPrivatePool, initialPoolFee, maxPoolFee, poolId, ipfsDescriptionHash);
+    .initialize(isPrivatePool, initialPoolFee, maxPoolFee, poolId);
   await tokenController.setStakingPoolManager(poolId, manager.address);
 
   await stakingProducts.connect(fixture.stakingProductsSigner).setInitialProducts(poolId, products);

--- a/test/unit/StakingPool/withdraw.js
+++ b/test/unit/StakingPool/withdraw.js
@@ -47,11 +47,11 @@ async function withdrawSetup() {
   const { stakingPool, stakingProducts, tokenController } = fixture;
   const manager = fixture.accounts.defaultSender;
 
-  const { poolId, initialPoolFee, maxPoolFee, products, isPrivatePool, ipfsDescriptionHash } = initializeParams;
+  const { poolId, initialPoolFee, maxPoolFee, products, isPrivatePool } = initializeParams;
 
   await stakingPool
     .connect(fixture.stakingProductsSigner)
-    .initialize(isPrivatePool, initialPoolFee, maxPoolFee, poolId, ipfsDescriptionHash);
+    .initialize(isPrivatePool, initialPoolFee, maxPoolFee, poolId);
 
   await tokenController.setStakingPoolManager(poolId, manager.address);
 

--- a/test/unit/StakingPool/withdraw.js
+++ b/test/unit/StakingPool/withdraw.js
@@ -31,7 +31,6 @@ const initializeParams = {
   initialPoolFee: 5, // 5%
   maxPoolFee: 5, // 5%
   products: [product0],
-  ipfsDescriptionHash: 'Description Hash',
 };
 
 const withdrawFixture = {

--- a/test/unit/StakingPoolFactory/setup.js
+++ b/test/unit/StakingPoolFactory/setup.js
@@ -1,9 +1,9 @@
 const { ethers } = require('hardhat');
-const { getAccounts } = require('../../utils/accounts');
+const { getAccounts } = require('../utils').accounts;
 
 async function setup() {
   const accounts = await getAccounts();
-  const operator = accounts.nonMembers[0];
+  const [operator] = accounts.nonMembers;
 
   const stakingPoolFactory = await ethers.deployContract('StakingPoolFactory', [operator.address]);
 

--- a/test/unit/StakingProducts/createStakingPool.js
+++ b/test/unit/StakingProducts/createStakingPool.js
@@ -4,21 +4,23 @@ const { expect } = require('chai');
 const { keccak256 } = require('ethereum-cryptography/keccak');
 const { bytesToHex, hexToBytes } = require('ethereum-cryptography/utils');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
+
 const setup = require('./setup');
+
 const { AddressZero } = ethers.constants;
+
+const product = {
+  productId: 200,
+  weight: 100,
+  initialPrice: '500',
+  targetPrice: '500',
+};
 
 const newPoolFixture = {
   initialPoolFee: 5, // 5%
   maxPoolFee: 5, // 5%
-  productInitializationParams: [
-    {
-      productId: 200,
-      weight: 100,
-      initialPrice: '500',
-      targetPrice: '500',
-    },
-  ],
-  ipfsDescriptionHash: 'Description Hash',
+  productInitializationParams: [product],
+  ipfsDescriptionHash: 'staking-pool-ipfs-metadata',
 };
 
 async function createStakingPoolSetup() {
@@ -34,18 +36,10 @@ async function createStakingPoolSetup() {
   };
 
   const productId = initialProducts.length;
+  const productParam = { ...coverProductTemplate, initialPriceRatio: coverProductTemplate.initialPriceRatio };
 
-  await coverProducts.setProduct(
-    { ...coverProductTemplate, initialPriceRatio: coverProductTemplate.initialPriceRatio },
-    productId,
-  );
-  await coverProducts.setProductType(
-    {
-      claimMethod: 1,
-      gracePeriod: 7 * 24 * 3600, // 7 days
-    },
-    productId,
-  );
+  await coverProducts.setProduct(productParam, productId);
+  await coverProducts.setProductType({ claimMethod: 1, gracePeriod: 7 * 24 * 3600 /* = 7 days */ }, productId);
 
   return fixture;
 }
@@ -66,7 +60,7 @@ describe('createStakingPool', function () {
         initialPoolFee,
         maxPoolFee,
         productInitializationParams,
-        '', // ipfsDescriptionHash
+        'staking-pool-ipfs-metadata',
       ),
     ).to.be.revertedWith('System is paused');
   });

--- a/test/unit/StakingProducts/helpers.js
+++ b/test/unit/StakingProducts/helpers.js
@@ -1,7 +1,8 @@
 const { expect } = require('chai');
 const { ethers } = require('hardhat');
-const { getCurrentTrancheId } = require('../StakingPool/helpers');
-const { setEtherBalance } = require('../../utils/evm');
+
+const { setEtherBalance } = require('../utils').evm;
+
 const { BigNumber } = ethers;
 const { parseEther } = ethers.utils;
 const { AddressZero } = ethers.constants;
@@ -56,6 +57,13 @@ const burnStakeParams = {
   period: buyCoverParamsTemplate.period,
   deallocationAmount: 0,
 };
+
+const TRANCHE_DURATION = daysToSeconds(91);
+
+async function getCurrentTrancheId() {
+  const { timestamp } = await ethers.provider.getBlock('latest');
+  return Math.floor(timestamp / TRANCHE_DURATION);
+}
 
 async function verifyProduct(params) {
   const { coverProducts } = this;

--- a/test/unit/StakingProducts/recalculateEffectiveWeight.js
+++ b/test/unit/StakingProducts/recalculateEffectiveWeight.js
@@ -1,7 +1,6 @@
 const { ethers } = require('hardhat');
 const { expect } = require('chai');
-const { parseEther } = ethers.utils;
-const { Zero, One } = ethers.constants;
+const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 const {
   allocateCapacity,
   depositTo,
@@ -11,14 +10,17 @@ const {
   burnStakeParams,
   newProductTemplate,
 } = require('./helpers');
-const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 const setup = require('./setup');
-const { increaseTime, setEtherBalance } = require('../../utils').evm;
+const { increaseTime, setEtherBalance } = require('../utils').evm;
+
+const { parseEther } = ethers.utils;
+const { Zero, One } = ethers.constants;
 
 const DEFAULT_PRODUCTS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
 const MAX_TARGET_WEIGHT = 100;
 const MAX_TOTAL_EFFECTIVE_WEIGHT = 2000;
 const UINT16_MAX = 65535;
+
 describe('recalculateEffectiveWeight', function () {
   it('recalculating effective weight should have no effect for products not found in stakingPool', async function () {
     const fixture = await loadFixture(setup);

--- a/test/unit/StakingProducts/setPoolMetadata.js
+++ b/test/unit/StakingProducts/setPoolMetadata.js
@@ -1,0 +1,36 @@
+const { expect } = require('chai');
+const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
+
+const setup = require('./setup');
+
+describe('setPoolMetadata', function () {
+  it('reverts if manager is not the caller', async function () {
+    const fixture = await loadFixture(setup);
+    const [nonManager] = fixture.accounts.nonMembers;
+    const stakingProducts = fixture.stakingProducts.connect(nonManager);
+
+    const poolId = 1;
+    const ipfsHash = 'some-string';
+
+    await expect(stakingProducts.setPoolMetadata(poolId, ipfsHash)).to.be.revertedWithCustomError(
+      stakingProducts,
+      'OnlyManager',
+    );
+  });
+
+  it('updates pool metadata', async function () {
+    const fixture = await loadFixture(setup);
+    const [manager] = fixture.accounts.members;
+    const stakingProducts = fixture.stakingProducts.connect(manager);
+
+    const poolId = 1;
+    const ipfsHash = 'some-string';
+
+    const initialMetadata = await stakingProducts.getPoolMetadata(poolId);
+    await stakingProducts.setPoolMetadata(poolId, ipfsHash);
+    const updatedMetadata = await stakingProducts.getPoolMetadata(poolId);
+
+    expect(updatedMetadata).to.be.not.equal(initialMetadata);
+    expect(updatedMetadata).to.be.equal(ipfsHash);
+  });
+});

--- a/test/unit/StakingProducts/setProducts.js
+++ b/test/unit/StakingProducts/setProducts.js
@@ -50,7 +50,10 @@ describe('setProducts unit tests', function () {
     const [manager] = fixture.accounts.members;
 
     const product = { ...newProductTemplate };
-    await expect(stakingProducts.connect(manager).setProducts(324985304958, [product])).to.be.revertedWithoutReason();
+    await expect(stakingProducts.connect(manager).setProducts(324985304958, [product])).to.be.revertedWithCustomError(
+      stakingProducts,
+      'OnlyManager',
+    );
   });
 
   it('should set products and store values correctly', async function () {

--- a/test/unit/StakingProducts/setProducts.js
+++ b/test/unit/StakingProducts/setProducts.js
@@ -1,12 +1,14 @@
 const { expect } = require('chai');
 const { ethers } = require('hardhat');
+const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
+
 const { verifyProduct, depositTo, daysToSeconds, newProductTemplate } = require('./helpers');
+const { increaseTime, setEtherBalance } = require('../utils').evm;
+const setup = require('./setup');
+
 const { AddressZero } = ethers.constants;
 const { parseEther } = ethers.utils;
 const { BigNumber } = ethers;
-const { increaseTime, setEtherBalance } = require('../../utils/evm');
-const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
-const setup = require('./setup');
 
 const poolId = 1;
 


### PR DESCRIPTION
## Context

Staking pools' titles and descriptions are stored on ipfs and the contract only emits an event with the ipfs hash. Event fetching takes a looooooooooong time and we want to optimize this.

## Changes proposed in this pull request

This PR moves the ipfs hashes from events to storage. The contract choice (`StakingProducts` instead of `StakingPool`) is due to the extremly limited space in `StakingPool`.

## Test plan

Added new unit tests and cleaned up staking pool unit tests.

## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
