### PR TITLE
Modify -library flag to take contract name and address

### DIFF
--- a/scripts/create2/find-salt.js
+++ b/scripts/create2/find-salt.js
@@ -6,6 +6,7 @@ const { bytesToHex, hexToBytes } = require('ethereum-cryptography/utils');
 const linker = require('solc/linker');
 const workerpool = require('workerpool');
 
+const ADDRESS_REGEX = /^0x[a-f0-9]{40}$/i;
 const Position = {
   start: 'start',
   end: 'end',
@@ -34,12 +35,10 @@ const usage = () => {
         Start the search from this salt.
       --help, -h
         Print this help message.
-      --library, -l PATH:CONTRACT_NAME:ADDRESS
+      --library, -l CONTRACT_NAME:ADDRESS
         Link an external library.
   `);
 };
-
-const ADDRESS_REGEX = /^0x[a-f0-9]{40}$/i;
 
 const parseArgs = async args => {
   const opts = {
@@ -111,12 +110,14 @@ const parseArgs = async args => {
     if (['--library', '-l'].includes(arg)) {
       const libArg = argsArray.shift();
 
-      const [path, contractName, address] = libArg.split(':');
-      if (!path || !contractName || !address || !address.match(ADDRESS_REGEX)) {
-        throw new Error(`Invalid library format: ${libArg}. Expected format is PATH:CONTRACT_NAME:ADDRESS`);
+      const [contractName, address] = libArg.split(':');
+      if (!contractName || !address || !address.match(ADDRESS_REGEX)) {
+        throw new Error(`Invalid library format: ${libArg}. Expected format is CONTRACT_NAME:ADDRESS`);
       }
 
-      opts.libraries[`${path}:${contractName}`] = address;
+      const { sourceName } = await artifacts.readArtifact(contractName);
+      opts.libraries[`${sourceName}:${contractName}`] = address;
+
       continue;
     }
 


### PR DESCRIPTION
## Context

Making the dev UX better by only requiring contract name and address instead of the FQCN:address


## Changes proposed in this pull request

* Modify --libary, -l flags to take in CONTRACT_NAME:ADDRESS


## Test plan

Tested manually


## Checklist

- [x] Rebased the base branch
- [ ] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [x] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
