### PR TITLE
ci: add release and release next workflows

### DIFF
--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -1,0 +1,110 @@
+# Release Next Workflow
+#
+# This workflow is responsible for creating and publishing release candidate (RC) versions
+# to npm with the '@next' tag when changes are pushed to the release-candidate branch.
+#
+# Workflow Behavior:
+# - Triggered on push to release-candidate branch
+# - Checks if commits since the last tag trigger a version bump using conventional commits
+# - If a version bump is triggered, determines the appropriate RC version number
+# - Publishes an RC version to npm with the '@next' tag
+# - RC versions follow the pattern: {new_version}-rc{number} (e.g., 1.2.0-rc1, 1.2.0-rc2)
+# - RC number increments for each new RC of the same base version
+#
+# Scenarios:
+# 1. Feature branch merged to release-candidate with commits that trigger a version bump:
+#    - Workflow determines the next semantic version (e.g., 0.2.0 from 0.1.0)
+#    - Publishes first RC (e.g., 0.2.0-rc1) or increments RC number (e.g., 0.2.0-rc2)
+#    - No commits are made to the repository, only published to npm
+#
+# 2. Feature branch merged to release-candidate with commits that don't trigger a version bump:
+#    - Workflow exits early with no action
+#    - No RC version is published
+#
+# 3. Multiple pushes to release-candidate for the same base version:
+#    - RC number increments with each push (rc1, rc2, rc3, etc.) and publishes to npm
+#    - No commits are made to the repository, only published to npm
+#
+# 4. Version bump commit from master rebased to release-candidate:
+#    - Contains [skip ci] in the commit message to prevent this workflow from running
+#    - Prevents publishing RC versions based on the version bump commit itself
+#
+# NOTE: This workflow does NOT commit any changes to git. It only publishes to npm.
+# The actual version bump commit happens in the main release.yml workflow.
+
+name: Release Next
+
+on:
+  push:
+    branches:
+      - release-candidate
+
+env:
+  NODE_VERSION: 22
+  PROVIDER_URL: ${{ secrets.PROVIDER_URL }}
+
+jobs:
+  # First step: Determines if the commits since last tag triggers a version bump
+  # Outputs:
+  # - bump_type: The type of semantic version bump (major, minor, patch)
+  # - triggers_bump: 'true' if a version bump is needed, 'false' otherwise
+  check-version-bump:
+    uses: NexusMutual/workflows/.github/workflows/check-version-bump.yml@master
+    with:
+      ref: ${{ github.ref_name }}
+      environment: production
+      bump-command: |
+        timeout 5s npx conventional-recommended-bump --config .github/config/conventional-bump-setup.js
+    secrets:
+      DEPLOYER_APP_ID: ${{ secrets.DEPLOYER_APP_ID }}
+      DEPLOYER_APP_PK: ${{ secrets.DEPLOYER_APP_PK }}
+
+  # Second step: Determines the next RC version number based on the bump type and existing RC versions
+  # Only runs if a version bump is needed
+  # Outputs:
+  # - rc_version: The next rc version (e.g., 1.2.0-rc1)
+  rc-version:
+    needs: check-version-bump
+    if: needs.check-version-bump.outputs.triggers_bump == 'true'
+    uses: NexusMutual/workflows/.github/workflows/determine-rc-version.yml@feat/add-determine-rc-version-workflow
+    with:
+      package-name: "@nexusmutual/deployments"
+      bump-type: ${{ needs.check-version-bump.outputs.bump_type }}
+
+  # Final step: Temporarily updates package.json with RC version and publishes to npm with @next tag
+  # No changes are committed to the repository
+  publish-deployments-next:
+    needs: rc-version
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: 'https://registry.npmjs.org'
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+          
+      - name: Install dependencies
+        run: npm ci --ignore-scripts --prefer-offline --no-audit --no-fund
+
+      # Set the RC version in deployments package.json for publishing
+      # This is an ephemeral change only for publishing and not committed to the repository
+      - name: RC version bump
+        run: |
+          cd deployments
+          npm version ${{ needs.rc-version.outputs.rc_version }} --no-git-tag-version
+      
+      # Build the deployments package
+      - name: Build deployments
+        run: npm run deployments:build
+      
+      # Publish the deployments package to npm with the '@next' tag
+      - name: Publish to npm with @next tag
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm run deployments:publish:next

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -1,11 +1,11 @@
 # Release Next Workflow
 #
 # This workflow is responsible for creating and publishing release candidate (RC) versions
-# to npm with the '@next' tag when changes are pushed to the release-candidate branch.
+# to npm with the '@next' tag when manually triggered via workflow_dispatch.
 #
 # Workflow Behavior:
-# - Triggered on push to release-candidate branch
-# - Checks if commits since the last tag trigger a version bump using conventional commits
+# - Manually triggered via workflow_dispatch
+# - Checks if commits since the last tag on the release-candidate branch trigger a version bump using conventional commits
 # - If a version bump is triggered, determines the appropriate RC version number
 # - Publishes an RC version to npm with the '@next' tag
 # - RC versions follow the pattern: {new_version}-rc{number} (e.g., 1.2.0-rc1, 1.2.0-rc2)
@@ -21,8 +21,8 @@
 #    - Workflow exits early with no action
 #    - No RC version is published
 #
-# 3. Multiple pushes to release-candidate for the same base version:
-#    - RC number increments with each push (rc1, rc2, rc3, etc.) and publishes to npm
+# 3. Multiple manual triggers for the same base version:
+#    - RC number increments with each trigger (rc1, rc2, rc3, etc.) and publishes to npm
 #    - No commits are made to the repository, only published to npm
 #
 # 4. Version bump commit from master rebased to release-candidate:
@@ -35,9 +35,7 @@
 name: Release Next
 
 on:
-  push:
-    branches:
-      - release-candidate
+  workflow_dispatch:
 
 env:
   NODE_VERSION: 22
@@ -66,7 +64,7 @@ jobs:
   rc-version:
     needs: check-version-bump
     if: needs.check-version-bump.outputs.triggers_bump == 'true'
-    uses: NexusMutual/workflows/.github/workflows/determine-rc-version.yml@feat/add-determine-rc-version-workflow
+    uses: NexusMutual/workflows/.github/workflows/determine-rc-version.yml@master
     with:
       package-name: "@nexusmutual/deployments"
       bump-type: ${{ needs.check-version-bump.outputs.bump_type }}
@@ -80,7 +78,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -88,7 +86,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: "npm"
           cache-dependency-path: package-lock.json
-          
+
       - name: Install dependencies
         run: npm ci --ignore-scripts --prefer-offline --no-audit --no-fund
 
@@ -98,11 +96,11 @@ jobs:
         run: |
           cd deployments
           npm version ${{ needs.rc-version.outputs.rc_version }} --no-git-tag-version
-      
+
       # Build the deployments package
       - name: Build deployments
         run: npm run deployments:build
-      
+
       # Publish the deployments package to npm with the '@next' tag
       - name: Publish to npm with @next tag
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,42 +1,37 @@
 # Release Workflow
 #
 # This workflow is responsible for creating and publishing stable releases to npm
-# with the '@latest' tag when changes are pushed to the master branch.
+# with the '@latest' tag. It is manually triggered via workflow_dispatch.
 #
 # Workflow Behavior:
-# - Triggered on push to master branch
-# - Checks if commits since the last tag triggers a version bump using conventional commits
+# - Manually triggered via workflow_dispatch
+# - Checks if commits on the release-candidate branch since the last tag trigger a version bump using conventional commits
 # - If a version bump is triggered:
-#   - creates a version bump commit on both root package.json and deployments/package.json
-#   - creates a git tag
-# - Publishes the package to npm with the '@latest' tag
-# - Creates a git tag and GitHub release with release notes
-# - Rebases the release-candidate branch to ensure it stays in sync with master
+#   - Creates a version bump commit on both root package.json and deployments/package.json in the release-candidate branch
+#   - Fast-forwards release-candidate branch to master branch to include these changes
+#   - Publishes the package to npm with the '@latest' tag
+#   - Creates a git tag and GitHub release with release notes
 #
 # Scenarios:
-# 1. Release candidate merged to master with commits that trigger a version bump:
+# 1. Release candidate contains commits that trigger a version bump:
 #    - Workflow determines the next semantic version (e.g., 0.2.0 from 0.1.0)
-#    - Creates a version bump commit in package.json files
+#    - Creates a version bump commit in package.json files on release-candidate branch
+#    - Fast-forwards release-candidate branch to master branch to include these changes
 #    - Publishes the new version to npm with '@latest' tag
 #    - Creates a git tag and GitHub release with release notes
-#    - Rebases release-candidate branch to sync with master
 #
-# 2. Push to master with commits that don't trigger a version bump:
+# 2. Release candidate contains commits that don't trigger a version bump:
 #    - Workflow fails with an error message
 #    - No version is published, no tag is created
 #    - Ensures only meaningful changes result in new releases
-#    - Still rebases release-candidate branch to ensure it stays in sync with master
-# 
-# Note: The rebase-release-candidate job always runs (if: always()) to ensure
-# release-candidate branch is always in sync with master, regardless of whether
-# the release process succeeds or fails.
+#
+# Note: This workflow operates on the release-candidate branch first, then fast-forwards
+# those changes to the master branch, ensuring master always contains the latest release.
 
 name: Release
 
 on:
-  push:
-    branches:
-      - master
+  workflow_dispatch:
 
 env:
   NODE_VERSION: 22
@@ -74,15 +69,15 @@ jobs:
       - name: Confirm version bump
         run: |
           echo "Version bump of type '${{ needs.check-version-bump.outputs.bump_type }}' will be applied"
-          
-  # Third step: Updates the package version in root and deployments directories
+
+  # Third step: Updates the package version in root and deployments directories in release-candidate branch
   # Creates a commit with the version bump
   bump-version:
     needs: [check-version-bump, validate-version-bump]
-    uses: NexusMutual/workflows/.github/workflows/bump.yml@feat/add-determine-rc-version-workflow
+    uses: NexusMutual/workflows/.github/workflows/bump.yml@master
     with:
       environment: production
-      ref: master
+      ref: release-candidate
       bump-command: |
         echo 'Executing npm version bump: ${{ needs.check-version-bump.outputs.bump_type }} on root and deployments package.json'
         # Bump package version in root
@@ -94,9 +89,23 @@ jobs:
       DEPLOYER_APP_ID: ${{ secrets.DEPLOYER_APP_ID }}
       DEPLOYER_APP_PK: ${{ secrets.DEPLOYER_APP_PK }}
 
-  # Fourth step: Builds and publishes the deployments package to npm with the @latest tag
-  publish-deployments:
+  # Fourth step: Fast forward
+  # This fast forwards changes from release-candidate (including version bump) to master
+  ff-master:
     needs: bump-version
+    uses: NexusMutual/workflows/.github/workflows/fast-forward.yml@master
+
+    with:
+      environment: production
+      source-ref: release-candidate
+      target-ref: master
+    secrets:
+      DEPLOYER_APP_ID: ${{ secrets.DEPLOYER_APP_ID }}
+      DEPLOYER_APP_PK: ${{ secrets.DEPLOYER_APP_PK }}
+
+  # Fifth step: Builds and publishes the deployments package to npm with the @latest tag
+  publish-deployments:
+    needs: ff-master
     runs-on: ubuntu-latest
     environment: production
     steps:
@@ -104,7 +113,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: master
-        
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -112,42 +121,26 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: "npm"
           cache-dependency-path: package-lock.json
-          
+
       - name: Install dependencies
         run: npm ci --ignore-scripts --prefer-offline --no-audit --no-fund
-        
+
       - name: Build deployments
         run: npm run deployments:build
-        
+
       - name: Publish to npm with @latest tag
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           npm run deployments:publish:latest
-    
+
   # Fifth step: Creates a git tag and GitHub release with release notes
   git-tag-release:
-    needs: bump-version
+    needs: ff-master
     uses: NexusMutual/workflows/.github/workflows/git-tag-github-release.yml@master
     with:
       environment: production
       ref: master
-    secrets:
-      DEPLOYER_APP_ID: ${{ secrets.DEPLOYER_APP_ID }}
-      DEPLOYER_APP_PK: ${{ secrets.DEPLOYER_APP_PK }}
-  
-  # Final step: Rebase the version bump commit back to release-candidate
-  # This always executes whether the workflow passes or not to ensure release-candidate branch is always synced with master
-  # The version bump commit includes [skip ci] so release-next.yml won't run on this commit
-  rebase-release-candidate:
-    needs: bump-version
-    if: always()
-    uses: NexusMutual/workflows/.github/workflows/rebase.yml@master
-    
-    with:
-      environment: production
-      source-ref: master
-      target-ref: release-candidate
     secrets:
       DEPLOYER_APP_ID: ${{ secrets.DEPLOYER_APP_ID }}
       DEPLOYER_APP_PK: ${{ secrets.DEPLOYER_APP_PK }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,153 @@
+# Release Workflow
+#
+# This workflow is responsible for creating and publishing stable releases to npm
+# with the '@latest' tag when changes are pushed to the master branch.
+#
+# Workflow Behavior:
+# - Triggered on push to master branch
+# - Checks if commits since the last tag triggers a version bump using conventional commits
+# - If a version bump is triggered:
+#   - creates a version bump commit on both root package.json and deployments/package.json
+#   - creates a git tag
+# - Publishes the package to npm with the '@latest' tag
+# - Creates a git tag and GitHub release with release notes
+# - Rebases the release-candidate branch to ensure it stays in sync with master
+#
+# Scenarios:
+# 1. Release candidate merged to master with commits that trigger a version bump:
+#    - Workflow determines the next semantic version (e.g., 0.2.0 from 0.1.0)
+#    - Creates a version bump commit in package.json files
+#    - Publishes the new version to npm with '@latest' tag
+#    - Creates a git tag and GitHub release with release notes
+#    - Rebases release-candidate branch to sync with master
+#
+# 2. Push to master with commits that don't trigger a version bump:
+#    - Workflow fails with an error message
+#    - No version is published, no tag is created
+#    - Ensures only meaningful changes result in new releases
+#    - Still rebases release-candidate branch to ensure it stays in sync with master
+# 
+# Note: The rebase-release-candidate job always runs (if: always()) to ensure
+# release-candidate branch is always in sync with master, regardless of whether
+# the release process succeeds or fails.
+
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  NODE_VERSION: 22
+  PROVIDER_URL: ${{ secrets.PROVIDER_URL }}
+
+jobs:
+  # First step: Determines if the commits since last tag trigger a version bump
+  # Outputs:
+  # - bump_type: The type of semantic version bump (major, minor, patch)
+  # - triggers_bump: 'true' if a version bump is needed, 'false' otherwise
+  check-version-bump:
+    uses: NexusMutual/workflows/.github/workflows/check-version-bump.yml@master
+    with:
+      ref: release-candidate
+      environment: production
+      bump-command: |
+        timeout 5s npx conventional-recommended-bump --config .github/config/conventional-bump-setup.js
+    secrets:
+      DEPLOYER_APP_ID: ${{ secrets.DEPLOYER_APP_ID }}
+      DEPLOYER_APP_PK: ${{ secrets.DEPLOYER_APP_PK }}
+
+  # Second step: Fails the workflow if the commits since last tag does not trigger a version bump
+  # This ensures we don't create releases without meaningful changes
+  validate-version-bump:
+    needs: check-version-bump
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Verify version bump is triggered
+        if: needs.check-version-bump.outputs.triggers_bump != 'true'
+        run: |
+          echo "::error::Forbidden to release a version without a version bump"
+          echo "::warning::Commit messages on the dev branch must include changes beyond 'docs', 'style', 'test', or 'ci'"
+          echo "Please ensure your commits reflect meaningful changes to trigger an automatic version bump."
+          exit 1
+      - name: Confirm version bump
+        run: |
+          echo "Version bump of type '${{ needs.check-version-bump.outputs.bump_type }}' will be applied"
+          
+  # Third step: Updates the package version in root and deployments directories
+  # Creates a commit with the version bump
+  bump-version:
+    needs: [check-version-bump, validate-version-bump]
+    uses: NexusMutual/workflows/.github/workflows/bump.yml@feat/add-determine-rc-version-workflow
+    with:
+      environment: production
+      ref: master
+      bump-command: |
+        echo 'Executing npm version bump: ${{ needs.check-version-bump.outputs.bump_type }} on root and deployments package.json'
+        # Bump package version in root
+        npm version "${{ needs.check-version-bump.outputs.bump_type }}" --no-git-tag-version
+        # Bump package version in deployments with the same version
+        cd deployments
+        npm version $(jq -r '.version' ../package.json) --no-git-tag-version
+    secrets:
+      DEPLOYER_APP_ID: ${{ secrets.DEPLOYER_APP_ID }}
+      DEPLOYER_APP_PK: ${{ secrets.DEPLOYER_APP_PK }}
+
+  # Fourth step: Builds and publishes the deployments package to npm with the @latest tag
+  publish-deployments:
+    needs: bump-version
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: master
+        
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: 'https://registry.npmjs.org'
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+          
+      - name: Install dependencies
+        run: npm ci --ignore-scripts --prefer-offline --no-audit --no-fund
+        
+      - name: Build deployments
+        run: npm run deployments:build
+        
+      - name: Publish to npm with @latest tag
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm run deployments:publish:latest
+    
+  # Fifth step: Creates a git tag and GitHub release with release notes
+  git-tag-release:
+    needs: bump-version
+    uses: NexusMutual/workflows/.github/workflows/git-tag-github-release.yml@master
+    with:
+      environment: production
+      ref: master
+    secrets:
+      DEPLOYER_APP_ID: ${{ secrets.DEPLOYER_APP_ID }}
+      DEPLOYER_APP_PK: ${{ secrets.DEPLOYER_APP_PK }}
+  
+  # Final step: Rebase the version bump commit back to release-candidate
+  # This always executes whether the workflow passes or not to ensure release-candidate branch is always synced with master
+  # The version bump commit includes [skip ci] so release-next.yml won't run on this commit
+  rebase-release-candidate:
+    needs: bump-version
+    if: always()
+    uses: NexusMutual/workflows/.github/workflows/rebase.yml@master
+    
+    with:
+      environment: production
+      source-ref: master
+      target-ref: release-candidate
+    secrets:
+      DEPLOYER_APP_ID: ${{ secrets.DEPLOYER_APP_ID }}
+      DEPLOYER_APP_PK: ${{ secrets.DEPLOYER_APP_PK }}


### PR DESCRIPTION
## Description

* add release-next workflow
* add release workflow

Please refer to the description w/in each file for a more detailed info.

**NOTE:** this [workflows PR](https://github.com/NexusMutual/workflows/pull/8/files) needs to be merged first 

## Pre-merge Tasks

* [ ] add production environment to settings with the necessary secrets @shark0der 
* [ ] give `release-candidate` branch access to production environments @shark0der 

## Testing

* tested the flows in test-ci-1 repo

## Checklist

- [x] Performed a self-review of my own code
- [x] Made corresponding changes to the documentation
