### PR TITLE
feat: add setAssetOracle to Pool and add AggregatorRETH contract

### DIFF
--- a/contracts/interfaces/IPool.sol
+++ b/contracts/interfaces/IPool.sol
@@ -53,6 +53,8 @@ interface IPool {
 
   function setAssetDetails(uint assetId, bool isCoverAsset, bool isAbandoned) external;
 
+  function setAssetOracle(address assetAddress, address aggregator, AggregatorType aggregatorType, uint8 assetDecimals) external;
+
   function sendPayout(uint assetIndex, address payable payoutAddress, uint amount, uint depositInETH) external;
 
   function sendEth(address payable payoutAddress, uint amount) external;
@@ -113,6 +115,7 @@ interface IPool {
 
   // price feed
   error AggregatorMustNotBeZeroAddress();
+  error AggregatorAssetMustNotBeETH();
   error IncompatibleAggregatorDecimals(address aggregator, uint expectedDecimals, uint aggregatorDecimals);
   error InvalidEthAggregatorType(AggregatorType actual, AggregatorType expected);
   error NonPositiveRate(address aggregator, int rate);

--- a/contracts/interfaces/IPool.sol
+++ b/contracts/interfaces/IPool.sol
@@ -53,7 +53,7 @@ interface IPool {
 
   function setAssetDetails(uint assetId, bool isCoverAsset, bool isAbandoned) external;
 
-  function setAssetOracle(address assetAddress, address aggregator, AggregatorType aggregatorType, uint8 assetDecimals) external;
+  function setAssetOracle(address assetAddress, address aggregator, AggregatorType aggregatorType) external;
 
   function sendPayout(uint assetIndex, address payable payoutAddress, uint amount, uint depositInETH) external;
 

--- a/contracts/mocks/generic/PoolGeneric.sol
+++ b/contracts/mocks/generic/PoolGeneric.sol
@@ -35,7 +35,7 @@ contract PoolGeneric is IPool {
     revert("transferAssetToSwapOperator unsupported");
   }
 
-  function setAssetOracle(address /* assetAddress */, address /* aggregator */, AggregatorType /* aggregatorType */, uint8 /* assetDecimals */) external virtual {
+  function setAssetOracle(address /* assetAddress */, address /* aggregator */, AggregatorType /* aggregatorType */) external virtual {
     revert("setAssetOracle unsupported");
   }
 

--- a/contracts/mocks/generic/PoolGeneric.sol
+++ b/contracts/mocks/generic/PoolGeneric.sol
@@ -35,6 +35,10 @@ contract PoolGeneric is IPool {
     revert("transferAssetToSwapOperator unsupported");
   }
 
+  function setAssetOracle(address /* assetAddress */, address /* aggregator */, AggregatorType /* aggregatorType */, uint8 /* assetDecimals */) external virtual {
+    revert("setAssetOracle unsupported");
+  }
+
   function sendPayout(uint /* assetIndex */, address payable /* payoutAddress */, uint /* amount */, uint /* depositInETH */) external virtual {
     revert("sendPayout unsupported");
   }

--- a/contracts/modules/capital/AggregatorRETH.sol
+++ b/contracts/modules/capital/AggregatorRETH.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity ^0.8.18;
+
+interface IRETH {
+  function getExchangeRate() external view returns (uint256);
+}
+
+contract AggregatorRETH {
+
+  uint8 public decimals = 18;
+  IRETH public immutable rETH;
+
+  constructor(address _rETH) {
+    rETH = IRETH(_rETH);
+  }
+
+  function latestAnswer() public view returns (uint256) {
+    return rETH.getExchangeRate();
+  }
+
+}

--- a/contracts/modules/capital/AggregatorRETH.sol
+++ b/contracts/modules/capital/AggregatorRETH.sol
@@ -15,8 +15,8 @@ contract AggregatorRETH {
     rETH = IRETH(_rETH);
   }
 
-  function latestAnswer() public view returns (uint256) {
-    return rETH.getExchangeRate();
+  function latestAnswer() public view returns (int256) {
+    return int256(rETH.getExchangeRate());
   }
 
 }

--- a/contracts/modules/capital/AggregatorRETH.sol
+++ b/contracts/modules/capital/AggregatorRETH.sol
@@ -8,7 +8,7 @@ interface IRETH {
 
 contract AggregatorRETH {
 
-  uint8 public decimals = 18;
+  uint8 public constant decimals = 18;
   IRETH public immutable rETH;
 
   constructor(address _rETH) {

--- a/contracts/modules/capital/Pool.sol
+++ b/contracts/modules/capital/Pool.sol
@@ -480,6 +480,29 @@ contract Pool is IPool, ReentrancyGuard, RegistryAware {
     return uint(rate) * 1 ether / uint(ethUsdRate);
   }
 
+  function setAssetOracle(address assetAddress, address aggregator, AggregatorType aggregatorType, uint8 assetDecimals) external onlyContracts(C_GOVERNOR) {
+    require(assetAddress != address(0), AssetMustNotBeZeroAddress());
+    require(assetAddress != ETH, AggregatorAssetMustNotBeETH());
+    require(aggregator != address(0), AggregatorMustNotBeZeroAddress());
+
+    // require asset to be registered in the pool (reverts AssetNotFound otherwise)
+    getAssetId(assetAddress);
+    uint8 aggregatorDecimals = Aggregator(aggregator).decimals();
+
+    if (aggregatorType == AggregatorType.ETH && aggregatorDecimals != 18) {
+      revert IncompatibleAggregatorDecimals(address(aggregator), 18, aggregatorDecimals);
+    }
+    if (aggregatorType == AggregatorType.USD && aggregatorDecimals != 8) {
+      revert IncompatibleAggregatorDecimals(address(aggregator), 8, aggregatorDecimals);
+    }
+
+    oracles[assetAddress] = Oracle({
+      aggregator: Aggregator(aggregator),
+      aggregatorType: aggregatorType,
+      assetDecimals: assetDecimals
+    });
+  }
+
   /* ========== MIGRATION ========== */
 
   function migrate(

--- a/contracts/modules/capital/Pool.sol
+++ b/contracts/modules/capital/Pool.sol
@@ -480,13 +480,14 @@ contract Pool is IPool, ReentrancyGuard, RegistryAware {
     return uint(rate) * 1 ether / uint(ethUsdRate);
   }
 
-  function setAssetOracle(address assetAddress, address aggregator, AggregatorType aggregatorType, uint8 assetDecimals) external onlyContracts(C_GOVERNOR) {
+  function setAssetOracle(address assetAddress, address aggregator, AggregatorType aggregatorType) external onlyContracts(C_GOVERNOR) {
     require(assetAddress != address(0), AssetMustNotBeZeroAddress());
     require(assetAddress != ETH, AggregatorAssetMustNotBeETH());
     require(aggregator != address(0), AggregatorMustNotBeZeroAddress());
 
     // require asset to be registered in the pool (reverts AssetNotFound otherwise)
     getAssetId(assetAddress);
+    uint assetDecimals = IERC20Metadata(assetAddress).decimals();
     uint8 aggregatorDecimals = Aggregator(aggregator).decimals();
 
     if (aggregatorType == AggregatorType.ETH && aggregatorDecimals != 18) {
@@ -499,7 +500,7 @@ contract Pool is IPool, ReentrancyGuard, RegistryAware {
     oracles[assetAddress] = Oracle({
       aggregator: Aggregator(aggregator),
       aggregatorType: aggregatorType,
-      assetDecimals: assetDecimals
+      assetDecimals: assetDecimals.toUint8()
     });
   }
 

--- a/release/3.4.0/config/create2.json
+++ b/release/3.4.0/config/create2.json
@@ -1,0 +1,20 @@
+[
+  {
+    "contract": "Pool",
+    "address": "0xcafea77B6f25338e8C7d13defdA7Fb71773a7343",
+    "factory": "0xfac7011663910F75CbE1E25539ec2D7529f93C3F",
+    "salt": 47681594,
+    "constructor": [
+      "0xcafea2c575550512582090AA06d0a069E7236b9e"
+    ]
+  },
+  {
+    "contract": "AggregatorRETH",
+    "address": "0xcafea65F0fC6B2b7B1a1C5d22c0bE6F5fe313016",
+    "factory": "0xfac7011663910F75CbE1E25539ec2D7529f93C3F",
+    "salt": 196228209,
+    "constructor": [
+      "0xae78736Cd615f374D3085123A210448E74Fc6393"
+    ]
+  }
+]

--- a/release/3.4.0/config/deployments-config.js
+++ b/release/3.4.0/config/deployments-config.js
@@ -1,0 +1,19 @@
+/**
+ * @typedef {Object} Create2Config
+ * @property {string} expectedAddress - The expected deployment address
+ * @property {number} salt - The salt value for CREATE2 deployment
+ * @property {Array<string>} [constructorArgs] - Optional constructor arguments
+ * @property {Object} [libraries] - Optional library addresses for linking
+ */
+
+/**
+ * Deployment configurations CREATE2 implementations
+ * @type {{
+ *   create2Impl: Object.<string, Create2Config>
+ * }}
+ */
+const deploymentsConfig = {
+  create2Impl: require('./deployments.json'),
+};
+
+module.exports = deploymentsConfig;

--- a/release/3.4.0/config/deployments.json
+++ b/release/3.4.0/config/deployments.json
@@ -1,0 +1,16 @@
+{
+  "Pool": {
+    "expectedAddress": "0xcafea77B6f25338e8C7d13defdA7Fb71773a7343",
+    "salt": 47681594,
+    "constructorArgs": [
+      "0xcafea2c575550512582090AA06d0a069E7236b9e"
+    ]
+  },
+  "AggregatorRETH": {
+    "expectedAddress": "0xcafea65F0fC6B2b7B1a1C5d22c0bE6F5fe313016",
+    "salt": 196228209,
+    "constructorArgs": [
+      "0xae78736Cd615f374D3085123A210448E74Fc6393"
+    ]
+  }
+}

--- a/release/3.4.0/release-3.4.0.md
+++ b/release/3.4.0/release-3.4.0.md
@@ -1,0 +1,76 @@
+# Release 3.4.0: Pool and rETH Aggregator
+
+## Github PR
+
+* [feat: add setAssetOracle to Pool and add AggregatorRETH contract](https://github.com/NexusMutual/smart-contracts/pull/1526)
+
+## Contracts to be upgraded
+
+* Pool.sol
+* AggregatorRETH.sol
+
+## Contract deployment & verification
+
+#### Pool.sol
+
+* Constructor Params
+  * _registry = `0xcafea2c575550512582090AA06d0a069E7236b9e`
+* Address brute force command
+  * Address: `0xcafea77B6f25338e8C7d13defdA7Fb71773a7343`
+  * Salt: 47681594
+```bash
+ENABLE_OPTIMIZER=1 node scripts/create2/find-salt.js \
+  -t cafea \
+  -f 0xfac7011663910F75CbE1E25539ec2D7529f93C3F \
+  -c "$(jq -c '.Pool.constructorArgs' release/3.4.0/config/deployments.json)" \
+  Pool
+```
+* Deploy command
+  * replace the baseGasFee parameter (-b 0.5) with the [current gwei gas price](https://etherscan.io/gastracker)
+```bash
+HARDHAT_NETWORK=mainnet ENABLE_OPTIMIZER=1 node scripts/create2/deploy.js \
+  -f 0xfac7011663910F75CbE1E25539ec2D7529f93C3F \
+  -c "$(jq -c '.Pool.constructorArgs' release/3.4.0/config/deployments.json)" \
+  -a "$(jq -r '.Pool.expectedAddress' release/3.4.0/config/deployments.json)" \
+  -s "$(jq -r '.Pool.salt'            release/3.4.0/config/deployments.json)" \
+  -k -p 1 -b 0.5 Pool
+```
+* Verify command
+```bash
+ENABLE_OPTIMIZER=1 npx hardhat verify --network mainnet \
+  "$(jq -r '.Pool.expectedAddress' release/3.4.0/config/deployments.json)" \
+  $(jq -r '.Pool.constructorArgs | .[]' release/3.4.0/config/deployments.json | xargs -I {} echo '"{}"' | xargs) \
+  --contract contracts/modules/capital/Pool.sol:Pool
+```
+
+#### AggregatorRETH.sol
+
+* Constructor Params
+  * _rETH = `0xae78736Cd615f374D3085123A210448E74Fc6393`
+* Address brute force command
+  * Address: `0xcafea65F0fC6B2b7B1a1C5d22c0bE6F5fe313016`
+  * Salt: 196228209
+```bash
+ENABLE_OPTIMIZER=1 node scripts/create2/find-salt.js \
+  -t cafea \
+  -f 0xfac7011663910F75CbE1E25539ec2D7529f93C3F \
+  -c "$(jq -c '.AggregatorRETH.constructorArgs' release/3.4.0/config/deployments.json)" \
+  AggregatorRETH
+```
+* Deploy command
+  * replace the baseGasFee parameter (-b 0.5) with the [current gwei gas price](https://etherscan.io/gastracker)
+```bash
+HARDHAT_NETWORK=mainnet ENABLE_OPTIMIZER=1 node scripts/create2/deploy.js \
+  -f 0xfac7011663910F75CbE1E25539ec2D7529f93C3F \
+  -c "$(jq -c '.AggregatorRETH.constructorArgs' release/3.4.0/config/deployments.json)" \
+  -a "$(jq -r '.AggregatorRETH.expectedAddress' release/3.4.0/config/deployments.json)" \
+  -s "$(jq -r '.AggregatorRETH.salt'            release/3.4.0/config/deployments.json)" \
+  -k -p 1 -b 0.5 AggregatorRETH
+```
+* Verify command
+```bash
+ENABLE_OPTIMIZER=1 npx hardhat verify --network mainnet \
+  "$(jq -r '.AggregatorRETH.expectedAddress' release/3.4.0/config/deployments.json)" \
+  $(jq -r '.AggregatorRETH.constructorArgs | .[]' release/3.4.0/config/deployments.json | xargs -I {} echo '"{}"' | xargs) \
+  --contract contracts/modules/capital/AggregatorRETH.sol:AggregatorRETH
+```

--- a/test/fork/rEthOracle/rETH.js
+++ b/test/fork/rEthOracle/rETH.js
@@ -1,0 +1,140 @@
+const { ethers, network, nexus, tracer } = require('hardhat');
+const { expect } = require('chai');
+const { abis, addresses } = require('@nexusmutual/deployments');
+const { setBalance, takeSnapshot } = require('@nomicfoundation/hardhat-network-helpers');
+const {
+  revertToSnapshot,
+  Addresses,
+  createSafeExecutor,
+  getFundedSigner,
+  executeGovernorProposal,
+} = require('../utils');
+const rETHAbi = require('./rETHAbi.json');
+
+const { deployContract, parseEther, formatEther } = ethers;
+const { ContractIndexes } = nexus.constants;
+
+describe('Pool - rETH oracle change', function () {
+  before(async function () {
+    // Get or revert snapshot if network is tenderly
+    if (network.name === 'tenderly') {
+      const { TENDERLY_SNAPSHOT_ID } = process.env;
+      if (TENDERLY_SNAPSHOT_ID) {
+        await revertToSnapshot(TENDERLY_SNAPSHOT_ID);
+        console.info(`Reverted to snapshot ${TENDERLY_SNAPSHOT_ID}`);
+      } else {
+        const { snapshotId } = await takeSnapshot();
+        console.info('Snapshot ID: ', snapshotId);
+      }
+    }
+
+    const [deployer] = await ethers.getSigners();
+    await setBalance(deployer.address, parseEther('1000'));
+  });
+
+  it('load contracts', async function () {
+    this.registry = await ethers.getContractAt(abis.Registry, addresses.Registry);
+    this.cover = await ethers.getContractAt(abis.Cover, addresses.Cover);
+    this.nxm = await ethers.getContractAt(abis.NXMToken, addresses.NXMToken);
+    this.master = await ethers.getContractAt(abis.NXMaster, addresses.NXMaster);
+    this.coverNFT = await ethers.getContractAt(abis.CoverNFT, addresses.CoverNFT);
+    this.coverProducts = await ethers.getContractAt(abis.CoverProducts, addresses.CoverProducts);
+    this.pool = await ethers.getContractAt(abis.Pool, addresses.Pool);
+    this.safeTracker = await ethers.getContractAt(abis.SafeTracker, addresses.SafeTracker);
+    this.assessments = await ethers.getContractAt(abis.Assessments, addresses.Assessments);
+    this.claims = await ethers.getContractAt(abis.Claims, addresses.Claims);
+    this.stakingNFT = await ethers.getContractAt(abis.StakingNFT, addresses.StakingNFT);
+    this.stakingProducts = await ethers.getContractAt(abis.StakingProducts, addresses.StakingProducts);
+    this.swapOperator = await ethers.getContractAt(abis.SwapOperator, addresses.SwapOperator);
+    this.tokenController = await ethers.getContractAt(abis.TokenController, addresses.TokenController);
+    this.individualClaims = await ethers.getContractAt(abis.Claims, addresses.Claims);
+    this.stakingPoolFactory = await ethers.getContractAt(abis.StakingPoolFactory, addresses.StakingPoolFactory);
+    this.ramm = await ethers.getContractAt(abis.Ramm, addresses.Ramm);
+    this.limitOrders = await ethers.getContractAt(abis.LimitOrders, addresses.LimitOrders);
+    this.governor = await ethers.getContractAt(abis.Governor, addresses.Governor);
+    this.assessmentsViewer = await ethers.getContractAt(abis.Assessments, addresses.Assessments);
+    this.coverViewer = await ethers.getContractAt(abis.CoverViewer, addresses.CoverViewer);
+    this.stakingViewer = await ethers.getContractAt(abis.StakingViewer, addresses.StakingViewer);
+
+    // External contracts
+    this.coverBroker = await ethers.getContractAt(abis.CoverBroker, addresses.CoverBroker);
+
+    // Token Mocks
+    this.weth = await ethers.getContractAt('WETH9', Addresses.WETH_ADDRESS);
+    this.cbBTC = await ethers.getContractAt('ERC20Mock', Addresses.CBBTC_ADDRESS);
+    this.dai = await ethers.getContractAt('ERC20Mock', Addresses.DAI_ADDRESS);
+    this.usdc = await ethers.getContractAt('ERC20Mock', Addresses.USDC_ADDRESS);
+    this.rEth = await ethers.getContractAt(rETHAbi, Addresses.RETH_ADDRESS);
+    this.stEth = await ethers.getContractAt('ERC20Mock', Addresses.STETH_ADDRESS);
+    this.awEth = await ethers.getContractAt('ERC20Mock', Addresses.AWETH_ADDRESS);
+    this.enzymeShares = await ethers.getContractAt('ERC20Mock', Addresses.ENZYMEV4_VAULT_PROXY_ADDRESS);
+
+    // safe executor
+    this.executeSafeTransaction = await createSafeExecutor(Addresses.ADVISORY_BOARD_MULTISIG);
+
+    Object.entries(addresses).forEach(([k, v]) => (tracer.nameTags[v] = `#[${k}]`));
+  });
+
+  it('Impersonate AB members', async function () {
+    const boardSeats = await this.registry.ADVISORY_BOARD_SEATS();
+    this.abMembers = [];
+    for (let i = 1; i <= boardSeats; i++) {
+      const address = await this.registry.getMemberAddressBySeat(i);
+      this.abMembers.push(await getFundedSigner(address));
+    }
+  });
+
+  it('Collect storage data before upgrade', async function () {
+    this.poolData = {};
+    this.poolData.assets = await this.pool.getAssets();
+    this.poolData.mcr = await this.pool.getMCR();
+    this.poolData.mcrRatio = await this.pool.getMCRRatio();
+    this.rate = await this.pool.getEthForAsset(this.rEth.target, parseEther('1'));
+  });
+
+  it('Upgrade Pool contracts and change rETH oracle', async function () {
+    this.rETHAggregator = await deployContract('AggregatorRETH', [this.rEth]);
+    const pool = await deployContract('Pool', [this.registry.target]);
+
+    const transactions = [
+      {
+        target: this.registry,
+        value: 0n,
+        data: this.registry.interface.encodeFunctionData('upgradeContract', [ContractIndexes.C_POOL, pool.target]),
+      },
+      {
+        target: this.pool,
+        value: 0n,
+        data: pool.interface.encodeFunctionData('setAssetOracle', [
+          this.rEth.target,
+          this.rETHAggregator.target,
+          nexus.constants.AggregatorType.ETH,
+          18,
+        ]),
+      },
+    ];
+
+    await executeGovernorProposal(this.governor, this.abMembers, transactions);
+
+    this.pool = await ethers.getContractAt('Pool', pool.target);
+
+    const assets = await this.pool.getAssets();
+    const mcr = await this.pool.getMCR();
+    const mcrRatio = await this.pool.getMCRRatio();
+    const rEthOracle = await this.pool.oracles(this.rEth.target);
+
+    console.log('===================OLD VALUES=====================');
+    console.log('mcr', formatEther(this.poolData.mcr));
+    console.log('mcrRatio', formatEther(this.poolData.mcrRatio));
+    console.log('rate', formatEther(this.rate));
+    console.log('===================NEW VALUES=====================');
+    console.log('mcr', formatEther(mcr));
+    console.log('mcrRatio', formatEther(mcrRatio));
+    console.log('rate', formatEther(await this.rEth.getExchangeRate()));
+
+    expect(this.poolData.assets).to.be.deep.equal(assets);
+    expect(rEthOracle.aggregator).to.be.deep.equal(this.rETHAggregator.target);
+  });
+
+  require('../basic-functionality-tests');
+});

--- a/test/fork/rEthOracle/rETH.js
+++ b/test/fork/rEthOracle/rETH.js
@@ -1,14 +1,8 @@
 const { ethers, network, nexus, tracer } = require('hardhat');
 const { expect } = require('chai');
 const { abis, addresses } = require('@nexusmutual/deployments');
-const { setBalance, takeSnapshot } = require('@nomicfoundation/hardhat-network-helpers');
-const {
-  revertToSnapshot,
-  Addresses,
-  createSafeExecutor,
-  getFundedSigner,
-  executeGovernorProposal,
-} = require('../utils');
+const { setBalance, takeSnapshot, time } = require('@nomicfoundation/hardhat-network-helpers');
+const { revertToSnapshot, Addresses, createSafeExecutor, getFundedSigner } = require('../utils');
 const rETHAbi = require('./rETHAbi.json');
 
 const { deployContract, parseEther, formatEther } = ethers;
@@ -84,14 +78,6 @@ describe('Pool - rETH oracle change', function () {
     }
   });
 
-  it('Collect storage data before upgrade', async function () {
-    this.poolData = {};
-    this.poolData.assets = await this.pool.getAssets();
-    this.poolData.mcr = await this.pool.getMCR();
-    this.poolData.mcrRatio = await this.pool.getMCRRatio();
-    this.poolData.rate = await this.pool.getEthForAsset(this.rEth.target, parseEther('1'));
-  });
-
   it('Upgrade Pool contracts and change rETH oracle', async function () {
     this.rETHAggregator = await deployContract('AggregatorRETH', [this.rEth]);
     const pool = await deployContract('Pool', [this.registry.target]);
@@ -113,40 +99,60 @@ describe('Pool - rETH oracle change', function () {
       },
     ];
 
-    await executeGovernorProposal(this.governor, this.abMembers, transactions);
+    const [proposer] = this.abMembers;
+    await this.governor.connect(proposer).propose(transactions, 'Upgrade Pool contracts and change rETH oracle');
+    const proposalId = await this.governor.proposalCount();
 
+    for (const voter of this.abMembers.slice(0, 3)) {
+      await this.governor.connect(voter).vote(proposalId, nexus.constants.Choice.For);
+    }
+
+    const VOTING_PERIOD = await this.governor.VOTING_PERIOD();
+    const TIMELOCK_PERIOD = await this.governor.TIMELOCK_PERIOD();
+    await time.increase(VOTING_PERIOD + TIMELOCK_PERIOD);
+
+    // Snapshot pool state before upgrade
+    const oldAssets = await this.pool.getAssets();
+    const oldMcr = await this.pool.getMCR();
+    const oldRate = await this.pool.getEthForAsset(this.rEth.target, parseEther('1'));
+    const oldEthPoolValue = await this.pool.getPoolValueInEth();
+    const rEthBalance = await this.rEth.balanceOf(this.pool.target);
+    const oldRethEthValue = await this.pool.getEthForAsset(this.rEth.target, rEthBalance);
+
+    // Execute the governance proposal (applies upgrade + oracle change)
+    await this.governor.connect(proposer).execute(proposalId);
     this.pool = await ethers.getContractAt('Pool', this.pool.target);
 
-    const assets = await this.pool.getAssets();
-    const mcr = await this.pool.getMCR();
-    const mcrRatio = await this.pool.getMCRRatio();
+    // Fetch new values after upgrade
+    const newRate = await this.pool.getEthForAsset(this.rEth.target, parseEther('1'));
+    const newRethEthValue = await this.pool.getEthForAsset(this.rEth.target, rEthBalance);
+    const newEthPoolValue = await this.pool.getPoolValueInEth();
+    const newMcrRatio = await this.pool.getMCRRatio();
+
+    // Assets array should be unchanged
+    expect(await this.pool.getAssets()).to.deep.equal(oldAssets);
+
+    // Oracle should point to the new aggregator
     const rEthOracle = await this.pool.oracles(this.rEth.target);
-    const rate = await this.pool.getEthForAsset(this.rEth.target, parseEther('1'));
+    expect(rEthOracle.aggregator).to.equal(this.rETHAggregator.target);
 
-    expect(this.poolData.assets).to.be.deep.equal(assets);
-    expect(rEthOracle.aggregator).to.be.deep.equal(this.rETHAggregator.target);
-    expect(this.poolData.mcr).to.be.equal(mcr);
-    expect(this.poolData.mcrRatio).to.be.closeTo(mcrRatio, 1);
+    // MCR should be unchanged
+    expect(await this.pool.getMCR()).to.equal(oldMcr);
 
-    // Verify the new oracle rate is within 0.1% of the old rate
-    const oldRate = this.poolData.rate;
-    const newRate = rate;
-    const absDiff = oldRate > newRate ? oldRate - newRate : newRate - oldRate;
-    const maxDivergenceBps = 10n; // 0.1%
-    const basisPrecision = 10000n;
-    expect(absDiff * basisPrecision).to.be.lte(
-      oldRate * maxDivergenceBps,
+    // New rate should be within 0.1% of old rate
+    const rateDiff = oldRate > newRate ? oldRate - newRate : newRate - oldRate;
+    expect(rateDiff * 10000n).to.be.lte(
+      oldRate * 10n,
       `Rate divergence exceeds 0.1%: old=${formatEther(oldRate)}, new=${formatEther(newRate)}`,
     );
 
-    console.log('===================OLD VALUES=====================');
-    console.log('mcr', formatEther(this.poolData.mcr));
-    console.log('mcrRatio', formatEther(this.poolData.mcrRatio));
-    console.log('rate', formatEther(this.poolData.rate));
-    console.log('===================NEW VALUES=====================');
-    console.log('mcr', formatEther(mcr));
-    console.log('mcrRatio', formatEther(mcrRatio));
-    console.log('rate', formatEther(await this.rEth.getExchangeRate()));
+    // ethPoolValue diff should match the rETH valuation change
+    const expectedEthPoolValue = oldEthPoolValue - oldRethEthValue + newRethEthValue;
+    expect(newEthPoolValue).to.equal(expectedEthPoolValue);
+
+    // mcrRatio should reflect the new pool value
+    const expectedMcrRatio = (expectedEthPoolValue * 10n ** 4n) / oldMcr;
+    expect(newMcrRatio).to.equal(expectedMcrRatio);
   });
 
   require('../basic-functionality-tests');

--- a/test/fork/rEthOracle/rETH.js
+++ b/test/fork/rEthOracle/rETH.js
@@ -109,7 +109,6 @@ describe('Pool - rETH oracle change', function () {
           this.rEth.target,
           this.rETHAggregator.target,
           nexus.constants.AggregatorType.ETH,
-          18,
         ]),
       },
     ];

--- a/test/fork/rEthOracle/rETH.js
+++ b/test/fork/rEthOracle/rETH.js
@@ -89,7 +89,7 @@ describe('Pool - rETH oracle change', function () {
     this.poolData.assets = await this.pool.getAssets();
     this.poolData.mcr = await this.pool.getMCR();
     this.poolData.mcrRatio = await this.pool.getMCRRatio();
-    this.rate = await this.pool.getEthForAsset(this.rEth.target, parseEther('1'));
+    this.poolData.rate = await this.pool.getEthForAsset(this.rEth.target, parseEther('1'));
   });
 
   it('Upgrade Pool contracts and change rETH oracle', async function () {
@@ -115,24 +115,38 @@ describe('Pool - rETH oracle change', function () {
 
     await executeGovernorProposal(this.governor, this.abMembers, transactions);
 
-    this.pool = await ethers.getContractAt('Pool', pool.target);
+    this.pool = await ethers.getContractAt('Pool', this.pool.target);
 
     const assets = await this.pool.getAssets();
     const mcr = await this.pool.getMCR();
     const mcrRatio = await this.pool.getMCRRatio();
     const rEthOracle = await this.pool.oracles(this.rEth.target);
+    const rate = await this.pool.getEthForAsset(this.rEth.target, parseEther('1'));
+
+    expect(this.poolData.assets).to.be.deep.equal(assets);
+    expect(rEthOracle.aggregator).to.be.deep.equal(this.rETHAggregator.target);
+    expect(this.poolData.mcr).to.be.equal(mcr);
+    expect(this.poolData.mcrRatio).to.be.closeTo(mcrRatio, 1);
+
+    // Verify the new oracle rate is within 0.1% of the old rate
+    const oldRate = this.poolData.rate;
+    const newRate = rate;
+    const absDiff = oldRate > newRate ? oldRate - newRate : newRate - oldRate;
+    const maxDivergenceBps = 10n; // 0.1%
+    const basisPrecision = 10000n;
+    expect(absDiff * basisPrecision).to.be.lte(
+      oldRate * maxDivergenceBps,
+      `Rate divergence exceeds 0.1%: old=${formatEther(oldRate)}, new=${formatEther(newRate)}`,
+    );
 
     console.log('===================OLD VALUES=====================');
     console.log('mcr', formatEther(this.poolData.mcr));
     console.log('mcrRatio', formatEther(this.poolData.mcrRatio));
-    console.log('rate', formatEther(this.rate));
+    console.log('rate', formatEther(this.poolData.rate));
     console.log('===================NEW VALUES=====================');
     console.log('mcr', formatEther(mcr));
     console.log('mcrRatio', formatEther(mcrRatio));
     console.log('rate', formatEther(await this.rEth.getExchangeRate()));
-
-    expect(this.poolData.assets).to.be.deep.equal(assets);
-    expect(rEthOracle.aggregator).to.be.deep.equal(this.rETHAggregator.target);
   });
 
   require('../basic-functionality-tests');

--- a/test/fork/rEthOracle/rETHAbi.json
+++ b/test/fork/rEthOracle/rETHAbi.json
@@ -1,0 +1,509 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "contract RocketStorageInterface",
+        "name": "_rocketStorageAddress",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "time",
+        "type": "uint256"
+      }
+    ],
+    "name": "EtherDeposited",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "ethAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "time",
+        "type": "uint256"
+      }
+    ],
+    "name": "TokensBurned",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "ethAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "time",
+        "type": "uint256"
+      }
+    ],
+    "name": "TokensMinted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_rethAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "burn",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "subtractedValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "decreaseAllowance",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "depositExcess",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "depositExcessCollateral",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCollateralRate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_rethAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "getEthValue",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getExchangeRate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_ethAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "getRethValue",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getTotalCollateral",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "addedValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "increaseAllowance",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_ethAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_to",
+        "type": "address"
+      }
+    ],
+    "name": "mint",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "version",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  }
+]

--- a/test/unit/Pool/setAssetOracle.js
+++ b/test/unit/Pool/setAssetOracle.js
@@ -38,10 +38,7 @@ describe('setAssetOracle', function () {
     const fixture = await loadFixture(setAssetOracleSetup);
     const { pool, token, tokenAggregatorOne } = fixture;
 
-    await expect(pool.setAssetOracle(token, tokenAggregatorOne, 0, 18)).to.be.revertedWithCustomError(
-      pool,
-      'Unauthorized',
-    );
+    await expect(pool.setAssetOracle(token, tokenAggregatorOne, 0)).to.be.revertedWithCustomError(pool, 'Unauthorized');
   });
 
   it('reverts when asset address is zero address', async function () {
@@ -49,7 +46,7 @@ describe('setAssetOracle', function () {
     const { pool, governor, tokenAggregatorOne } = fixture;
 
     await expect(
-      pool.connect(governor).setAssetOracle(ZeroAddress, tokenAggregatorOne.target, 0, 18),
+      pool.connect(governor).setAssetOracle(ZeroAddress, tokenAggregatorOne.target, 0),
     ).to.be.revertedWithCustomError(pool, 'AssetMustNotBeZeroAddress');
   });
 
@@ -57,7 +54,7 @@ describe('setAssetOracle', function () {
     const fixture = await loadFixture(setAssetOracleSetup);
     const { pool, governor, tokenAggregatorOne } = fixture;
 
-    await expect(pool.connect(governor).setAssetOracle(ETH, tokenAggregatorOne, 0, 18)).to.be.revertedWithCustomError(
+    await expect(pool.connect(governor).setAssetOracle(ETH, tokenAggregatorOne, 0)).to.be.revertedWithCustomError(
       pool,
       'AggregatorAssetMustNotBeETH',
     );
@@ -67,7 +64,7 @@ describe('setAssetOracle', function () {
     const fixture = await loadFixture(setAssetOracleSetup);
     const { pool, governor, token } = fixture;
 
-    await expect(pool.connect(governor).setAssetOracle(token, ZeroAddress, 0, 18)).to.be.revertedWithCustomError(
+    await expect(pool.connect(governor).setAssetOracle(token, ZeroAddress, 0)).to.be.revertedWithCustomError(
       pool,
       'AggregatorMustNotBeZeroAddress',
     );
@@ -82,7 +79,7 @@ describe('setAssetOracle', function () {
     await ethWrongDecimalsAggregator.setDecimals(8);
 
     await expect(
-      pool.connect(governor).setAssetOracle(token, ethWrongDecimalsAggregator, 0, 18),
+      pool.connect(governor).setAssetOracle(token, ethWrongDecimalsAggregator, 0),
     ).to.be.revertedWithCustomError(pool, 'IncompatibleAggregatorDecimals');
   });
 
@@ -90,7 +87,7 @@ describe('setAssetOracle', function () {
     const fixture = await loadFixture(setAssetOracleSetup);
     const { pool, governor, token, tokenAggregatorTwo } = fixture;
 
-    await expect(pool.connect(governor).setAssetOracle(token, tokenAggregatorTwo, 1, 18)).to.be.revertedWithCustomError(
+    await expect(pool.connect(governor).setAssetOracle(token, tokenAggregatorTwo, 1)).to.be.revertedWithCustomError(
       pool,
       'IncompatibleAggregatorDecimals',
     );
@@ -104,7 +101,7 @@ describe('setAssetOracle', function () {
     const token = await ethers.deployContract('ERC20Mock');
     await token.setMetadata('MockWSETH', 'wsETH', tokenDecimals);
 
-    await expect(pool.connect(governor).setAssetOracle(token, tokenAggregatorOne, 0, 18)).to.be.revertedWithCustomError(
+    await expect(pool.connect(governor).setAssetOracle(token, tokenAggregatorOne, 0)).to.be.revertedWithCustomError(
       pool,
       'AssetNotFound',
     );
@@ -114,7 +111,7 @@ describe('setAssetOracle', function () {
     const fixture = await loadFixture(setAssetOracleSetup);
     const { pool, governor, token, tokenAggregatorTwo } = fixture;
 
-    await pool.connect(governor).setAssetOracle(token, tokenAggregatorTwo, 0, 18);
+    await pool.connect(governor).setAssetOracle(token, tokenAggregatorTwo, 0);
     const tokenAsset = await pool.getAsset(3);
 
     const tokenOracle = await pool.oracles(token);

--- a/test/unit/Pool/setAssetOracle.js
+++ b/test/unit/Pool/setAssetOracle.js
@@ -1,0 +1,130 @@
+const { ethers, nexus } = require('hardhat');
+const { expect } = require('chai');
+const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
+
+const setup = require('./setup');
+
+const { ZeroAddress, parseEther } = ethers;
+const { ETH } = nexus.constants.Assets;
+
+async function setAssetOracleSetup() {
+  const fixture = await loadFixture(setup);
+
+  const { pool, governor } = fixture;
+
+  const tokenDecimals = 18;
+  const token = await ethers.deployContract('ERC20Mock');
+  await token.setMetadata('MockRETH', 'rETH', tokenDecimals);
+
+  const tokenAggregatorOne = await ethers.deployContract('ChainlinkAggregatorMock');
+  await tokenAggregatorOne.setLatestAnswer(parseEther('1'));
+  await tokenAggregatorOne.setDecimals(18);
+
+  const tokenAggregatorTwo = await ethers.deployContract('ChainlinkAggregatorMock');
+  await tokenAggregatorTwo.setLatestAnswer(parseEther('1'));
+  await tokenAggregatorTwo.setDecimals(18);
+
+  await pool.connect(governor).addAsset(token, true, tokenAggregatorOne, 0);
+  return {
+    ...fixture,
+    token,
+    tokenAggregatorOne,
+    tokenAggregatorTwo,
+  };
+}
+
+describe('setAssetOracle', function () {
+  it('reverts when not called by governor', async function () {
+    const fixture = await loadFixture(setAssetOracleSetup);
+    const { pool, token, tokenAggregatorOne } = fixture;
+
+    await expect(pool.setAssetOracle(token, tokenAggregatorOne, 0, 18)).to.be.revertedWithCustomError(
+      pool,
+      'Unauthorized',
+    );
+  });
+
+  it('reverts when asset address is zero address', async function () {
+    const fixture = await loadFixture(setAssetOracleSetup);
+    const { pool, governor, tokenAggregatorOne } = fixture;
+
+    await expect(
+      pool.connect(governor).setAssetOracle(ZeroAddress, tokenAggregatorOne.target, 0, 18),
+    ).to.be.revertedWithCustomError(pool, 'AssetMustNotBeZeroAddress');
+  });
+
+  it('reverts when asset address is ETH', async function () {
+    const fixture = await loadFixture(setAssetOracleSetup);
+    const { pool, governor, tokenAggregatorOne } = fixture;
+
+    await expect(pool.connect(governor).setAssetOracle(ETH, tokenAggregatorOne, 0, 18)).to.be.revertedWithCustomError(
+      pool,
+      'AggregatorAssetMustNotBeETH',
+    );
+  });
+
+  it('reverts when aggregator address is zero address', async function () {
+    const fixture = await loadFixture(setAssetOracleSetup);
+    const { pool, governor, token } = fixture;
+
+    await expect(pool.connect(governor).setAssetOracle(token, ZeroAddress, 0, 18)).to.be.revertedWithCustomError(
+      pool,
+      'AggregatorMustNotBeZeroAddress',
+    );
+  });
+
+  it('reverts if incompatible aggregator decimals are used for ETH', async function () {
+    const fixture = await loadFixture(setAssetOracleSetup);
+    const { pool, governor, token } = fixture;
+
+    const ethWrongDecimalsAggregator = await ethers.deployContract('ChainlinkAggregatorMock');
+    await ethWrongDecimalsAggregator.setLatestAnswer(parseEther('1'));
+    await ethWrongDecimalsAggregator.setDecimals(8);
+
+    await expect(
+      pool.connect(governor).setAssetOracle(token, ethWrongDecimalsAggregator, 0, 18),
+    ).to.be.revertedWithCustomError(pool, 'IncompatibleAggregatorDecimals');
+  });
+
+  it('reverts if incompatible aggregator decimals are used for USD', async function () {
+    const fixture = await loadFixture(setAssetOracleSetup);
+    const { pool, governor, token, tokenAggregatorTwo } = fixture;
+
+    await expect(pool.connect(governor).setAssetOracle(token, tokenAggregatorTwo, 1, 18)).to.be.revertedWithCustomError(
+      pool,
+      'IncompatibleAggregatorDecimals',
+    );
+  });
+
+  it("reverts if asset doesn't exists", async function () {
+    const fixture = await loadFixture(setAssetOracleSetup);
+    const { pool, governor, tokenAggregatorOne } = fixture;
+
+    const tokenDecimals = 18;
+    const token = await ethers.deployContract('ERC20Mock');
+    await token.setMetadata('MockWSETH', 'wsETH', tokenDecimals);
+
+    await expect(pool.connect(governor).setAssetOracle(token, tokenAggregatorOne, 0, 18)).to.be.revertedWithCustomError(
+      pool,
+      'AssetNotFound',
+    );
+  });
+
+  it('should add new aggregator for an asset', async function () {
+    const fixture = await loadFixture(setAssetOracleSetup);
+    const { pool, governor, token, tokenAggregatorTwo } = fixture;
+
+    await pool.connect(governor).setAssetOracle(token, tokenAggregatorTwo, 0, 18);
+    const tokenAsset = await pool.getAsset(3);
+
+    const tokenOracle = await pool.oracles(token);
+
+    expect(tokenAsset.assetAddress).to.equal(token);
+    expect(tokenAsset.isCoverAsset).to.equal(true);
+    expect(tokenAsset.isAbandoned).to.equal(false);
+
+    expect(tokenOracle.aggregator).to.equal(tokenAggregatorTwo);
+    expect(tokenOracle.aggregatorType).to.equal(0);
+    expect(tokenOracle.assetDecimals).to.equal(18);
+  });
+});


### PR DESCRIPTION
## Description

- Add a method to change the oracle address for the asset
- Add a proxy contract that will read rETH/ETH ratio from the token contract

## Testing

Explain how you tested your changes to ensure they work as expected.

## Checklist

- [x] Performed a self-review of my own code
- [ ] Made corresponding changes to the documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added oracle configuration capability for registered assets with comprehensive validation for decimal compatibility between aggregators and assets.
  * Introduced rETH oracle aggregator support to enable enhanced pricing accuracy for rETH assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->