### PR TITLE
fix: add yield token incident claim method type back

### DIFF
--- a/contracts/interfaces/ICoverProducts.sol
+++ b/contracts/interfaces/ICoverProducts.sol
@@ -7,7 +7,8 @@ import "./ICover.sol";
 /* enums */
 
 enum ClaimMethod {
-  IndividualClaims
+  IndividualClaims,
+  DeprecatedYieldTokenIncidents
 }
 
 /* io structs */


### PR DESCRIPTION
Add yield token incident claim method type back and mark it as deprecated

## Description

Removed enum value made getProductType calls fail because of claim method being `1` in contract storage on mainnet. Adding it back to address the issue.

## Deployment

:warning:  If there's nothing failing on-chain we may keep this for the next release, otherwise we may consider a hotfix.

## Testing

Explain how you tested your changes to ensure they work as expected.

## Checklist

- [x] Performed a self-review of my own code
- [ ] Made corresponding changes to the documentation
