### PR TITLE
DRAFT: feat: add TokenController.unstakeAssessmentFor

### DIFF
--- a/contracts/interfaces/ITokenController.sol
+++ b/contracts/interfaces/ITokenController.sol
@@ -85,6 +85,8 @@ interface ITokenController {
 
   function withdrawClaimAssessmentTokens(address[] calldata users) external;
 
+  function unstakeAssessmentFor(address member) external;
+
   function transferStakingPoolsOwnership(address from, address to) external;
 
   function assignStakingPoolManager(uint poolId, address manager) external;

--- a/contracts/mocks/generic/TokenControllerGeneric.sol
+++ b/contracts/mocks/generic/TokenControllerGeneric.sol
@@ -128,6 +128,10 @@ contract TokenControllerGeneric is ITokenController {
     revert("getPendingRewards unsupported");
   }
 
+  function unstakeAssessmentFor(address) external virtual {
+    revert("unstakeAssessmentFor unsupported");
+  }
+
   function withdrawNXM(
     StakingPoolDeposit[] calldata,
     StakingPoolManagerReward[] calldata,

--- a/contracts/modules/token/TokenController.sol
+++ b/contracts/modules/token/TokenController.sol
@@ -176,6 +176,13 @@ contract TokenController is ITokenController, ITokenControllerErrors, LockHandle
     }
   }
 
+  /// @dev Unstakes all assessment stake for a specific member.
+  /// @param member The member's address.
+  /// TODO: remove once all stake is withdrawn from Assessment
+  function unstakeAssessmentFor(address member) external override whenNotPaused {
+    assessment().unstakeAllFor(member);
+  }
+
   /// @notice Retrieves the reasons why a user's tokens were locked.
   /// @param _of       The address of the user whose lock reasons are being retrieved.
   /// @return reasons  An array of reasons (as bytes32) for the token lock.
@@ -283,8 +290,8 @@ contract TokenController is ITokenController, ITokenControllerErrors, LockHandle
   /// @param stakingPoolManagerRewards  Details for withdrawing staking pools manager rewards. Empty array to skip
   /// @param govRewardsBatchSize        The maximum number of iterations to avoid unbounded loops when withdrawing
   ///                                   governance rewards.
-  /// @param withdrawAssessment         Options specifying assesment withdrawals, set flags to true to include
-  ///                                   specific assesment stake or rewards withdrawal.
+  /// @param withdrawAssessment         Options specifying assessment withdrawals, set flags to true to include
+  ///                                   specific assessment stake or rewards withdrawal.
   function withdrawNXM(
     WithdrawAssessment calldata withdrawAssessment,
     StakingPoolDeposit[] calldata stakingPoolDeposits,
@@ -294,6 +301,7 @@ contract TokenController is ITokenController, ITokenControllerErrors, LockHandle
   ) external whenNotPaused {
 
     // assessment stake
+    // TODO: deprecate once all assessment member stake are unstaked
     if (withdrawAssessment.stake) {
       assessment().unstakeAllFor(msg.sender);
     }
@@ -317,7 +325,7 @@ contract TokenController is ITokenController, ITokenControllerErrors, LockHandle
       stakingPool(poolId).withdraw(tokenId, true, true, stakingPoolDeposits[i].trancheIds);
     }
 
-    // staking pool manager rewards    
+    // staking pool manager rewards
     for (uint i = 0; i < stakingPoolManagerRewards.length; i++) {
       uint poolId = stakingPoolManagerRewards[i].poolId;
       stakingPool(poolId).withdraw(0, false, true, stakingPoolManagerRewards[i].trancheIds);

--- a/test/integration/TokenController/unstakeAssessmentFor.js
+++ b/test/integration/TokenController/unstakeAssessmentFor.js
@@ -1,0 +1,98 @@
+const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+
+const { withdrawNXMSetup } = require('./setup');
+const { setNextBlockTime, mineNextBlock } = require('../utils').evm;
+
+const setTime = async timestamp => {
+  await setNextBlockTime(timestamp);
+  await mineNextBlock();
+};
+
+describe('unstakeAssessmentFor', function () {
+  it('should unstake all assessment stake for the specified member', async function () {
+    const fixture = await loadFixture(withdrawNXMSetup);
+    const { tk: nxm, as: assessment, tc: tokenController } = fixture.contracts;
+    const [manager] = fixture.accounts.stakingPoolManagers;
+
+    const balanceBefore = await nxm.balanceOf(manager.address);
+    const assessmentStakeBefore = await assessment.stakeOf(manager.address);
+
+    expect(assessmentStakeBefore.amount).to.be.greaterThan(0);
+
+    // adjust time so stake is no longer locked for assessment
+    const { timestamp } = await ethers.provider.getBlock('latest');
+    const stakeLockupPeriod = (await assessment.getStakeLockupPeriod()).toNumber();
+    await setTime(timestamp + stakeLockupPeriod + 1);
+
+    // unstake assessment
+    const [caller] = fixture.accounts.members;
+    await tokenController.connect(caller).unstakeAssessmentFor(manager.address);
+
+    const balanceAfter = await nxm.balanceOf(manager.address);
+    const assessmentStakeAfter = await assessment.stakeOf(manager.address);
+
+    expect(balanceAfter).to.equal(balanceBefore.add(assessmentStakeBefore.amount));
+    expect(assessmentStakeAfter.amount).to.equal(0);
+  });
+
+  it('should respect stake lockup period', async function () {
+    const fixture = await loadFixture(withdrawNXMSetup);
+    const { as: assessment, tc: tokenController } = fixture.contracts;
+    const [manager] = fixture.accounts.stakingPoolManagers;
+    const [caller] = fixture.accounts.members;
+
+    // try to unstake immediately (should fail due to lockup)
+    const unstakeAssessmentFor = tokenController.connect(caller).unstakeAssessmentFor(manager.address);
+    await expect(unstakeAssessmentFor).to.be.revertedWithCustomError(assessment, 'StakeLockedForAssessment');
+  });
+
+  it('should work even if member has no assessment stake', async function () {
+    const fixture = await loadFixture(withdrawNXMSetup);
+    const { tk: nxm, as: assessment, tc: tokenController } = fixture.contracts;
+    const [memberWithoutStake] = fixture.accounts.members;
+    const [caller] = fixture.accounts.members;
+
+    const balanceBefore = await nxm.balanceOf(memberWithoutStake.address);
+    const assessmentStakeBefore = await assessment.stakeOf(memberWithoutStake.address);
+
+    expect(assessmentStakeBefore.amount).to.equal(0);
+
+    // should not revert even with zero stake
+    await tokenController.connect(caller).unstakeAssessmentFor(memberWithoutStake.address);
+
+    const balanceAfter = await nxm.balanceOf(memberWithoutStake.address);
+    const assessmentStakeAfter = await assessment.stakeOf(memberWithoutStake.address);
+
+    expect(balanceAfter).to.equal(balanceBefore);
+    expect(assessmentStakeAfter.amount).to.equal(0);
+  });
+
+  it('should allow anyone to help recover tokens', async function () {
+    const fixture = await loadFixture(withdrawNXMSetup);
+    const { tk: nxm, as: assessment, tc: tokenController } = fixture.contracts;
+    const [manager] = fixture.accounts.stakingPoolManagers;
+    const [helper] = fixture.accounts.members;
+
+    // Get stake amount before any operations
+    const assessmentStakeBefore = await assessment.stakeOf(manager.address);
+    const stakeAmount = assessmentStakeBefore.amount;
+
+    const balanceBefore = await nxm.balanceOf(manager.address);
+
+    // wait for assessment lockup to expire
+    const { timestamp } = await ethers.provider.getBlock('latest');
+    const stakeLockupPeriod = (await assessment.getStakeLockupPeriod()).toNumber();
+    await setTime(timestamp + stakeLockupPeriod + 1);
+
+    // A different user can help recover tokens for the manager
+    await tokenController.connect(helper).unstakeAssessmentFor(manager.address);
+
+    const balanceAfter = await nxm.balanceOf(manager.address);
+    const assessmentStakeAfter = await assessment.stakeOf(manager.address);
+
+    expect(balanceAfter).to.equal(balanceBefore.add(stakeAmount));
+    expect(assessmentStakeAfter.amount).to.equal(0);
+  });
+});


### PR DESCRIPTION
## Description

Before we can deprecate the current version of Assessment we first need to empty the contract of stake and rewards. For rewards we can call `withdrawRewards` but for stake we need to create this new helper function `unstakeAssessmentFor` to help us return users stake.

## Testing

* unit test

## Checklist

- [x] Performed a self-review of my own code
- [ ] Made corresponding changes to the documentation
