### PR TITLE
test: migrate StakingNFT and StakingPoolFactory unit tests to ethers v6

### DIFF
--- a/test/unit/StakingNFT/setup.js
+++ b/test/unit/StakingNFT/setup.js
@@ -1,0 +1,47 @@
+const { ethers } = require('hardhat');
+const { setEtherBalance } = require('../../utils/evm');
+const { getAccounts } = require('../../utils/accounts');
+
+const { parseEther } = ethers;
+
+async function setup() {
+  const accounts = await getAccounts();
+  const [operator] = accounts.members;
+
+  const stakingPoolFactory = await ethers.deployContract('StakingPoolFactory', [operator.address]);
+  const cover = await ethers.deployContract('SNFTMockCover', [stakingPoolFactory.target]);
+  const stakingNFTDescriptor = await ethers.deployContract('StakingNFTDescriptor');
+
+  const stakingNFT = await ethers.deployContract('StakingNFT', [
+    'NexusMutual Staking',
+    'NXMS',
+    stakingPoolFactory.target,
+    cover.target,
+    stakingNFTDescriptor.target,
+  ]);
+
+  await cover.setStakingNFT(stakingNFT.target);
+
+  // impersonate staking pool address
+  const poolId = 50;
+  const stakingAddress = await cover.stakingPool(poolId);
+  await setEtherBalance(stakingAddress, parseEther('1000'));
+  await setEtherBalance(cover.target, parseEther('1000'));
+  const stakingPoolSigner = await ethers.getImpersonatedSigner(stakingAddress);
+  const coverSigner = await ethers.getImpersonatedSigner(cover.target);
+
+  return {
+    contracts: {
+      nftDescriptor: stakingNFTDescriptor,
+      cover,
+      stakingPoolFactory,
+      stakingNFT,
+    },
+    accounts,
+    stakingPoolSigner,
+    coverSigner,
+    poolId,
+  };
+}
+
+module.exports = setup;

--- a/test/unit/StakingNFT/stakingNFT.js
+++ b/test/unit/StakingNFT/stakingNFT.js
@@ -1,0 +1,226 @@
+const { ethers } = require('hardhat');
+const { expect } = require('chai');
+const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
+
+const { toBytes } = require('../../../lib/helpers');
+const setup = require('./setup');
+
+const { ZeroAddress } = ethers;
+
+describe('StakingNFT', function () {
+  it('should verify that constructor variables were set correctly', async function () {
+    const fixture = await loadFixture(setup);
+    const { stakingNFT } = fixture.contracts;
+    expect(await stakingNFT.name()).to.be.eq('NexusMutual Staking');
+    expect(await stakingNFT.symbol()).to.be.eq('NXMS');
+    expect(await stakingNFT.totalSupply()).to.be.eq(0);
+  });
+
+  it('should revert if changing operator from non operator account', async function () {
+    const fixture = await loadFixture(setup);
+    const { stakingNFT } = fixture.contracts;
+    const [member] = fixture.accounts.members;
+    await expect(stakingNFT.connect(member).changeOperator(member.address)).to.be.revertedWithCustomError(
+      stakingNFT,
+      'NotOperator',
+    );
+  });
+
+  it('should revert if changing operator to zero address account', async function () {
+    const fixture = await loadFixture(setup);
+    const { stakingNFT } = fixture.contracts;
+    await expect(stakingNFT.connect(fixture.coverSigner).changeOperator(ZeroAddress)).to.be.revertedWithCustomError(
+      stakingNFT,
+      'InvalidNewOperatorAddress',
+    );
+  });
+
+  it('should revert if changing nft descriptor from non operator account', async function () {
+    const fixture = await loadFixture(setup);
+    const { stakingNFT } = fixture.contracts;
+    const [member] = fixture.accounts.members;
+    await expect(stakingNFT.connect(member).changeNFTDescriptor(member.address)).to.be.revertedWithCustomError(
+      stakingNFT,
+      'NotOperator',
+    );
+  });
+
+  it('should revert if changing nft descriptor to zero address account', async function () {
+    const fixture = await loadFixture(setup);
+    const { stakingNFT } = fixture.contracts;
+    await expect(
+      stakingNFT.connect(fixture.coverSigner).changeNFTDescriptor(ZeroAddress),
+    ).to.be.revertedWithCustomError(stakingNFT, 'InvalidNewNFTDescriptorAddress');
+  });
+
+  it('should revert when calling tokenURI for unminted token', async function () {
+    const fixture = await loadFixture(setup);
+    const { stakingNFT } = fixture.contracts;
+    await expect(stakingNFT.tokenURI(0)).to.be.revertedWithCustomError(stakingNFT, 'NotMinted');
+  });
+
+  it('should revert when reading tokenInfo for a non-existent token', async function () {
+    const fixture = await loadFixture(setup);
+    const { stakingNFT } = fixture.contracts;
+    await expect(stakingNFT.tokenInfo(0)).to.be.revertedWithCustomError(stakingNFT, 'NotMinted');
+  });
+
+  it('should revert if calling stakingPoolOf for a non existent token', async function () {
+    const fixture = await loadFixture(setup);
+    const { stakingNFT } = fixture.contracts;
+    await expect(stakingNFT.stakingPoolOf(0)).to.be.revertedWithCustomError(stakingNFT, 'NotMinted');
+  });
+
+  it('should fail to mint to zero address', async function () {
+    const fixture = await loadFixture(setup);
+    const { stakingNFT } = fixture.contracts;
+    await expect(
+      stakingNFT.connect(fixture.stakingPoolSigner).mint(fixture.poolId, ZeroAddress),
+    ).to.be.revertedWithCustomError(stakingNFT, 'InvalidRecipient');
+  });
+
+  it('should fail to mint - OnlyStakingPool()', async function () {
+    const fixture = await loadFixture(setup);
+    const { stakingNFT } = fixture.contracts;
+    const [member] = fixture.accounts.members;
+    await expect(stakingNFT.connect(member).mint(fixture.poolId, member.address)).to.be.revertedWithCustomError(
+      stakingNFT,
+      'NotStakingPool',
+    );
+  });
+
+  it('should successfully mint', async function () {
+    const fixture = await loadFixture(setup);
+    const { stakingNFT } = fixture.contracts;
+    const [nftOwner] = fixture.accounts.members;
+    const tokenId = 1;
+    await stakingNFT.connect(fixture.stakingPoolSigner).mint(fixture.poolId, nftOwner.address);
+    expect(await stakingNFT.ownerOf(tokenId)).to.be.equal(nftOwner.address);
+    expect(await stakingNFT.stakingPoolOf(tokenId)).to.be.equal(fixture.poolId);
+    const { poolId, owner } = await stakingNFT.tokenInfo(tokenId);
+    expect(poolId).to.be.equal(fixture.poolId);
+    expect(owner).to.be.equal(nftOwner.address);
+    expect(await stakingNFT.totalSupply()).to.be.eq(1);
+  });
+
+  it('should return success for isApprovedOrOwner() - owner == sender', async function () {
+    const fixture = await loadFixture(setup);
+    const { stakingNFT } = fixture.contracts;
+    const [operator, nftOwner] = fixture.accounts.members;
+    await stakingNFT.connect(fixture.stakingPoolSigner).mint(fixture.poolId, nftOwner.address);
+    expect(await stakingNFT.isApprovedOrOwner(nftOwner.address, 1)).to.be.equal(true);
+    expect(await stakingNFT.isApprovedOrOwner(operator.address, 1)).to.be.equal(false);
+  });
+
+  it('should increment totalSupply properly', async function () {
+    const fixture = await loadFixture(setup);
+    const { stakingNFT } = fixture.contracts;
+    const [nftOwner] = fixture.accounts.members;
+    for (let i = 0; i < 10; i++) {
+      await stakingNFT.connect(fixture.stakingPoolSigner).mint(fixture.poolId, nftOwner.address);
+    }
+    expect(await stakingNFT.totalSupply()).to.be.eq(10);
+    expect(await stakingNFT.balanceOf(nftOwner.address)).to.be.eq(10);
+    expect(await stakingNFT.balanceOf(fixture.stakingPoolSigner.address)).to.be.eq(0);
+    expect(await stakingNFT.ownerOf(10)).to.be.equal(nftOwner.address);
+    const [owner, nonOwner] = fixture.accounts.members;
+    await stakingNFT.connect(fixture.stakingPoolSigner).mint(fixture.poolId, owner.address);
+    expect(await stakingNFT.isApprovedOrOwner(owner.address, 1)).to.be.equal(true);
+    expect(await stakingNFT.isApprovedOrOwner(nonOwner.address, 1)).to.be.equal(false);
+  });
+
+  it('should revert when msg.sender is not the owner of the token - NOT_AUTHORIZED', async function () {
+    const fixture = await loadFixture(setup);
+    const { stakingNFT } = fixture.contracts;
+    const [owner, nonOwner] = fixture.accounts.members;
+    await stakingNFT.connect(fixture.stakingPoolSigner).mint(fixture.poolId, owner.address);
+    await expect(stakingNFT.connect(nonOwner).approve(nonOwner.address, 1)).to.be.revertedWithCustomError(
+      stakingNFT,
+      'NotAuthorized',
+    );
+  });
+
+  it('should revert if reading balance of 0 address - NotMinted', async function () {
+    const fixture = await loadFixture(setup);
+    const { stakingNFT } = fixture.contracts;
+    await expect(stakingNFT.balanceOf(ZeroAddress)).to.be.revertedWithCustomError(stakingNFT, 'NotMinted');
+  });
+
+  it('should revert if trying to transferFrom a token from a non-owner - WrongFrom', async function () {
+    const fixture = await loadFixture(setup);
+    const { stakingNFT } = fixture.contracts;
+    const [nonOwner, owner] = fixture.accounts.members;
+    await stakingNFT.connect(fixture.stakingPoolSigner).mint(fixture.poolId, owner.address);
+    await expect(stakingNFT.transferFrom(nonOwner.address, owner.address, 1)).to.be.revertedWithCustomError(
+      stakingNFT,
+      'WrongFrom',
+    );
+  });
+
+  it('should revert if trying to transferFrom a token to a zero address - ZeroAddress', async function () {
+    const fixture = await loadFixture(setup);
+    const { stakingNFT } = fixture.contracts;
+    const [owner] = fixture.accounts.members;
+    await stakingNFT.connect(fixture.stakingPoolSigner).mint(fixture.poolId, owner.address);
+    await expect(stakingNFT.transferFrom(owner.address, ZeroAddress, 1)).to.be.revertedWithCustomError(
+      stakingNFT,
+      'InvalidRecipient',
+    );
+  });
+
+  it('should revert if not approved to transferFrom a token - NOT_AUTHORIZED', async function () {
+    const fixture = await loadFixture(setup);
+    const { stakingNFT } = fixture.contracts;
+    const [owner, nonOwner] = fixture.accounts.members;
+    await stakingNFT.connect(fixture.stakingPoolSigner).mint(fixture.poolId, owner.address);
+    await expect(
+      stakingNFT.connect(nonOwner).transferFrom(owner.address, nonOwner.address, 1),
+    ).to.be.revertedWithCustomError(stakingNFT, 'NotAuthorized');
+  });
+
+  it('should transferFrom a token', async function () {
+    const fixture = await loadFixture(setup);
+    const { stakingNFT } = fixture.contracts;
+    const [owner, nonOwner] = fixture.accounts.members;
+    await stakingNFT.connect(fixture.stakingPoolSigner).mint(fixture.poolId, owner.address);
+    await stakingNFT.connect(owner).approve(nonOwner.address, 1);
+    await stakingNFT.connect(nonOwner).transferFrom(owner.address, nonOwner.address, 1);
+    expect(await stakingNFT.ownerOf(1)).to.be.equal(nonOwner.address);
+  });
+
+  it('should fail to safeTransfer with bytes to a contract without onERC721Received function', async function () {
+    const fixture = await loadFixture(setup);
+    const { stakingNFT, cover } = fixture.contracts;
+    const [owner] = fixture.accounts.members;
+    await stakingNFT.connect(fixture.stakingPoolSigner).mint(fixture.poolId, owner.address);
+    // Reverts without reason if the contract does not implement onERC721Received
+    await expect(
+      stakingNFT
+        .connect(owner)
+        ['safeTransferFrom(address,address,uint256,bytes)'](owner.address, cover.target, 1n, toBytes('cafe')),
+    ).to.be.revertedWithoutReason();
+  });
+
+  it('should fail to safeTransfer to a contract that does not implement onERC721Received', async function () {
+    const fixture = await loadFixture(setup);
+    const { stakingNFT, cover } = fixture.contracts;
+    const [owner] = fixture.accounts.members;
+    await stakingNFT.connect(fixture.stakingPoolSigner).mint(fixture.poolId, owner.address);
+    // Reverts without reason if the contract does not implement onERC721Received
+    await expect(
+      stakingNFT.connect(owner)['safeTransferFrom(address,address,uint256)'](owner.address, cover.target, 1n),
+    ).to.be.revertedWithoutReason();
+  });
+
+  it('should support erc721 and ERC165 interfaces', async function () {
+    const fixture = await loadFixture(setup);
+    const { stakingNFT } = fixture.contracts;
+    // 0x80ac58cd // ERC165 Interface ID for ERC721
+    expect(await stakingNFT.supportsInterface('0x80ac58cd')).to.be.equal(true);
+    // 0x01ffc9a7 // ERC165 Interface ID for ERC165
+    expect(await stakingNFT.supportsInterface('0x01ffc9a7')).to.be.equal(true);
+    // 0x5b5e139f   // ERC165 Interface ID for ERC721Metadata
+    expect(await stakingNFT.supportsInterface('0x5b5e139f')).to.be.equal(true);
+    expect(await stakingNFT.supportsInterface('0xdeadbeef')).to.be.equal(false);
+  });
+});

--- a/test/unit/StakingPoolFactory/setup.js
+++ b/test/unit/StakingPoolFactory/setup.js
@@ -1,0 +1,17 @@
+const { ethers } = require('hardhat');
+const { getAccounts } = require('../../utils/accounts');
+
+async function setup() {
+  const accounts = await getAccounts();
+  const [operator] = accounts.nonMembers;
+
+  const stakingPoolFactory = await ethers.deployContract('StakingPoolFactory', [operator.address]);
+
+  return {
+    operator,
+    stakingPoolFactory,
+    accounts,
+  };
+}
+
+module.exports = setup;

--- a/test/unit/StakingPoolFactory/stakingPoolFactory.js
+++ b/test/unit/StakingPoolFactory/stakingPoolFactory.js
@@ -1,0 +1,75 @@
+const { ethers, artifacts } = require('hardhat');
+const { expect } = require('chai');
+const { keccak256 } = require('ethereum-cryptography/keccak');
+const { bytesToHex, hexToBytes } = require('ethereum-cryptography/utils');
+const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
+
+const setup = require('./setup');
+
+const { ZeroAddress } = ethers;
+
+describe('StakingPoolFactory', function () {
+  it('should verify that constructor variables were set correctly', async function () {
+    const fixture = await loadFixture(setup);
+    const { stakingPoolFactory, operator } = fixture;
+
+    expect(await stakingPoolFactory.operator()).to.be.equal(operator.address);
+  });
+
+  it('should revert if trying to change operator from non-operator', async function () {
+    const fixture = await loadFixture(setup);
+    const { stakingPoolFactory } = fixture;
+    const [nonOperator] = fixture.accounts.members;
+
+    await expect(stakingPoolFactory.connect(nonOperator).changeOperator(nonOperator.address)).to.be.revertedWith(
+      'StakingPoolFactory: Not operator',
+    );
+  });
+
+  it('should fail to change operator to 0 address', async function () {
+    const fixture = await loadFixture(setup);
+    const { stakingPoolFactory, operator } = fixture;
+    await expect(stakingPoolFactory.connect(operator).changeOperator(ZeroAddress)).to.be.revertedWith(
+      'StakingPoolFactory: Invalid operator',
+    );
+  });
+
+  it('should successfully change operator', async function () {
+    const fixture = await loadFixture(setup);
+    const { stakingPoolFactory, operator } = fixture;
+    const [newOperator] = fixture.accounts.members;
+    await stakingPoolFactory.connect(operator).changeOperator(newOperator.address);
+    expect(await stakingPoolFactory.operator()).to.be.equal(newOperator.address);
+  });
+
+  it('should revert if trying to create a pool from non-operator', async function () {
+    const fixture = await loadFixture(setup);
+    const { stakingPoolFactory } = fixture;
+    const [nonOperator] = fixture.accounts.members;
+
+    await expect(stakingPoolFactory.connect(nonOperator).create(nonOperator.address)).to.be.revertedWith(
+      'StakingPoolFactory: Not operator',
+    );
+  });
+
+  it('should successfully create staking pools with the expected address', async function () {
+    const fixture = await loadFixture(setup);
+    const { stakingPoolFactory, operator } = fixture;
+    const [beacon] = fixture.accounts.members;
+
+    const { bytecode: proxyBytecode } = await artifacts.readArtifact('MinimalBeaconProxy');
+    const proxyHash = bytesToHex(keccak256(hexToBytes(proxyBytecode.replace(/^0x/i, ''))));
+    const initCodeHash = Buffer.from(proxyHash, 'hex');
+
+    for (let i = 1; i <= 10; i++) {
+      const poolId = i;
+      const salt = Buffer.from(poolId.toString(16).padStart(64, '0'), 'hex');
+      const expectedAddress = ethers.getCreate2Address(stakingPoolFactory.target, salt, initCodeHash);
+
+      await expect(stakingPoolFactory.connect(operator).create(beacon.address))
+        .to.emit(stakingPoolFactory, 'StakingPoolCreated')
+        .withArgs(poolId, expectedAddress);
+      expect(await stakingPoolFactory.stakingPoolCount()).to.be.equal(BigInt(poolId));
+    }
+  });
+});


### PR DESCRIPTION
## Description

Describe the changes made in this PR. A link to the issue is enough if it contains all the relevant information.

## Testing

Explain how you tested your changes to ensure they work as expected.

## Checklist

- [ ] Performed a self-review of my own code
- [ ] Made corresponding changes to the documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test coverage for the StakingNFT contract, validating initialization, access control, minting operations, transfers, and ERC721 interface compliance.
  * Added comprehensive unit test coverage for the StakingPoolFactory contract, validating operator governance, pool creation permissions, and deterministic address derivation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->