### PR TITLE
fix: renewal of a cover that was bought with limitOrders

### DIFF
--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -130,7 +130,8 @@ interface ICover {
 
   function executeCoverBuy(
     BuyCoverParams calldata params,
-    PoolAllocationRequest[] calldata coverChunkRequests
+    PoolAllocationRequest[] calldata coverChunkRequests,
+    address buyer
   ) external payable returns (uint coverId);
 
   function burnStake(uint coverId, uint amount) external returns (address coverOwner);

--- a/contracts/interfaces/ILimitOrders.sol
+++ b/contracts/interfaces/ILimitOrders.sol
@@ -62,7 +62,7 @@ interface ILimitOrders {
 
   /* ==== EVENTS ==== */
 
-  event OrderExecuted(address owner, uint coverId, bytes32 id);
+  event OrderExecuted(address owner, uint originalCoverId, uint coverId, bytes32 id);
   event OrderCancelled(bytes32 id);
 
   /* ==== ERRORS ==== */

--- a/contracts/mocks/generic/CoverGeneric.sol
+++ b/contracts/mocks/generic/CoverGeneric.sol
@@ -84,7 +84,8 @@ contract CoverGeneric is ICover {
 
   function executeCoverBuy(
     BuyCoverParams calldata /* params */,
-    PoolAllocationRequest[] calldata /* coverChunkRequests */
+    PoolAllocationRequest[] calldata, /* coverChunkRequests */
+    address /*buyer*/
   ) external virtual payable returns (uint) {
     revert("Unsupported");
   }

--- a/contracts/mocks/modules/LimitOrders/LimitOrdersCoverMock.sol
+++ b/contracts/mocks/modules/LimitOrders/LimitOrdersCoverMock.sol
@@ -7,7 +7,8 @@ contract LimitOrdersCoverMock is CoverGeneric {
 
   function executeCoverBuy(
     BuyCoverParams memory,
-    PoolAllocationRequest[] memory
+    PoolAllocationRequest[] memory,
+    address
   ) external payable override returns (uint coverId) {
     return 1;
   }

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -105,13 +105,24 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard, Mu
     BuyCoverParams memory params,
     PoolAllocationRequest[] memory poolAllocationRequests
   ) external payable onlyMember returns (uint coverId) {
+
+    if (params.coverId != 0) {
+      require(coverNFT.isApprovedOrOwner(msg.sender, params.coverId), OnlyOwnerOrApproved());
+    }
+
     return _buyCover(params, poolAllocationRequests);
   }
 
   function executeCoverBuy(
     BuyCoverParams memory params,
-    PoolAllocationRequest[] memory poolAllocationRequests
+    PoolAllocationRequest[] memory poolAllocationRequests,
+    address buyer
   ) external payable onlyInternal returns (uint coverId) {
+
+    if (params.coverId != 0) {
+      require(coverNFT.isApprovedOrOwner(buyer, params.coverId), OnlyOwnerOrApproved());
+    }
+
     return _buyCover(params, poolAllocationRequests);
   }
 
@@ -136,7 +147,6 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard, Mu
 
     if (params.coverId != 0) {
 
-      require(coverNFT.isApprovedOrOwner(msg.sender, params.coverId), OnlyOwnerOrApproved());
 
       CoverReference memory coverReference = getCoverReference(params.coverId);
 

--- a/contracts/modules/cover/LimitOrders.sol
+++ b/contracts/modules/cover/LimitOrders.sol
@@ -101,7 +101,7 @@ contract LimitOrders is ILimitOrders, MasterAwareV2, EIP712 {
     require(!_orderStatus.isCancelled, OrderAlreadyCancelled());
 
     uint originalCoverId = _orderStatus.coverId;
-    bool isNewCover = _orderStatus.coverId == 0;
+    bool isNewCover = _orderStatus.coverId == 0 && params.coverId == 0;
     BuyCoverParams memory _params = params;
 
     if (isNewCover) {


### PR DESCRIPTION
Two issues we currently have:
- When there is an order with initial cover buy and renewals, we don't pass an original cover ID when renewing, so the cover doesn't get edited, and we would have double covers for some period. The second renewal would fail because we have a check for the expiration by the initial cover ID that doesn't have a new cover linked to it, and limit order contract would see it as expired, and the renewal wouldn't happen.

- When renewing a cover (edit), since we don't pass the original cover ID, we never get to check the approval and ownership of the cover. And it fails since the msg.sender is the LimitOrders contract and not the owner of the cover. 


## Description

- Created `_params` that copy arguments from `params` passed to the execute function and add coverId if the cover was initially bought by the LimitOrders contract

- Move the check for approval and ownership to the `buyCover` and `executeCoverBuy` methods so we can compare different values. In the case of `buyCover`, we still check the information of msg.sender, but in executeCoverBuy we use the buyer param for the check.

## Testing

Explain how you tested your changes to ensure they work as expected.

## Checklist

- [ ] Performed a self-review of my own code
- [ ] Made corresponding changes to the documentation
