### PR TITLE
feat(NexusViewer): add pool manager NXM locked for MV timestamp

### DIFF
--- a/contracts/interfaces/IAssessmentViewer.sol
+++ b/contracts/interfaces/IAssessmentViewer.sol
@@ -10,7 +10,12 @@ interface IAssessmentViewer {
     uint withdrawableUntilIndex;
   }
 
+  struct AssessmentStakeLockedState {
+    bool isStakeLocked;
+    uint stakeLockupExpiry;
+  }
+
   function getRewards(address user) external view returns (AssessmentRewards memory);
 
-  function isStakeLocked(address member) external view returns (bool stakeLocked);
+  function getStakeLocked(address member) external view returns (AssessmentStakeLockedState memory);
 }

--- a/contracts/interfaces/INexusViewer.sol
+++ b/contracts/interfaces/INexusViewer.sol
@@ -23,6 +23,7 @@ interface INexusViewer {
   struct StakedNXM {
     uint stakingPoolTotalActiveStake; // Total amount of active stake in staking pools in NXM
     uint assessmentStake; // Locked assessment stake in NXM
+    uint assessmentStakeLockupExpiry; // Locked stake expiry timestamp
     uint assessmentRewards; // Locked assessment rewards in NXM
   }
 

--- a/contracts/interfaces/INexusViewer.sol
+++ b/contracts/interfaces/INexusViewer.sol
@@ -13,6 +13,7 @@ interface INexusViewer {
     uint assessmentStake; // Claimable assessment stake in NXM
     uint stakingPoolTotalRewards; // Total staking pool rewards in NXM
     uint stakingPoolTotalExpiredStake; // Total staking pool expired stake in NXM
+    uint stakingPoolManagerIsNXMLockedForMV; // Staking pool manager NXM locked for MV
     uint managerTotalRewards; // Pool manager total staking rewards in NXM
     uint legacyPooledStakeRewards; // Legacy pooled staking rewards in NXM
     uint legacyPooledStakeDeposits; // Legacy pooled staking deposits in NXM

--- a/contracts/mocks/modules/NexusViewer/NVMockAssessmentViewer.sol
+++ b/contracts/mocks/modules/NexusViewer/NVMockAssessmentViewer.sol
@@ -9,13 +9,13 @@ import {INXMToken} from "../../../interfaces/INXMToken.sol";
 
 contract NVMockAssessmentViewer is IAssessmentViewer {
 
-  bool stakeLocked;
+  AssessmentStakeLockedState stakeLockedState;
   AssessmentRewards assessmentRewards;
 
   /* ========== SETTERS ========== */
 
-  function setStakeLocked(bool _stakeLocked) external {
-    stakeLocked = _stakeLocked;
+  function setStakeLocked(AssessmentStakeLockedState memory _stakeLockedState) external {
+    stakeLockedState = _stakeLockedState;
   }
 
   function setRewards(
@@ -32,8 +32,8 @@ contract NVMockAssessmentViewer is IAssessmentViewer {
 
   /* ========== VIEWS ========== */
 
-  function isStakeLocked(address) external view returns (bool) {
-    return stakeLocked;
+  function getStakeLocked(address) external view returns (AssessmentStakeLockedState memory) {
+    return stakeLockedState;
   }
 
   function getRewards(address) external view returns (AssessmentRewards memory) {

--- a/contracts/modules/assessment/AssessmentViewer.sol
+++ b/contracts/modules/assessment/AssessmentViewer.sol
@@ -39,20 +39,29 @@ contract AssessmentViewer is IAssessmentViewer {
     });
   }
 
-  /// @notice Check if the stake of a member is locked
+  /// @notice Check if the stake of a member is locked and when it will be unlocked
   /// @param member The address of the member
-  /// @return stakeLocked Boolean indicating if the stake is locked
-  function isStakeLocked(address member) external view returns (bool stakeLocked) {
+  /// @return AssessmentStakeLockedState structure containing locked stake details
+  function getStakeLocked(address member) external view returns (AssessmentStakeLockedState memory) {
 
     IAssessment _assessment = assessment();
 
     uint voteCount = _assessment.getVoteCountOfAssessor(member);
-    if (voteCount == 0) return false;
+    if (voteCount == 0) return AssessmentStakeLockedState({
+      isStakeLocked: false,
+      stakeLockupExpiry: 0
+    });
 
     (,, uint32 timestamp,) = _assessment.votesOf(member, voteCount - 1);
     (, uint8 stakeLockupPeriodInDays,,) = _assessment.config();
 
     uint stakeLockupExpiry = timestamp + stakeLockupPeriodInDays * 1 days;
-    stakeLocked = stakeLockupExpiry > block.timestamp;
+    bool isStakeLocked = stakeLockupExpiry > block.timestamp;
+
+    return AssessmentStakeLockedState({
+      isStakeLocked: isStakeLocked,
+      stakeLockupExpiry: stakeLockupExpiry
+    });
+    
   }
 }

--- a/scripts/deploy/assessment-and-nexus-viewer-deploy.js
+++ b/scripts/deploy/assessment-and-nexus-viewer-deploy.js
@@ -1,0 +1,28 @@
+const { ethers, network } = require('hardhat');
+
+const STV = '0xcafea5E8a7a54dd14Bb225b66C7a016dfd7F236b'; // StakingViewer
+const MS = '0x01BFd82675DBCc7762C84019cA518e701C0cD07e'; // NXMaster
+
+const main = async () => {
+  console.log(`Starting deploy script on ${network.name} network`);
+
+  console.log('Getting a signer');
+  const [signer] = await ethers.getSigners();
+
+  console.log('Deploying contracts');
+  const assessmentViewerImplementation = await ethers.deployContract('AssessmentViewer', [MS], signer);
+  const nexusViewerImplementation = await ethers.deployContract(
+    'NexusViewer',
+    [MS, STV, assessmentViewerImplementation.address],
+    signer,
+  );
+
+  console.log('AssessmentViewer implementation address:', assessmentViewerImplementation.address);
+  console.log('NexusViewer implementation address:', nexusViewerImplementation.address);
+};
+main()
+  .then(() => process.exit(0))
+  .catch(error => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/deploy/assessment-and-nexus-viewer-deploy.js
+++ b/scripts/deploy/assessment-and-nexus-viewer-deploy.js
@@ -19,6 +19,7 @@ const main = async () => {
 
   console.log('AssessmentViewer implementation address:', assessmentViewerImplementation.address);
   console.log('NexusViewer implementation address:', nexusViewerImplementation.address);
+  console.log('NexusViewer ABI', nexusViewerImplementation.interface.format(ethers.utils.FormatTypes.json));
 };
 main()
   .then(() => process.exit(0))

--- a/scripts/deploy/assessment-and-nexus-viewer-deploy.js
+++ b/scripts/deploy/assessment-and-nexus-viewer-deploy.js
@@ -2,6 +2,7 @@ const { ethers, network } = require('hardhat');
 
 const STV = '0xcafea5E8a7a54dd14Bb225b66C7a016dfd7F236b'; // StakingViewer
 const MS = '0x01BFd82675DBCc7762C84019cA518e701C0cD07e'; // NXMaster
+const NXM = '0xd7c49CEE7E9188cCa6AD8FF264C1DA2e69D4Cf3B'; // NXMToken
 
 const main = async () => {
   console.log(`Starting deploy script on ${network.name} network`);
@@ -13,13 +14,15 @@ const main = async () => {
   const assessmentViewerImplementation = await ethers.deployContract('AssessmentViewer', [MS], signer);
   const nexusViewerImplementation = await ethers.deployContract(
     'NexusViewer',
-    [MS, STV, assessmentViewerImplementation.address],
+    [MS, STV, assessmentViewerImplementation.address, NXM],
     signer,
   );
 
   console.log('AssessmentViewer implementation address:', assessmentViewerImplementation.address);
   console.log('NexusViewer implementation address:', nexusViewerImplementation.address);
   console.log('NexusViewer ABI', nexusViewerImplementation.interface.format(ethers.utils.FormatTypes.json));
+
+  console.log('Done');
 };
 main()
   .then(() => process.exit(0))

--- a/scripts/ui-data-fetching/get-claimable-nxm.js
+++ b/scripts/ui-data-fetching/get-claimable-nxm.js
@@ -1,0 +1,137 @@
+require('dotenv').config();
+const { ethers } = require('hardhat');
+
+const NexusViewerABI = [
+  {
+    type: 'constructor',
+    payable: false,
+    inputs: [
+      { type: 'address', name: '_master' },
+      { type: 'address', name: '_stakingViewer' },
+      { type: 'address', name: '_assessmentViewer' },
+      { type: 'address', name: '_nxm' },
+    ],
+  },
+  { type: 'error', name: 'RevertedWithoutReason', inputs: [{ type: 'uint256', name: 'index' }] },
+  {
+    type: 'function',
+    name: 'assessmentViewer',
+    constant: true,
+    stateMutability: 'view',
+    payable: false,
+    gas: 11000000,
+    inputs: [],
+    outputs: [{ type: 'address' }],
+  },
+  {
+    type: 'function',
+    name: 'getClaimableNXM',
+    constant: true,
+    stateMutability: 'view',
+    payable: false,
+    gas: 11000000,
+    inputs: [
+      { type: 'address', name: 'member' },
+      { type: 'uint256[]', name: 'tokenIds' },
+    ],
+    outputs: [
+      {
+        type: 'tuple',
+        components: [
+          { type: 'uint256', name: 'governanceRewards' },
+          { type: 'uint256', name: 'assessmentRewards' },
+          { type: 'uint256', name: 'assessmentStake' },
+          { type: 'uint256', name: 'stakingPoolTotalRewards' },
+          { type: 'uint256', name: 'stakingPoolTotalExpiredStake' },
+          { type: 'uint256', name: 'stakingPoolManagerIsNXMLockedForMV' },
+          { type: 'uint256', name: 'managerTotalRewards' },
+          { type: 'uint256', name: 'legacyPooledStakeRewards' },
+          { type: 'uint256', name: 'legacyPooledStakeDeposits' },
+          { type: 'uint256', name: 'legacyClaimAssessmentTokens' },
+          { type: 'uint256', name: 'legacyCoverNoteDeposits' },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'function',
+    name: 'getStakedNXM',
+    constant: true,
+    stateMutability: 'view',
+    payable: false,
+    gas: 11000000,
+    inputs: [
+      { type: 'address', name: 'member' },
+      { type: 'uint256[]', name: 'tokenIds' },
+    ],
+    outputs: [
+      {
+        type: 'tuple',
+        components: [
+          { type: 'uint256', name: 'stakingPoolTotalActiveStake' },
+          { type: 'uint256', name: 'assessmentStake' },
+          { type: 'uint256', name: 'assessmentStakeLockupExpiry' },
+          { type: 'uint256', name: 'assessmentRewards' },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'function',
+    name: 'master',
+    constant: true,
+    stateMutability: 'view',
+    payable: false,
+    gas: 11000000,
+    inputs: [],
+    outputs: [{ type: 'address' }],
+  },
+  {
+    type: 'function',
+    name: 'multicall',
+    constant: false,
+    payable: false,
+    gas: 11000000,
+    inputs: [{ type: 'bytes[]', name: 'data' }],
+    outputs: [{ type: 'bytes[]', name: 'results' }],
+  },
+  {
+    type: 'function',
+    name: 'nxm',
+    constant: true,
+    stateMutability: 'view',
+    payable: false,
+    gas: 11000000,
+    inputs: [],
+    outputs: [{ type: 'address' }],
+  },
+  {
+    type: 'function',
+    name: 'stakingViewer',
+    constant: true,
+    stateMutability: 'view',
+    payable: false,
+    gas: 11000000,
+    inputs: [],
+    outputs: [{ type: 'address' }],
+  },
+];
+const NexusViewerAddress = '0xF62eEc897fa5ef36a957702AA4a45B58fE8Fe312';
+
+const member = '0xd6CE9335f5A68e885271CdbE460b7A4FED5FeDA9';
+const tokenIds = [34, 35, 36, 103, 136];
+
+async function main() {
+  const viewer = await ethers.getContractAt(NexusViewerABI, NexusViewerAddress);
+
+  const claimableNXM = await viewer.getClaimableNXM(member, tokenIds);
+
+  console.log('Claimable NXM:', claimableNXM);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch(error => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Description
Alternative for UI multicall https://github.com/NexusMutual/frontend-next/pull/1049 to support https://github.com/NexusMutual/frontend-next/issues/1044. 

The advantage of this approach would be saving an on chain call on the UI, the disadvantage being this implies a smart contract deployment + not sure about how computationally heavy the added logic is. The UI approach is faster in terms of going live with the fix, but I don't think this is an urgent issue so we can decide based on the other criteria. 

## Testing

- tested on https://virtual.mainnet.rpc.tenderly.co/1f396564-cf8d-4662-85cb-965e69f23a8e

**NexusViewer implementation address: 0x6874ABAf1c8a1694b08066e5bB38487D680fa38d**
**NexusViewer implementation ABI:**
```
[{"type":"constructor","payable":false,"inputs":[{"type":"address","name":"_master"},{"type":"address","name":"_stakingViewer"},{"type":"address","name":"_assessmentViewer"},{"type":"address","name":"_nxm"}]},{"type":"error","name":"RevertedWithoutReason","inputs":[{"type":"uint256","name":"index"}]},{"type":"function","name":"assessmentViewer","constant":true,"stateMutability":"view","payable":false,"inputs":[],"outputs":[{"type":"address"}]},{"type":"function","name":"getClaimableNXM","constant":true,"stateMutability":"view","payable":false,"inputs":[{"type":"address","name":"member"},{"type":"uint256[]","name":"tokenIds"}],"outputs":[{"type":"tuple","components":[{"type":"uint256","name":"governanceRewards"},{"type":"uint256","name":"assessmentRewards"},{"type":"uint256","name":"assessmentStake"},{"type":"uint256","name":"stakingPoolTotalRewards"},{"type":"uint256","name":"stakingPoolTotalExpiredStake"},{"type":"uint256","name":"stakingPoolManagerIsNXMLockedForMV"},{"type":"uint256","name":"managerTotalRewards"},{"type":"uint256","name":"legacyPooledStakeRewards"},{"type":"uint256","name":"legacyPooledStakeDeposits"},{"type":"uint256","name":"legacyClaimAssessmentTokens"},{"type":"uint256","name":"legacyCoverNoteDeposits"}]}]},{"type":"function","name":"getStakedNXM","constant":true,"stateMutability":"view","payable":false,"inputs":[{"type":"address","name":"member"},{"type":"uint256[]","name":"tokenIds"}],"outputs":[{"type":"tuple","components":[{"type":"uint256","name":"stakingPoolTotalActiveStake"},{"type":"uint256","name":"assessmentStake"},{"type":"uint256","name":"assessmentStakeLockupExpiry"},{"type":"uint256","name":"assessmentRewards"}]}]},{"type":"function","name":"master","constant":true,"stateMutability":"view","payable":false,"inputs":[],"outputs":[{"type":"address"}]},{"type":"function","name":"multicall","constant":false,"payable":false,"inputs":[{"type":"bytes[]","name":"data"}],"outputs":[{"type":"bytes[]","name":"results"}]},{"type":"function","name":"nxm","constant":true,"stateMutability":"view","payable":false,"inputs":[],"outputs":[{"type":"address"}]},{"type":"function","name":"stakingViewer","constant":true,"stateMutability":"view","payable":false,"inputs":[],"outputs":[{"type":"address"}]}]
```
- `getClaimableNXM` call should return `stakingPoolManagerIsNXMLockedForMV` in the result

OR
- on local node: `HARDHAT_NETWORK=localhost node scripts/get-claimable-nxm.js`

## Checklist

- [x] Performed a self-review of my own code
- [x] Made corresponding changes to the documentation
