### PR TITLE
chore: add back the CoverEdited event so frontend can use it

### DIFF
--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -152,6 +152,15 @@ interface ICover {
     string ipfsMetadata
   );
 
+  // left here for legacy support (frontend needs it to scan past events)
+  event CoverEdited(
+    uint indexed coverId,
+    uint indexed productId,
+    uint indexed unused,
+    address buyer,
+    string ipfsMetadata
+  );
+
   // Auth
   error OnlyOwnerOrApproved();
 


### PR DESCRIPTION
## Description

Add `CoverEdited` back to `ICover` for legacy support.

## Testing

Explain how you tested your changes to ensure they work as expected.

## Checklist

- [ ] Performed a self-review of my own code
- [ ] Made corresponding changes to the documentation
