### PR TITLE
chore: ensure .env loading and cleanup compilers

### DIFF
--- a/hardhat-config/index.js
+++ b/hardhat-config/index.js
@@ -1,4 +1,8 @@
-require('dotenv').config();
+const path = require('node:path');
+
+// ensure .env is loaded even if cwd is not the project root
+require('dotenv').config({ path: path.resolve(__dirname, '../.env') });
+
 require('@typechain/hardhat');
 require('@nomiclabs/hardhat-etherscan');
 require('@nomicfoundation/hardhat-chai-matchers');

--- a/hardhat-config/solidity.js
+++ b/hardhat-config/solidity.js
@@ -18,6 +18,6 @@ const overrides = {
 };
 
 module.exports = {
-  compilers: Object.values(compilers),
+  compilers,
   overrides,
 };


### PR DESCRIPTION
## Description

1. If `cwd` was not the root directory, running `hh compile` would compile without optimizer enabled because `dotenv` wouldn't load `.env`. This fix ensures `.env` is always loaded, regardless of the `cwd`.
2. We had a leftover `Object.values(array)` in `solidity.js` that we no longer need (the compilers array was an object at some point).

## Testing

```
cd test/
hh compile
```

this should result in no compilation warnings (contracts exceeding max size) which we'd get when compiling without optimizer enabled.

## Checklist

- [x] Performed a self-review of my own code
- [ ] Made corresponding changes to the documentation
