### PR TITLE
feat: add min price per product

### DIFF
--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -110,7 +110,7 @@ interface ICover {
     uint _globalMinPriceRatio
   );
 
-  function GLOBAL_MIN_PRICE_RATIO() external view returns (uint);
+  function DEFAULT_MIN_PRICE_RATIO() external view returns (uint);
 
   /* === MUTATIVE FUNCTIONS ==== */
 

--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -103,11 +103,11 @@ interface ICover {
 
   function getGlobalRewardsRatio() external view returns (uint);
 
-  function getGlobalMinPriceRatio() external pure returns (uint);
+  function getDefaultMinPriceRatio() external pure returns (uint);
 
   function getGlobalCapacityAndPriceRatios() external view returns (
     uint _globalCapacityRatio,
-    uint _globalMinPriceRatio
+    uint _defaultMinPriceRatio
   );
 
   function DEFAULT_MIN_PRICE_RATIO() external view returns (uint);

--- a/contracts/interfaces/ICoverProducts.sol
+++ b/contracts/interfaces/ICoverProducts.sol
@@ -129,7 +129,7 @@ interface ICoverProducts {
 
   // Misc
   error UnsupportedCoverAssets();
-  error InitialPriceRatioBelowGlobalMinPriceRatio();
+  error InitialPriceRatioBelowDefaultMinPriceRatio();
   error InitialPriceRatioAbove100Percent();
   error CapacityReductionRatioAbove100Percent();
 

--- a/contracts/interfaces/ICoverProducts.sol
+++ b/contracts/interfaces/ICoverProducts.sol
@@ -131,7 +131,7 @@ interface ICoverProducts {
 
   // Misc
   error UnsupportedCoverAssets();
-  error InitialPriceRatioBelowDefaultMinPriceRatio();
+  error InitialPriceRatioBelowMinPriceRatio();
   error InitialPriceRatioAbove100Percent();
   error CapacityReductionRatioAbove100Percent();
 

--- a/contracts/interfaces/ICoverProducts.sol
+++ b/contracts/interfaces/ICoverProducts.sol
@@ -101,6 +101,8 @@ interface ICoverProducts {
 
   function getInitialPrices(uint[] calldata productIds) external view returns (uint[] memory);
 
+  function getMinPrices(uint[] calldata productIds) external view returns (uint[] memory);
+
   function prepareStakingProductsParams(
     ProductInitializationParams[] calldata params
   ) external returns (

--- a/contracts/interfaces/IStakingPool.sol
+++ b/contracts/interfaces/IStakingPool.sol
@@ -17,7 +17,7 @@ struct AllocationRequest {
   uint globalCapacityRatio;
   uint capacityReductionRatio;
   uint rewardRatio;
-  uint globalMinPrice;
+  uint defaultMinPrice;
 }
 
 struct BurnStakeParams {

--- a/contracts/interfaces/IStakingPool.sol
+++ b/contracts/interfaces/IStakingPool.sol
@@ -17,7 +17,7 @@ struct AllocationRequest {
   uint globalCapacityRatio;
   uint capacityReductionRatio;
   uint rewardRatio;
-  uint defaultMinPrice;
+  uint productMinPrice;
 }
 
 struct BurnStakeParams {

--- a/contracts/interfaces/IStakingProducts.sol
+++ b/contracts/interfaces/IStakingProducts.sol
@@ -57,7 +57,7 @@ interface IStakingProducts {
     uint period,
     uint coverAmount,
     uint totalCapacity,
-    uint globalMinPrice,
+    uint defaultMinPrice,
     bool useFixedPrice,
     uint nxmPerAllocationUnit
   ) external returns (uint premium);
@@ -128,7 +128,7 @@ interface IStakingProducts {
   // Staking Pool creation
   error ProductDoesntExistOrIsDeprecated();
   error InvalidProductType();
-  error TargetPriceBelowGlobalMinPriceRatio();
+  error TargetPriceBelowDefaultMinPriceRatio();
 
   // IPFS
   error IpfsHashRequired();

--- a/contracts/interfaces/IStakingProducts.sol
+++ b/contracts/interfaces/IStakingProducts.sol
@@ -57,7 +57,7 @@ interface IStakingProducts {
     uint period,
     uint coverAmount,
     uint totalCapacity,
-    uint defaultMinPrice,
+    uint productMinPrice,
     bool useFixedPrice,
     uint nxmPerAllocationUnit
   ) external returns (uint premium);

--- a/contracts/interfaces/IStakingProducts.sol
+++ b/contracts/interfaces/IStakingProducts.sol
@@ -128,7 +128,7 @@ interface IStakingProducts {
   // Staking Pool creation
   error ProductDoesntExistOrIsDeprecated();
   error InvalidProductType();
-  error TargetPriceBelowDefaultMinPriceRatio();
+  error TargetPriceBelowMinPriceRatio();
 
   // IPFS
   error IpfsHashRequired();

--- a/contracts/mocks/generic/CoverGeneric.sol
+++ b/contracts/mocks/generic/CoverGeneric.sol
@@ -10,7 +10,7 @@ contract CoverGeneric is ICover {
   uint public constant DEFAULT_MIN_PRICE_RATIO = 100; // 1%
   uint public constant MAX_COMMISSION_RATIO = 3000; // 30%
 
-  function getGlobalMinPriceRatio() public virtual pure returns (uint) {
+  function getDefaultMinPriceRatio() public virtual pure returns (uint) {
     revert("Unsupported");
   }
 

--- a/contracts/mocks/generic/CoverGeneric.sol
+++ b/contracts/mocks/generic/CoverGeneric.sol
@@ -7,7 +7,7 @@ import "../../interfaces/ICoverNFT.sol";
 
 contract CoverGeneric is ICover {
 
-  uint public constant GLOBAL_MIN_PRICE_RATIO = 100; // 1%
+  uint public constant DEFAULT_MIN_PRICE_RATIO = 100; // 1%
   uint public constant MAX_COMMISSION_RATIO = 3000; // 30%
 
   function getGlobalMinPriceRatio() public virtual pure returns (uint) {

--- a/contracts/mocks/generic/CoverProductsGeneric.sol
+++ b/contracts/mocks/generic/CoverProductsGeneric.sol
@@ -6,6 +6,8 @@ import "../../interfaces/ICoverProducts.sol";
 
 contract CoverProductsGeneric is ICoverProducts {
 
+  uint public constant DEFAULT_MIN_PRICE_RATIO = 100; // 1%
+
   /* ========== VIEWS ========== */
 
   function getProductType(uint) external virtual view returns (ProductType memory) {
@@ -82,6 +84,10 @@ contract CoverProductsGeneric is ICoverProducts {
   }
 
   function getInitialPrices(uint[] calldata) external virtual view returns (uint[] memory) {
+    revert("Unsupported");
+  }
+
+  function getMinPrices(uint[] calldata) external view virtual returns (uint[] memory) {
     revert("Unsupported");
   }
 

--- a/contracts/mocks/modules/Cover/COMockStakingPool.sol
+++ b/contracts/mocks/modules/Cover/COMockStakingPool.sol
@@ -27,7 +27,7 @@ contract COMockStakingPool is StakingPoolGeneric {
 
   uint public constant MAX_PRICE_RATIO = 10_000;
   uint constant REWARDS_DENOMINATOR = 10_000;
-  uint public constant GLOBAL_MIN_PRICE_RATIO = 100; // 1%
+  uint public constant DEFAULT_MIN_PRICE_RATIO = 100; // 1%
   uint public constant ONE_NXM = 1 ether;
   uint public constant ALLOCATION_UNITS_PER_NXM = 100;
   uint public constant NXM_PER_ALLOCATION_UNIT = ONE_NXM / ALLOCATION_UNITS_PER_NXM;

--- a/contracts/mocks/modules/Cover/COMockStakingProducts.sol
+++ b/contracts/mocks/modules/Cover/COMockStakingProducts.sol
@@ -13,7 +13,7 @@ contract COMockStakingProducts is StakingProductsGeneric {
 
   mapping(uint => mapping(uint => StakedProduct)) private _products;
 
-  uint public constant GLOBAL_MIN_PRICE_RATIO = 100; // 1%
+  uint public constant DEFAULT_MIN_PRICE_RATIO = 100; // 1%
 
   address public immutable coverContract;
   address public immutable tokenControllerContract;
@@ -78,7 +78,7 @@ contract COMockStakingProducts is StakingProductsGeneric {
     // override with initial price and check if pool is allowed
     for (uint i = 0; i < numProducts; i++) {
 
-      if (productInitParams[i].targetPrice < GLOBAL_MIN_PRICE_RATIO) {
+      if (productInitParams[i].targetPrice < DEFAULT_MIN_PRICE_RATIO) {
         revert TargetPriceBelowGlobalMinPriceRatio();
       }
 

--- a/contracts/mocks/modules/Cover/COMockStakingProducts.sol
+++ b/contracts/mocks/modules/Cover/COMockStakingProducts.sol
@@ -79,7 +79,7 @@ contract COMockStakingProducts is StakingProductsGeneric {
     for (uint i = 0; i < numProducts; i++) {
 
       if (productInitParams[i].targetPrice < DEFAULT_MIN_PRICE_RATIO) {
-        revert TargetPriceBelowGlobalMinPriceRatio();
+        revert TargetPriceBelowDefaultMinPriceRatio();
       }
 
       uint productId = productInitParams[i].productId;

--- a/contracts/mocks/modules/Cover/COMockStakingProducts.sol
+++ b/contracts/mocks/modules/Cover/COMockStakingProducts.sol
@@ -79,7 +79,7 @@ contract COMockStakingProducts is StakingProductsGeneric {
     for (uint i = 0; i < numProducts; i++) {
 
       if (productInitParams[i].targetPrice < DEFAULT_MIN_PRICE_RATIO) {
-        revert TargetPriceBelowDefaultMinPriceRatio();
+        revert TargetPriceBelowMinPriceRatio();
       }
 
       uint productId = productInitParams[i].productId;

--- a/contracts/mocks/modules/CoverProducts/CPMockCover.sol
+++ b/contracts/mocks/modules/CoverProducts/CPMockCover.sol
@@ -46,7 +46,7 @@ contract CPMockCover is CoverGeneric {
   }
 
   function getGlobalMinPriceRatio() public override pure returns (uint) {
-    return GLOBAL_MIN_PRICE_RATIO;
+    return DEFAULT_MIN_PRICE_RATIO;
   }
 
   function getProducts() external view returns (Product[] memory) {

--- a/contracts/mocks/modules/CoverProducts/CPMockCover.sol
+++ b/contracts/mocks/modules/CoverProducts/CPMockCover.sol
@@ -45,7 +45,7 @@ contract CPMockCover is CoverGeneric {
     }
   }
 
-  function getGlobalMinPriceRatio() public override pure returns (uint) {
+  function getDefaultMinPriceRatio() public override pure returns (uint) {
     return DEFAULT_MIN_PRICE_RATIO;
   }
 

--- a/contracts/mocks/modules/StakingPool/SKMockCover.sol
+++ b/contracts/mocks/modules/StakingPool/SKMockCover.sol
@@ -60,7 +60,7 @@ contract SKMockCover is CoverGeneric {
         _globalCapacityRatio,
         product.capacityReductionRatio,
         _globalRewardsRatio,
-        GLOBAL_MIN_PRICE_RATIO
+        DEFAULT_MIN_PRICE_RATIO
       )
     );
 

--- a/contracts/mocks/modules/StakingPool/SKMockStakingProducts.sol
+++ b/contracts/mocks/modules/StakingPool/SKMockStakingProducts.sol
@@ -320,13 +320,13 @@ contract SKMockStakingProducts is StakingProductsGeneric, MasterAwareV2, Multica
     uint period,
     uint coverAmount,
     uint totalCapacity,
-    uint defaultMinPrice,
+    uint productMinPrice,
     bool useFixedPrice,
     uint nxmPerAllocationUnit
   ) public override returns (uint premium) {
 
     StakedProduct memory product = _products[poolId][productId];
-    uint targetPrice = Math.max(product.targetPrice, defaultMinPrice);
+    uint targetPrice = Math.max(product.targetPrice, productMinPrice);
 
     if (useFixedPrice) {
       return calculateFixedPricePremium(period, coverAmount, targetPrice, nxmPerAllocationUnit, TARGET_PRICE_DENOMINATOR);

--- a/contracts/mocks/modules/StakingPool/SKMockStakingProducts.sol
+++ b/contracts/mocks/modules/StakingPool/SKMockStakingProducts.sol
@@ -115,7 +115,7 @@ contract SKMockStakingProducts is StakingProductsGeneric, MasterAwareV2, Multica
     }
 
     uint globalCapacityRatio;
-    uint globalMinPriceRatio;
+    uint defaultMinPriceRatio;
 
     uint[] memory initialPriceRatios;
     uint[] memory capacityReductionRatios;
@@ -135,7 +135,7 @@ contract SKMockStakingProducts is StakingProductsGeneric, MasterAwareV2, Multica
       ICover _cover = ICover(coverContract);
 
       globalCapacityRatio = _cover.getGlobalCapacityRatio();
-      globalMinPriceRatio = _cover.getGlobalMinPriceRatio();
+      defaultMinPriceRatio = _cover.getDefaultMinPriceRatio();
 
       initialPriceRatios = _coverProducts.getInitialPrices(productIds);
       capacityReductionRatios = _coverProducts.getCapacityReductionRatios(productIds);
@@ -166,7 +166,7 @@ contract SKMockStakingProducts is StakingProductsGeneric, MasterAwareV2, Multica
         if (_param.targetPrice > TARGET_PRICE_DENOMINATOR) {
           revert TargetPriceTooHigh();
         }
-        if (_param.targetPrice < globalMinPriceRatio) {
+        if (_param.targetPrice < defaultMinPriceRatio) {
           revert TargetPriceBelowMin();
         }
         _product.targetPrice = _param.targetPrice;
@@ -320,13 +320,13 @@ contract SKMockStakingProducts is StakingProductsGeneric, MasterAwareV2, Multica
     uint period,
     uint coverAmount,
     uint totalCapacity,
-    uint globalMinPrice,
+    uint defaultMinPrice,
     bool useFixedPrice,
     uint nxmPerAllocationUnit
   ) public override returns (uint premium) {
 
     StakedProduct memory product = _products[poolId][productId];
-    uint targetPrice = Math.max(product.targetPrice, globalMinPrice);
+    uint targetPrice = Math.max(product.targetPrice, defaultMinPrice);
 
     if (useFixedPrice) {
       return calculateFixedPricePremium(period, coverAmount, targetPrice, nxmPerAllocationUnit, TARGET_PRICE_DENOMINATOR);

--- a/contracts/mocks/modules/StakingProducts/SPMockCover.sol
+++ b/contracts/mocks/modules/StakingProducts/SPMockCover.sol
@@ -46,7 +46,7 @@ contract SPMockCover is CoverGeneric {
     stakingPool[id] = addr;
   }
 
-  function getGlobalMinPriceRatio() public override pure returns (uint) {
+  function getDefaultMinPriceRatio() public override pure returns (uint) {
     return DEFAULT_MIN_PRICE_RATIO;
   }
 

--- a/contracts/mocks/modules/StakingProducts/SPMockCover.sol
+++ b/contracts/mocks/modules/StakingProducts/SPMockCover.sol
@@ -47,7 +47,7 @@ contract SPMockCover is CoverGeneric {
   }
 
   function getGlobalMinPriceRatio() public override pure returns (uint) {
-    return GLOBAL_MIN_PRICE_RATIO;
+    return DEFAULT_MIN_PRICE_RATIO;
   }
 
   function getGlobalCapacityRatio() public override pure returns (uint) {
@@ -55,7 +55,7 @@ contract SPMockCover is CoverGeneric {
   }
 
   function getGlobalCapacityAndPriceRatios() public override pure returns (uint, uint) {
-    return (GLOBAL_CAPACITY_RATIO, GLOBAL_MIN_PRICE_RATIO);
+    return (GLOBAL_CAPACITY_RATIO, DEFAULT_MIN_PRICE_RATIO);
   }
 
   // TODO: remove me. see https://github.com/NexusMutual/smart-contracts/issues/1161
@@ -87,7 +87,7 @@ contract SPMockCover is CoverGeneric {
         GLOBAL_CAPACITY_RATIO,
         product.capacityReductionRatio,
         GLOBAL_REWARDS_RATIO,
-        GLOBAL_MIN_PRICE_RATIO
+        DEFAULT_MIN_PRICE_RATIO
       )
     );
 

--- a/contracts/mocks/modules/StakingProducts/SPMockCoverProducts.sol
+++ b/contracts/mocks/modules/StakingProducts/SPMockCoverProducts.sol
@@ -93,4 +93,15 @@ contract SPMockCoverProducts is CoverProductsGeneric {
       reductionRatios[i] = _products[productIds[i]].capacityReductionRatio;
     }
   }
+
+  function getMinPrices(uint[] calldata productIds) external override view returns (uint[] memory minPrices) {
+    minPrices = new uint[](productIds.length);
+    for (uint i = 0; i < productIds.length; i++) {
+      if (_products[productIds[i]].minPrice != 0) {
+        minPrices[i] = _products[productIds[i]].minPrice;
+      } else {
+        minPrices[i] = DEFAULT_MIN_PRICE_RATIO;
+      }
+    }
+  }
 }

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -67,7 +67,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard, Mu
 
   uint public constant MAX_COMMISSION_RATIO = 3000; // 30%
 
-  uint public constant GLOBAL_MIN_PRICE_RATIO = 100; // 1%
+  uint public constant DEFAULT_MIN_PRICE_RATIO = 100; // 1%
 
   uint private constant ONE_NXM = 1e18;
 
@@ -164,7 +164,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard, Mu
       allocationRequest.globalCapacityRatio = GLOBAL_CAPACITY_RATIO;
       allocationRequest.capacityReductionRatio = product.capacityReductionRatio;
       allocationRequest.rewardRatio = GLOBAL_REWARDS_RATIO;
-      allocationRequest.globalMinPrice = GLOBAL_MIN_PRICE_RATIO;
+      allocationRequest.globalMinPrice = DEFAULT_MIN_PRICE_RATIO;
     }
 
     uint previousSegmentAmount;
@@ -639,7 +639,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard, Mu
   }
 
   function getGlobalMinPriceRatio() external pure returns (uint) {
-    return GLOBAL_MIN_PRICE_RATIO;
+    return DEFAULT_MIN_PRICE_RATIO;
   }
 
   function getGlobalCapacityAndPriceRatios() external pure returns (
@@ -647,7 +647,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard, Mu
     uint _globalMinPriceRatio
   ) {
     _globalCapacityRatio = GLOBAL_CAPACITY_RATIO;
-    _globalMinPriceRatio = GLOBAL_MIN_PRICE_RATIO;
+    _globalMinPriceRatio = DEFAULT_MIN_PRICE_RATIO;
   }
 
   function isCoverAssetSupported(uint assetId, uint productCoverAssetsBitmap) internal view returns (bool) {

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -164,7 +164,11 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard, Mu
       allocationRequest.globalCapacityRatio = GLOBAL_CAPACITY_RATIO;
       allocationRequest.capacityReductionRatio = product.capacityReductionRatio;
       allocationRequest.rewardRatio = GLOBAL_REWARDS_RATIO;
-      allocationRequest.defaultMinPrice = DEFAULT_MIN_PRICE_RATIO;
+      if (product.minPrice != 0) {
+        allocationRequest.productMinPrice = product.minPrice;
+      } else {
+        allocationRequest.productMinPrice = DEFAULT_MIN_PRICE_RATIO;
+      }
     }
 
     uint previousSegmentAmount;

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -164,11 +164,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard, Mu
       allocationRequest.globalCapacityRatio = GLOBAL_CAPACITY_RATIO;
       allocationRequest.capacityReductionRatio = product.capacityReductionRatio;
       allocationRequest.rewardRatio = GLOBAL_REWARDS_RATIO;
-      if (product.minPrice != 0) {
-        allocationRequest.productMinPrice = product.minPrice;
-      } else {
-        allocationRequest.productMinPrice = DEFAULT_MIN_PRICE_RATIO;
-      }
+      allocationRequest.productMinPrice = product.minPrice != 0 ? product.minPrice : DEFAULT_MIN_PRICE_RATIO;
     }
 
     uint previousSegmentAmount;

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -164,7 +164,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard, Mu
       allocationRequest.globalCapacityRatio = GLOBAL_CAPACITY_RATIO;
       allocationRequest.capacityReductionRatio = product.capacityReductionRatio;
       allocationRequest.rewardRatio = GLOBAL_REWARDS_RATIO;
-      allocationRequest.globalMinPrice = DEFAULT_MIN_PRICE_RATIO;
+      allocationRequest.defaultMinPrice = DEFAULT_MIN_PRICE_RATIO;
     }
 
     uint previousSegmentAmount;
@@ -638,16 +638,16 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard, Mu
     return GLOBAL_REWARDS_RATIO;
   }
 
-  function getGlobalMinPriceRatio() external pure returns (uint) {
+  function getDefaultMinPriceRatio() external pure returns (uint) {
     return DEFAULT_MIN_PRICE_RATIO;
   }
 
   function getGlobalCapacityAndPriceRatios() external pure returns (
     uint _globalCapacityRatio,
-    uint _globalMinPriceRatio
+    uint _defaultMinPriceRatio
   ) {
     _globalCapacityRatio = GLOBAL_CAPACITY_RATIO;
-    _globalMinPriceRatio = DEFAULT_MIN_PRICE_RATIO;
+    _defaultMinPriceRatio = DEFAULT_MIN_PRICE_RATIO;
   }
 
   function isCoverAssetSupported(uint assetId, uint productCoverAssetsBitmap) internal view returns (bool) {

--- a/contracts/modules/cover/CoverProducts.sol
+++ b/contracts/modules/cover/CoverProducts.sol
@@ -191,7 +191,7 @@ contract CoverProducts is ICoverProducts, MasterAwareV2, Multicall {
   function setProducts(ProductParam[] calldata productParams) external override onlyAdvisoryBoard {
 
     uint unsupportedCoverAssetsBitmap = type(uint).max;
-    uint globalMinPriceRatio = cover().getGlobalMinPriceRatio();
+    uint defaultMinPriceRatio = cover().getDefaultMinPriceRatio();
 
     uint poolCount = stakingProducts().getStakingPoolCount();
     Asset[] memory assets = pool().getAssets();
@@ -217,8 +217,8 @@ contract CoverProducts is ICoverProducts, MasterAwareV2, Multicall {
         revert UnsupportedCoverAssets();
       }
 
-      if (product.initialPriceRatio < globalMinPriceRatio) {
-        revert InitialPriceRatioBelowGlobalMinPriceRatio();
+      if (product.initialPriceRatio < defaultMinPriceRatio) {
+        revert InitialPriceRatioBelowDefaultMinPriceRatio();
       }
 
       if (product.initialPriceRatio > PRICE_DENOMINATOR) {

--- a/contracts/modules/cover/CoverProducts.sol
+++ b/contracts/modules/cover/CoverProducts.sol
@@ -239,15 +239,9 @@ contract CoverProducts is ICoverProducts, MasterAwareV2, Multicall {
         revert UnsupportedCoverAssets();
       }
 
-      if (product.minPrice == 0) {
-        if (product.initialPriceRatio < defaultMinPriceRatio) {
-          revert InitialPriceRatioBelowDefaultMinPriceRatio();
-        }
-      } else {
-        // TODO: define new error here?
-        if (product.initialPriceRatio < product.minPrice) {
-          revert InitialPriceRatioBelowDefaultMinPriceRatio();
-        }
+      uint256 minPrice = product.minPrice == 0 ? defaultMinPriceRatio : product.minPrice;
+      if (product.initialPriceRatio < minPrice) {
+        revert InitialPriceRatioBelowMinPriceRatio();
       }
 
       if (product.initialPriceRatio > PRICE_DENOMINATOR) {

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -613,7 +613,7 @@ contract StakingPool is IStakingPool, Multicall {
       request.period,
       coverAllocationAmount,
       totalCapacity,
-      request.globalMinPrice,
+      request.defaultMinPrice,
       request.useFixedPrice,
       NXM_PER_ALLOCATION_UNIT
     );

--- a/contracts/modules/staking/StakingPool.sol
+++ b/contracts/modules/staking/StakingPool.sol
@@ -613,7 +613,7 @@ contract StakingPool is IStakingPool, Multicall {
       request.period,
       coverAllocationAmount,
       totalCapacity,
-      request.defaultMinPrice,
+      request.productMinPrice,
       request.useFixedPrice,
       NXM_PER_ALLOCATION_UNIT
     );

--- a/contracts/modules/staking/StakingProducts.sol
+++ b/contracts/modules/staking/StakingProducts.sol
@@ -188,7 +188,7 @@ contract StakingProducts is IStakingProducts, MasterAwareV2, Multicall {
 
     (
       uint globalCapacityRatio,
-      uint globalMinPriceRatio
+      uint defaultMinPriceRatio
     ) = ICover(coverContract).getGlobalCapacityAndPriceRatios();
 
     uint[] memory initialPriceRatios;
@@ -240,7 +240,7 @@ contract StakingProducts is IStakingProducts, MasterAwareV2, Multicall {
           revert TargetPriceTooHigh();
         }
 
-        if (_param.targetPrice < globalMinPriceRatio) {
+        if (_param.targetPrice < defaultMinPriceRatio) {
           revert TargetPriceBelowMin();
         }
 
@@ -370,7 +370,7 @@ contract StakingProducts is IStakingProducts, MasterAwareV2, Multicall {
     uint period,
     uint coverAmount,
     uint totalCapacity,
-    uint globalMinPrice,
+    uint defaultMinPrice,
     bool useFixedPrice,
     uint nxmPerAllocationUnit
   ) public returns (uint premium) {
@@ -380,7 +380,7 @@ contract StakingProducts is IStakingProducts, MasterAwareV2, Multicall {
     }
 
     StakedProduct memory product = _products[poolId][productId];
-    uint targetPrice = Math.max(product.targetPrice, globalMinPrice);
+    uint targetPrice = Math.max(product.targetPrice, defaultMinPrice);
 
     if (useFixedPrice) {
       return calculateFixedPricePremium(coverAmount, period, targetPrice, nxmPerAllocationUnit, TARGET_PRICE_DENOMINATOR);
@@ -518,15 +518,15 @@ contract StakingProducts is IStakingProducts, MasterAwareV2, Multicall {
 
   function _setInitialProducts(uint poolId, ProductInitializationParams[] memory params) internal {
 
-    uint globalMinPriceRatio = cover().getGlobalMinPriceRatio();
+    uint defaultMinPriceRatio = cover().getDefaultMinPriceRatio();
     uint totalTargetWeight;
 
     for (uint i = 0; i < params.length; i++) {
 
       ProductInitializationParams memory param = params[i];
 
-      if (params[i].targetPrice < globalMinPriceRatio) {
-        revert TargetPriceBelowGlobalMinPriceRatio();
+      if (params[i].targetPrice < defaultMinPriceRatio) {
+        revert TargetPriceBelowDefaultMinPriceRatio();
       }
 
       if (param.targetPrice > TARGET_PRICE_DENOMINATOR) {

--- a/contracts/modules/staking/StakingProducts.sol
+++ b/contracts/modules/staking/StakingProducts.sol
@@ -517,15 +517,19 @@ contract StakingProducts is IStakingProducts, MasterAwareV2, Multicall {
 
   function _setInitialProducts(uint poolId, ProductInitializationParams[] memory params) internal {
 
-    uint defaultMinPriceRatio = cover().getDefaultMinPriceRatio();
+    uint numProducts = params.length;
+    uint[] memory productIds = new uint[](numProducts);
+    for (uint i = 0; i < numProducts; i++) {
+      productIds[i] = params[i].productId;
+    }
+    uint[] memory minPriceRatios = coverProducts().getMinPrices(productIds); 
     uint totalTargetWeight;
 
     for (uint i = 0; i < params.length; i++) {
 
       ProductInitializationParams memory param = params[i];
-
-      if (params[i].targetPrice < defaultMinPriceRatio) {
-        revert TargetPriceBelowDefaultMinPriceRatio();
+      if (params[i].targetPrice < minPriceRatios[i]) {
+        revert TargetPriceBelowMinPriceRatio();
       }
 
       if (param.targetPrice > TARGET_PRICE_DENOMINATOR) {

--- a/test/fork/utils.js
+++ b/test/fork/utils.js
@@ -271,7 +271,7 @@ async function getConfig() {
     TRANCHE_DURATION: stakingProducts.TRANCHE_DURATION(),
     GLOBAL_CAPACITY_RATIO: cover.globalCapacityRatio(),
     GLOBAL_REWARDS_RATIO: cover.getGlobalRewardsRatio(),
-    GLOBAL_MIN_PRICE_RATIO: cover.GLOBAL_MIN_PRICE_RATIO(),
+    DEFAULT_MIN_PRICE_RATIO: cover.DEFAULT_MIN_PRICE_RATIO(),
   };
   await Promise.all(Object.keys(config).map(async key => (config[key] = await config[key])));
   return config;

--- a/test/integration/StakingProducts/recalculateEffectiveWeightsForAllProducts.js
+++ b/test/integration/StakingProducts/recalculateEffectiveWeightsForAllProducts.js
@@ -95,11 +95,11 @@ describe('recalculateEffectiveWeightsForAllProducts', function () {
       divCeil(amount.mul(ONE_NXM), nxmPriceInCoverAsset),
       NXM_PER_ALLOCATION_UNIT,
     );
-    const { _globalCapacityRatio, _globalMinPriceRatio } = await cover.getGlobalCapacityAndPriceRatios();
+    const { _globalCapacityRatio, _defaultMinPriceRatio } = await cover.getGlobalCapacityAndPriceRatios();
 
     const expectedCapacity = stakeAmount
       .mul(_globalCapacityRatio)
-      .mul(CAPACITY_REDUCTION_DENOMINATOR.sub(_globalMinPriceRatio))
+      .mul(CAPACITY_REDUCTION_DENOMINATOR.sub(_defaultMinPriceRatio))
       .div(GLOBAL_CAPACITY_DENOMINATOR)
       .div(CAPACITY_REDUCTION_DENOMINATOR);
     const expectedActiveWeight = coverAmountInNXM.mul(WEIGHT_DENOMINATOR).div(expectedCapacity);
@@ -173,11 +173,11 @@ describe('recalculateEffectiveWeightsForAllProducts', function () {
         divCeil(amount.mul(ONE_NXM), nxmPriceInCoverAsset),
         NXM_PER_ALLOCATION_UNIT,
       );
-      const { _globalCapacityRatio, _globalMinPriceRatio } = await cover.getGlobalCapacityAndPriceRatios();
+      const { _globalCapacityRatio, _defaultMinPriceRatio } = await cover.getGlobalCapacityAndPriceRatios();
 
       const expectedCapacity = stakeAmount
         .mul(_globalCapacityRatio)
-        .mul(CAPACITY_REDUCTION_DENOMINATOR.sub(_globalMinPriceRatio))
+        .mul(CAPACITY_REDUCTION_DENOMINATOR.sub(_defaultMinPriceRatio))
         .div(GLOBAL_CAPACITY_DENOMINATOR)
         .div(CAPACITY_REDUCTION_DENOMINATOR);
       const expectedActiveWeight = coverAmountInNXM.mul(WEIGHT_DENOMINATOR).div(expectedCapacity);
@@ -214,11 +214,11 @@ describe('recalculateEffectiveWeightsForAllProducts', function () {
         divCeil(amount.mul(ONE_NXM), nxmPriceInCoverAsset),
         NXM_PER_ALLOCATION_UNIT,
       );
-      const { _globalCapacityRatio, _globalMinPriceRatio } = await cover.getGlobalCapacityAndPriceRatios();
+      const { _globalCapacityRatio, _defaultMinPriceRatio } = await cover.getGlobalCapacityAndPriceRatios();
 
       const expectedCapacity = stakeAmount
         .mul(_globalCapacityRatio)
-        .mul(CAPACITY_REDUCTION_DENOMINATOR.sub(_globalMinPriceRatio))
+        .mul(CAPACITY_REDUCTION_DENOMINATOR.sub(_defaultMinPriceRatio))
         .div(GLOBAL_CAPACITY_DENOMINATOR)
         .div(CAPACITY_REDUCTION_DENOMINATOR);
       const expectedActiveWeight = coverAmountInNXM.mul(WEIGHT_DENOMINATOR).div(expectedCapacity);

--- a/test/unit/Cover/setup.js
+++ b/test/unit/Cover/setup.js
@@ -195,7 +195,7 @@ async function setup() {
     },
   ]);
 
-  const GLOBAL_MIN_PRICE_RATIO = await cover.GLOBAL_MIN_PRICE_RATIO();
+  const DEFAULT_MIN_PRICE_RATIO = await cover.DEFAULT_MIN_PRICE_RATIO();
   const MAX_COMMISSION_RATIO = await cover.MAX_COMMISSION_RATIO();
   const BUCKET_SIZE = BigNumber.from(7 * 24 * 3600); // 7 days
   const capacityFactor = '20000';
@@ -216,7 +216,7 @@ async function setup() {
     stakingPoolFactory,
     stakingProducts,
     coverProducts,
-    config: { GLOBAL_MIN_PRICE_RATIO, BUCKET_SIZE, MAX_COMMISSION_RATIO },
+    config: { DEFAULT_MIN_PRICE_RATIO, BUCKET_SIZE, MAX_COMMISSION_RATIO },
     Assets,
     pooledStakingSigner,
   };

--- a/test/unit/CoverProducts/setProducts.js
+++ b/test/unit/CoverProducts/setProducts.js
@@ -288,7 +288,7 @@ describe('setProducts', function () {
     const productParams = { ...productParamsTemplate, product };
     await expect(
       coverProducts.connect(advisoryBoardMember0).setProducts([productParams]),
-    ).to.be.revertedWithCustomError(coverProducts, 'InitialPriceRatioBelowDefaultMinPriceRatio');
+    ).to.be.revertedWithCustomError(coverProducts, 'InitialPriceRatioBelowMinPriceRatio');
   });
 
   it('should revert if initialPriceRatio is below DEFAULT_MIN_PRICE_RATIO when editing a product', async function () {
@@ -305,7 +305,7 @@ describe('setProducts', function () {
       const productParams = { ...productParamsTemplate, product, productId };
       await expect(
         coverProducts.connect(advisoryBoardMember0).setProducts([productParams]),
-      ).to.be.revertedWithCustomError(coverProducts, 'InitialPriceRatioBelowDefaultMinPriceRatio');
+      ).to.be.revertedWithCustomError(coverProducts, 'InitialPriceRatioBelowMinPriceRatio');
     }
   });
 

--- a/test/unit/CoverProducts/setProducts.js
+++ b/test/unit/CoverProducts/setProducts.js
@@ -278,12 +278,12 @@ describe('setProducts', function () {
     ).to.be.revertedWithCustomError(coverProducts, 'InitialPriceRatioAbove100Percent');
   });
 
-  it('should revert if initialPriceRatio is below GLOBAL_MIN_PRICE_RATIO', async function () {
+  it('should revert if initialPriceRatio is below DEFAULT_MIN_PRICE_RATIO', async function () {
     const fixture = await loadFixture(setup);
     const { coverProducts } = fixture;
     const [advisoryBoardMember0] = fixture.accounts.advisoryBoardMembers;
-    const { GLOBAL_MIN_PRICE_RATIO } = fixture.config;
-    const initialPriceRatio = GLOBAL_MIN_PRICE_RATIO - 1;
+    const { DEFAULT_MIN_PRICE_RATIO } = fixture.config;
+    const initialPriceRatio = DEFAULT_MIN_PRICE_RATIO - 1;
     const product = { ...productTemplate, initialPriceRatio };
     const productParams = { ...productParamsTemplate, product };
     await expect(
@@ -291,16 +291,16 @@ describe('setProducts', function () {
     ).to.be.revertedWithCustomError(coverProducts, 'InitialPriceRatioBelowGlobalMinPriceRatio');
   });
 
-  it('should revert if initialPriceRatio is below GLOBAL_MIN_PRICE_RATIO when editing a product', async function () {
+  it('should revert if initialPriceRatio is below DEFAULT_MIN_PRICE_RATIO when editing a product', async function () {
     const fixture = await loadFixture(setup);
     const { coverProducts } = fixture;
     const [advisoryBoardMember0] = fixture.accounts.advisoryBoardMembers;
     const productId = 1;
-    const { GLOBAL_MIN_PRICE_RATIO } = fixture.config;
+    const { DEFAULT_MIN_PRICE_RATIO } = fixture.config;
     const productParams = { ...productParamsTemplate };
     await coverProducts.connect(advisoryBoardMember0).setProducts([productParams]);
     {
-      const initialPriceRatio = GLOBAL_MIN_PRICE_RATIO - 1;
+      const initialPriceRatio = DEFAULT_MIN_PRICE_RATIO - 1;
       const product = { ...productTemplate, initialPriceRatio };
       const productParams = { ...productParamsTemplate, product, productId };
       await expect(

--- a/test/unit/CoverProducts/setProducts.js
+++ b/test/unit/CoverProducts/setProducts.js
@@ -413,4 +413,27 @@ describe('setProducts', function () {
     const productName = await coverProducts.getProductName(productsCount.sub(1));
     expect(productName).to.be.equal(expectedProductName);
   });
+
+  it('should set a product with minPrice', async function () {
+    const fixture = await loadFixture(setup);
+    const { coverProducts } = fixture;
+    const [advisoryBoardMember0] = fixture.accounts.advisoryBoardMembers;
+
+    const expectedProductMinPrice = 100;
+
+    const productParams = {
+      ...productParamsTemplate,
+      product: {
+        ...productTemplate,
+        minPrice: expectedProductMinPrice,
+      },
+    };
+
+    await coverProducts.connect(advisoryBoardMember0).setProducts([productParams]);
+
+    const productsCount = await coverProducts.getProductCount();
+    const product = await coverProducts.getProduct(productsCount.sub(1));
+
+    expect(product.minPrice).to.be.equal(expectedProductMinPrice);
+  });
 });

--- a/test/unit/CoverProducts/setProducts.js
+++ b/test/unit/CoverProducts/setProducts.js
@@ -288,7 +288,7 @@ describe('setProducts', function () {
     const productParams = { ...productParamsTemplate, product };
     await expect(
       coverProducts.connect(advisoryBoardMember0).setProducts([productParams]),
-    ).to.be.revertedWithCustomError(coverProducts, 'InitialPriceRatioBelowGlobalMinPriceRatio');
+    ).to.be.revertedWithCustomError(coverProducts, 'InitialPriceRatioBelowDefaultMinPriceRatio');
   });
 
   it('should revert if initialPriceRatio is below DEFAULT_MIN_PRICE_RATIO when editing a product', async function () {
@@ -305,7 +305,7 @@ describe('setProducts', function () {
       const productParams = { ...productParamsTemplate, product, productId };
       await expect(
         coverProducts.connect(advisoryBoardMember0).setProducts([productParams]),
-      ).to.be.revertedWithCustomError(coverProducts, 'InitialPriceRatioBelowGlobalMinPriceRatio');
+      ).to.be.revertedWithCustomError(coverProducts, 'InitialPriceRatioBelowDefaultMinPriceRatio');
     }
   });
 

--- a/test/unit/CoverProducts/setup.js
+++ b/test/unit/CoverProducts/setup.js
@@ -174,7 +174,7 @@ async function setup() {
   // add products
   await coverProducts.connect(accounts.advisoryBoardMembers[0]).setProducts(products);
 
-  const GLOBAL_MIN_PRICE_RATIO = await cover.GLOBAL_MIN_PRICE_RATIO();
+  const DEFAULT_MIN_PRICE_RATIO = await cover.DEFAULT_MIN_PRICE_RATIO();
   const BUCKET_SIZE = BigNumber.from(7 * 24 * 3600); // 7 days
   const capacityFactor = '20000';
 
@@ -193,7 +193,7 @@ async function setup() {
     capacityFactor,
     stakingProducts,
     coverProducts,
-    config: { GLOBAL_MIN_PRICE_RATIO, BUCKET_SIZE },
+    config: { DEFAULT_MIN_PRICE_RATIO, BUCKET_SIZE },
     Assets,
     pooledStakingSigner,
     productTypes,

--- a/test/unit/StakingPool/burnStake.js
+++ b/test/unit/StakingPool/burnStake.js
@@ -66,7 +66,7 @@ const allocationRequestParams = {
   globalCapacityRatio: 20000,
   capacityReductionRatio: 0,
   rewardRatio: 5000,
-  defaultMinPrice: 10000,
+  productMinPrice: 10000,
 };
 
 const stakedNxmAmount = parseEther('100');

--- a/test/unit/StakingPool/burnStake.js
+++ b/test/unit/StakingPool/burnStake.js
@@ -66,7 +66,7 @@ const allocationRequestParams = {
   globalCapacityRatio: 20000,
   capacityReductionRatio: 0,
   rewardRatio: 5000,
-  globalMinPrice: 10000,
+  defaultMinPrice: 10000,
 };
 
 const stakedNxmAmount = parseEther('100');

--- a/test/unit/StakingPool/depositTo.js
+++ b/test/unit/StakingPool/depositTo.js
@@ -276,7 +276,7 @@ describe('depositTo', function () {
       globalCapacityRatio: 20000,
       capacityReductionRatio: 0,
       rewardRatio: 5000,
-      globalMinPrice: 10000,
+      defaultMinPrice: 10000,
     };
 
     const { firstActiveTrancheId } = await getTranches(allocationRequest.period, allocationRequest.gracePeriod);
@@ -342,7 +342,7 @@ describe('depositTo', function () {
       globalCapacityRatio: 20000,
       capacityReductionRatio: 0,
       rewardRatio: 5000,
-      globalMinPrice: 10000,
+      defaultMinPrice: 10000,
     };
 
     const { firstActiveTrancheId } = await getTranches(allocationRequest.period, allocationRequest.gracePeriod);
@@ -400,7 +400,7 @@ describe('depositTo', function () {
       globalCapacityRatio: 20000,
       capacityReductionRatio: 0,
       rewardRatio: 5000,
-      globalMinPrice: 10000,
+      defaultMinPrice: 10000,
     };
 
     const { firstActiveTrancheId } = await getTranches(allocationRequest.period, allocationRequest.gracePeriod);

--- a/test/unit/StakingPool/depositTo.js
+++ b/test/unit/StakingPool/depositTo.js
@@ -276,7 +276,7 @@ describe('depositTo', function () {
       globalCapacityRatio: 20000,
       capacityReductionRatio: 0,
       rewardRatio: 5000,
-      defaultMinPrice: 10000,
+      productMinPrice: 10000,
     };
 
     const { firstActiveTrancheId } = await getTranches(allocationRequest.period, allocationRequest.gracePeriod);
@@ -342,7 +342,7 @@ describe('depositTo', function () {
       globalCapacityRatio: 20000,
       capacityReductionRatio: 0,
       rewardRatio: 5000,
-      defaultMinPrice: 10000,
+      productMinPrice: 10000,
     };
 
     const { firstActiveTrancheId } = await getTranches(allocationRequest.period, allocationRequest.gracePeriod);
@@ -400,7 +400,7 @@ describe('depositTo', function () {
       globalCapacityRatio: 20000,
       capacityReductionRatio: 0,
       rewardRatio: 5000,
-      defaultMinPrice: 10000,
+      productMinPrice: 10000,
     };
 
     const { firstActiveTrancheId } = await getTranches(allocationRequest.period, allocationRequest.gracePeriod);

--- a/test/unit/StakingPool/helpers.js
+++ b/test/unit/StakingPool/helpers.js
@@ -110,7 +110,7 @@ async function generateRewards(
     globalCapacityRatio: 20000,
     capacityReductionRatio: 0,
     rewardRatio: 5000,
-    defaultMinPrice: 10000,
+    productMinPrice: 10000,
   };
   await stakingPool.connect(signer).requestAllocation(amount, previousPremium, allocationRequest);
 }

--- a/test/unit/StakingPool/helpers.js
+++ b/test/unit/StakingPool/helpers.js
@@ -110,7 +110,7 @@ async function generateRewards(
     globalCapacityRatio: 20000,
     capacityReductionRatio: 0,
     rewardRatio: 5000,
-    globalMinPrice: 10000,
+    defaultMinPrice: 10000,
   };
   await stakingPool.connect(signer).requestAllocation(amount, previousPremium, allocationRequest);
 }

--- a/test/unit/StakingPool/requestAllocation.js
+++ b/test/unit/StakingPool/requestAllocation.js
@@ -162,7 +162,7 @@ describe('requestAllocation', function () {
   it('should update allocation amount', async function () {
     const fixture = await loadFixture(requestAllocationSetup);
     const { stakingPool, cover } = fixture;
-    const { GLOBAL_CAPACITY_RATIO, GLOBAL_MIN_PRICE_RATIO, GLOBAL_REWARDS_RATIO, NXM_PER_ALLOCATION_UNIT } =
+    const { GLOBAL_CAPACITY_RATIO, DEFAULT_MIN_PRICE_RATIO, GLOBAL_REWARDS_RATIO, NXM_PER_ALLOCATION_UNIT } =
       fixture.config;
     const { timestamp } = await ethers.provider.getBlock('latest');
     const allocationId = await stakingPool.getNextAllocationId();
@@ -181,7 +181,7 @@ describe('requestAllocation', function () {
       globalCapacityRatio: GLOBAL_CAPACITY_RATIO,
       capacityReductionRatio: coverProductTemplate.capacityReductionRatio,
       rewardRatio: GLOBAL_REWARDS_RATIO,
-      globalMinPrice: GLOBAL_MIN_PRICE_RATIO,
+      globalMinPrice: DEFAULT_MIN_PRICE_RATIO,
     };
 
     await cover.requestAllocation(buyCoverParamsTemplate.amount, 0, request, stakingPool.address);

--- a/test/unit/StakingPool/requestAllocation.js
+++ b/test/unit/StakingPool/requestAllocation.js
@@ -54,7 +54,7 @@ const allocationRequestParams = {
   globalCapacityRatio: 20000,
   capacityReductionRatio: 0,
   rewardRatio: 5000,
-  defaultMinPrice: 10000,
+  productMinPrice: 10000,
 };
 
 const buyCoverParamsTemplate = {
@@ -181,7 +181,7 @@ describe('requestAllocation', function () {
       globalCapacityRatio: GLOBAL_CAPACITY_RATIO,
       capacityReductionRatio: coverProductTemplate.capacityReductionRatio,
       rewardRatio: GLOBAL_REWARDS_RATIO,
-      defaultMinPrice: DEFAULT_MIN_PRICE_RATIO,
+      productMinPrice: DEFAULT_MIN_PRICE_RATIO,
     };
 
     await cover.requestAllocation(buyCoverParamsTemplate.amount, 0, request, stakingPool.address);

--- a/test/unit/StakingPool/requestAllocation.js
+++ b/test/unit/StakingPool/requestAllocation.js
@@ -54,7 +54,7 @@ const allocationRequestParams = {
   globalCapacityRatio: 20000,
   capacityReductionRatio: 0,
   rewardRatio: 5000,
-  globalMinPrice: 10000,
+  defaultMinPrice: 10000,
 };
 
 const buyCoverParamsTemplate = {
@@ -181,7 +181,7 @@ describe('requestAllocation', function () {
       globalCapacityRatio: GLOBAL_CAPACITY_RATIO,
       capacityReductionRatio: coverProductTemplate.capacityReductionRatio,
       rewardRatio: GLOBAL_REWARDS_RATIO,
-      globalMinPrice: DEFAULT_MIN_PRICE_RATIO,
+      defaultMinPrice: DEFAULT_MIN_PRICE_RATIO,
     };
 
     await cover.requestAllocation(buyCoverParamsTemplate.amount, 0, request, stakingPool.address);

--- a/test/unit/StakingPool/setPoolFee.js
+++ b/test/unit/StakingPool/setPoolFee.js
@@ -22,7 +22,7 @@ const allocationRequestTemplate = {
   globalCapacityRatio: 20000,
   capacityReductionRatio: 0,
   rewardRatio: 5000,
-  globalMinPrice: 10000,
+  defaultMinPrice: 10000,
 };
 
 const product = {

--- a/test/unit/StakingPool/setPoolFee.js
+++ b/test/unit/StakingPool/setPoolFee.js
@@ -22,7 +22,7 @@ const allocationRequestTemplate = {
   globalCapacityRatio: 20000,
   capacityReductionRatio: 0,
   rewardRatio: 5000,
-  defaultMinPrice: 10000,
+  productMinPrice: 10000,
 };
 
 const product = {

--- a/test/unit/StakingPool/setup.js
+++ b/test/unit/StakingPool/setup.js
@@ -82,7 +82,7 @@ async function setup() {
     TRANCHE_DURATION: await stakingProducts.TRANCHE_DURATION(),
     GLOBAL_CAPACITY_RATIO: await cover.globalCapacityRatio(),
     GLOBAL_REWARDS_RATIO: await cover.getGlobalRewardsRatio(),
-    GLOBAL_MIN_PRICE_RATIO: await cover.GLOBAL_MIN_PRICE_RATIO(),
+    DEFAULT_MIN_PRICE_RATIO: await cover.DEFAULT_MIN_PRICE_RATIO(),
   };
 
   const coverSigner = await ethers.getImpersonatedSigner(cover.address);

--- a/test/unit/StakingPool/withdraw.js
+++ b/test/unit/StakingPool/withdraw.js
@@ -490,7 +490,7 @@ describe('withdraw', function () {
       globalCapacityRatio: 20000,
       capacityReductionRatio: 0,
       rewardRatio: 10000, // 1:1
-      globalMinPrice: 10000,
+      defaultMinPrice: 10000,
     };
 
     const poolId = initializeParams.poolId;

--- a/test/unit/StakingPool/withdraw.js
+++ b/test/unit/StakingPool/withdraw.js
@@ -490,7 +490,7 @@ describe('withdraw', function () {
       globalCapacityRatio: 20000,
       capacityReductionRatio: 0,
       rewardRatio: 10000, // 1:1
-      defaultMinPrice: 10000,
+      productMinPrice: 10000,
     };
 
     const poolId = initializeParams.poolId;

--- a/test/unit/StakingProducts/createStakingPool.js
+++ b/test/unit/StakingProducts/createStakingPool.js
@@ -269,6 +269,6 @@ describe('createStakingPool', function () {
         products,
         ipfsDescriptionHash,
       ),
-    ).to.be.revertedWithCustomError(stakingProducts, 'TargetPriceBelowGlobalMinPriceRatio');
+    ).to.be.revertedWithCustomError(stakingProducts, 'TargetPriceBelowDefaultMinPriceRatio');
   });
 });

--- a/test/unit/StakingProducts/createStakingPool.js
+++ b/test/unit/StakingProducts/createStakingPool.js
@@ -256,11 +256,11 @@ describe('createStakingPool', function () {
   it('should fail to initialize products with targetPrice below global minimum', async function () {
     const fixture = await loadFixture(createStakingPoolSetup);
     const { stakingProducts } = fixture;
-    const { GLOBAL_MIN_PRICE_RATIO } = fixture.config;
+    const { DEFAULT_MIN_PRICE_RATIO } = fixture.config;
     const [stakingPoolCreator] = fixture.accounts.members;
     const { initialPoolFee, maxPoolFee, productInitializationParams, ipfsDescriptionHash } = newPoolFixture;
 
-    const products = [{ ...productInitializationParams[0], targetPrice: GLOBAL_MIN_PRICE_RATIO - 1 }];
+    const products = [{ ...productInitializationParams[0], targetPrice: DEFAULT_MIN_PRICE_RATIO - 1 }];
     await expect(
       stakingProducts.connect(stakingPoolCreator).createStakingPool(
         false, // isPrivatePool,

--- a/test/unit/StakingProducts/helpers.js
+++ b/test/unit/StakingProducts/helpers.js
@@ -111,7 +111,7 @@ async function depositTo(params) {
 async function allocateCapacity({ amount, productId }) {
   const { stakingPool, coverSigner, coverProductTemplate } = this;
 
-  const { GLOBAL_CAPACITY_RATIO, GLOBAL_REWARDS_RATIO, GLOBAL_MIN_PRICE_RATIO } = this.config;
+  const { GLOBAL_CAPACITY_RATIO, GLOBAL_REWARDS_RATIO, DEFAULT_MIN_PRICE_RATIO } = this.config;
 
   const allocationRequest = {
     ...allocationRequestTemplate,
@@ -120,7 +120,7 @@ async function allocateCapacity({ amount, productId }) {
     capacityReductionRatio: coverProductTemplate.capacityReductionRatio,
     useFixedPrice: coverProductTemplate.useFixedPrice,
     rewardRatio: GLOBAL_REWARDS_RATIO,
-    globalMinPrice: GLOBAL_MIN_PRICE_RATIO,
+    globalMinPrice: DEFAULT_MIN_PRICE_RATIO,
   };
 
   await stakingPool.connect(coverSigner).requestAllocation(amount, 0, allocationRequest);

--- a/test/unit/StakingProducts/helpers.js
+++ b/test/unit/StakingProducts/helpers.js
@@ -50,6 +50,11 @@ const newProductTemplate = {
   targetPrice: 500,
 };
 
+const newProductWithMinPriceTemplate = {
+  ...newProductTemplate,
+  productId: 200,
+};
+
 const burnStakeParams = {
   allocationId: 1,
   productId: 1,
@@ -120,7 +125,7 @@ async function allocateCapacity({ amount, productId }) {
     capacityReductionRatio: coverProductTemplate.capacityReductionRatio,
     useFixedPrice: coverProductTemplate.useFixedPrice,
     rewardRatio: GLOBAL_REWARDS_RATIO,
-    defaultMinPrice: DEFAULT_MIN_PRICE_RATIO,
+    productMinPrice: DEFAULT_MIN_PRICE_RATIO,
   };
 
   await stakingPool.connect(coverSigner).requestAllocation(amount, 0, allocationRequest);
@@ -164,6 +169,7 @@ module.exports = {
   allocateCapacity,
   initialProductTemplate,
   newProductTemplate,
+  newProductWithMinPriceTemplate,
   buyCoverParamsTemplate,
   setStakedProducts,
   burnStake,

--- a/test/unit/StakingProducts/helpers.js
+++ b/test/unit/StakingProducts/helpers.js
@@ -120,7 +120,7 @@ async function allocateCapacity({ amount, productId }) {
     capacityReductionRatio: coverProductTemplate.capacityReductionRatio,
     useFixedPrice: coverProductTemplate.useFixedPrice,
     rewardRatio: GLOBAL_REWARDS_RATIO,
-    globalMinPrice: DEFAULT_MIN_PRICE_RATIO,
+    defaultMinPrice: DEFAULT_MIN_PRICE_RATIO,
   };
 
   await stakingPool.connect(coverSigner).requestAllocation(amount, 0, allocationRequest);

--- a/test/unit/StakingProducts/setProducts.js
+++ b/test/unit/StakingProducts/setProducts.js
@@ -366,7 +366,7 @@ describe('setProducts unit tests', function () {
   it('should edit prices and skip weights', async function () {
     const fixture = await loadFixture(setup);
     const { stakingProducts } = fixture;
-    const { GLOBAL_MIN_PRICE_RATIO } = fixture.config;
+    const { DEFAULT_MIN_PRICE_RATIO } = fixture.config;
     const [manager] = fixture.accounts.members;
 
     const newProductParams = { ...newProductTemplate };
@@ -382,7 +382,7 @@ describe('setProducts unit tests', function () {
     await stakingProducts
       .connect(manager)
       .setProducts(poolId, [
-        { ...newProductParams, targetWeight: 1, setTargetWeight: false, targetPrice: GLOBAL_MIN_PRICE_RATIO },
+        { ...newProductParams, targetWeight: 1, setTargetWeight: false, targetPrice: DEFAULT_MIN_PRICE_RATIO },
       ]);
 
     const { timestamp: bumpedPriceUpdateTimeAfter } = await ethers.provider.getBlock('latest');
@@ -390,7 +390,7 @@ describe('setProducts unit tests', function () {
       product: await stakingProducts.getProduct(poolId, 0),
       productParams: {
         ...newProductTemplate,
-        targetPrice: GLOBAL_MIN_PRICE_RATIO,
+        targetPrice: DEFAULT_MIN_PRICE_RATIO,
         bumpedPriceUpdateTimeAfter,
       },
     });
@@ -411,10 +411,10 @@ describe('setProducts unit tests', function () {
   it('should fail with targetPrice below global min price ratio', async function () {
     const fixture = await loadFixture(setup);
     const { stakingProducts } = fixture;
-    const { GLOBAL_MIN_PRICE_RATIO } = fixture.config;
+    const { DEFAULT_MIN_PRICE_RATIO } = fixture.config;
     const [manager] = fixture.accounts.members;
 
-    const product = { ...newProductTemplate, targetPrice: GLOBAL_MIN_PRICE_RATIO - 1 };
+    const product = { ...newProductTemplate, targetPrice: DEFAULT_MIN_PRICE_RATIO - 1 };
     await expect(stakingProducts.connect(manager).setProducts(poolId, [product])).to.be.revertedWithCustomError(
       stakingProducts,
       'TargetPriceBelowMin',

--- a/test/unit/StakingProducts/setup.js
+++ b/test/unit/StakingProducts/setup.js
@@ -152,7 +152,7 @@ async function setup() {
     TRANCHE_DURATION: await stakingProducts.TRANCHE_DURATION(),
     GLOBAL_CAPACITY_RATIO: await cover.GLOBAL_CAPACITY_RATIO(),
     GLOBAL_REWARDS_RATIO: await cover.GLOBAL_REWARDS_RATIO(),
-    GLOBAL_MIN_PRICE_RATIO: await cover.GLOBAL_MIN_PRICE_RATIO(),
+    DEFAULT_MIN_PRICE_RATIO: await cover.DEFAULT_MIN_PRICE_RATIO(),
   };
 
   const coverSigner = await ethers.getImpersonatedSigner(cover.address);

--- a/test/unit/StakingProducts/setup.js
+++ b/test/unit/StakingProducts/setup.js
@@ -5,6 +5,7 @@ const { getAccounts } = require('../utils').accounts;
 const { setEtherBalance } = require('../utils').evm;
 const { Role } = require('../utils').constants;
 const { hex } = require('../utils').helpers;
+const { MaxUint256 } = ethers.constants;
 
 const { parseEther, getContractAddress } = ethers.utils;
 
@@ -23,6 +24,11 @@ const coverProductTemplate = {
   initialPriceRatio: 500,
   capacityReductionRatio: 0,
   useFixedPrice: false,
+};
+
+const productWithMinPrice = {
+  ...coverProductTemplate,
+  minPrice: 10, // 0.1%
 };
 
 const ProductTypeFixture = {
@@ -136,6 +142,12 @@ async function setup() {
       await coverProducts.setPoolAllowed(productId, poolId, true);
     }),
   );
+
+  // set product with minPrice
+  const expectedProductId = await coverProducts.getProductCount();
+  await coverProducts.setProduct(productWithMinPrice, MaxUint256);
+  await coverProducts.setProductType(ProductTypeFixture, expectedProductId);
+  await coverProducts.setPoolAllowed(expectedProductId, poolId, true);
 
   const config = {
     PRICE_CHANGE_PER_DAY: await stakingProducts.PRICE_CHANGE_PER_DAY(),

--- a/test/unit/StakingProducts/setup.js
+++ b/test/unit/StakingProducts/setup.js
@@ -5,7 +5,6 @@ const { getAccounts } = require('../utils').accounts;
 const { setEtherBalance } = require('../utils').evm;
 const { Role } = require('../utils').constants;
 const { hex } = require('../utils').helpers;
-const { MaxUint256 } = ethers.constants;
 
 const { parseEther, getContractAddress } = ethers.utils;
 
@@ -145,7 +144,7 @@ async function setup() {
 
   // set product with minPrice
   const expectedProductId = await coverProducts.getProductCount();
-  await coverProducts.setProduct(productWithMinPrice, MaxUint256);
+  await coverProducts.setProduct(productWithMinPrice, expectedProductId);
   await coverProducts.setProductType(ProductTypeFixture, expectedProductId);
   await coverProducts.setPoolAllowed(expectedProductId, poolId, true);
 


### PR DESCRIPTION
## Description

Closes #1292 

Renamed `GLOBAL_MIN_PRICE` to `DEFAULT_MIN_PRICE`.
Added min price setting per product. If it's set to 0 then `DEFAULT_MIN_PRICE` is used for the product min price. 

note: base branch is currently set to `refactor/remove-yield-token-incidents` for an easier review of changes from this PR.

## Testing

wip

## Checklist

- [ ] Performed a self-review of my own code
- [ ] Made corresponding changes to the documentation
