### PR TITLE
chore: add cover asset check on edit

### DIFF
--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -169,6 +169,7 @@ interface ICover {
   error CoverPeriodTooLong();
   error CoverOutsideOfTheGracePeriod();
   error CoverAmountIsZero();
+  error CoverAssetMismatch();
 
   // Products
   error ProductNotFound();

--- a/contracts/modules/cover/Cover.sol
+++ b/contracts/modules/cover/Cover.sol
@@ -185,7 +185,7 @@ contract Cover is ICover, MasterAwareV2, IStakingPoolBeacon, ReentrancyGuard, Mu
 
       // mark previous cover as ending now
       cover.period = (block.timestamp - cover.start).toUint32();
-      _coverData[coverId] = cover;
+      _coverData[coverReference.latestCoverId] = cover;
 
       _coverReference[coverId].originalCoverId = params.coverId.toUint32();
       _coverReference[params.coverId].latestCoverId = coverId.toUint32();

--- a/test/unit/Cover/editCover.js
+++ b/test/unit/Cover/editCover.js
@@ -1691,6 +1691,38 @@ describe('editCover', function () {
     expect(coverReference.latestCoverId).to.equal(originalCoverId);
   });
 
+  it('reverts if the cover asset is different', async function () {
+    const fixture = await loadFixture(setup);
+    const { cover, Assets } = fixture;
+    const [coverBuyer] = fixture.accounts.members;
+
+    const coverBuyParams = { ...coverBuyFixture, coverAsset: Assets.ETH };
+    const editCoverAsset = Assets.DAI;
+
+    const { productId, period, amount } = coverBuyParams;
+    const { coverId: originalCoverId } = await buyCoverOnOnePool.call(fixture, coverBuyParams);
+
+    await expect(
+      cover.connect(coverBuyer).buyCover(
+        {
+          coverId: originalCoverId,
+          owner: coverBuyer.address,
+          productId,
+          coverAsset: editCoverAsset,
+          amount,
+          period,
+          maxPremiumInAsset: 0,
+          paymentAsset: editCoverAsset,
+          payWitNXM: false,
+          commissionRatio: parseEther('0'),
+          commissionDestination: AddressZero,
+          ipfsData: '',
+        },
+        [{ poolId: 1, coverAmountInAsset: amount }],
+      ),
+    ).to.be.revertedWithCustomError(cover, 'CoverAssetMismatch');
+  });
+
   it('cover reference should change after a cover edit', async function () {
     const fixture = await loadFixture(setup);
     const { cover } = fixture;

--- a/test/unit/Cover/editCover.js
+++ b/test/unit/Cover/editCover.js
@@ -329,6 +329,58 @@ describe('editCover', function () {
     });
   });
 
+  it('should mark the edited cover as ending now', async function () {
+    const fixture = await loadFixture(setup);
+    const { cover } = fixture;
+
+    const [coverBuyer] = fixture.accounts.members;
+
+    const { productId, coverAsset, period, amount } = coverBuyFixture;
+
+    const { coverId: expectedCoverId } = await buyCoverOnOnePool.call(fixture, coverBuyFixture);
+    const initialCover = await cover.getCoverData(expectedCoverId);
+
+    const reducedPeriod = period - daysToSeconds(1);
+
+    const tx = await cover.connect(coverBuyer).buyCover(
+      {
+        coverId: expectedCoverId,
+        owner: coverBuyer.address,
+        productId,
+        coverAsset,
+        amount,
+        period: reducedPeriod,
+        maxPremiumInAsset: 0,
+        paymentAsset: coverAsset,
+        payWitNXM: false,
+        commissionRatio: parseEther('0'),
+        commissionDestination: AddressZero,
+        ipfsData: '',
+      },
+      [{ poolId: 1, coverAmountInAsset: amount.toString() }],
+      {
+        value: 0,
+      },
+    );
+
+    const { blockNumber } = await tx.wait();
+    const { timestamp } = await ethers.provider.getBlock(blockNumber);
+    const expectedNewPeriod = BigNumber.from(timestamp).sub(initialCover.start);
+
+    const editedCover = await cover.getCoverData(expectedCoverId);
+    expect(editedCover.start).to.be.equal(initialCover.start);
+    expect(editedCover.period).to.be.equal(expectedNewPeriod);
+
+    const newCoverId = expectedCoverId.add(1);
+    await assertCoverFields(cover, newCoverId, {
+      productId,
+      coverAsset,
+      period: reducedPeriod,
+      amount,
+      gracePeriod,
+    });
+  });
+
   it('should edit purchased cover and increase period and amount', async function () {
     const fixture = await loadFixture(setup);
     const { cover } = fixture;


### PR DESCRIPTION
## Description

Had to move some of the logic from the `_requestDeallocation` function into the calling function to avoid reading the cover twice from the storage.

## Testing

Explain how you tested your changes to ensure they work as expected.

## Checklist

- [ ] Performed a self-review of my own code
- [ ] Made corresponding changes to the documentation
